### PR TITLE
feat: add faceting and aggregations

### DIFF
--- a/searchlite-cli/src/main.rs
+++ b/searchlite-cli/src/main.rs
@@ -191,6 +191,8 @@ fn cmd_search(
     vector_query: build_vector_query(vector_field, vector, alpha)?,
     return_stored,
     highlight_field: highlight,
+    facets: Vec::new(),
+    aggregations: Vec::new(),
   };
   let result = reader.search(&request)?;
   for hit in result.hits.iter() {

--- a/searchlite-core/benches/end_to_end.rs
+++ b/searchlite-core/benches/end_to_end.rs
@@ -84,6 +84,8 @@ fn bench_search(c: &mut Criterion) {
         vector_query: None,
         return_stored: true,
         highlight_field: None,
+        facets: Vec::new(),
+        aggregations: Vec::new(),
       };
       let _ = reader.search(&req).unwrap();
     });

--- a/searchlite-core/src/api/types.rs
+++ b/searchlite-core/src/api/types.rs
@@ -75,6 +75,10 @@ pub struct SearchRequest {
   pub vector_query: Option<(String, Vec<f32>, f32)>,
   pub return_stored: bool,
   pub highlight_field: Option<String>,
+  #[serde(default)]
+  pub facets: Vec<FacetRequest>,
+  #[serde(default)]
+  pub aggregations: Vec<AggregationRequest>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -83,6 +87,51 @@ pub enum Filter {
   KeywordIn { field: String, values: Vec<String> },
   I64Range { field: String, min: i64, max: i64 },
   F64Range { field: String, min: f64, max: f64 },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FacetRequest {
+  pub field: String,
+  #[serde(flatten)]
+  pub facet: FacetKind,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum FacetKind {
+  Keyword,
+  #[serde(rename_all = "camelCase")]
+  Range {
+    ranges: Vec<NumericRange>,
+  },
+  #[serde(rename_all = "camelCase")]
+  Histogram {
+    interval: f64,
+    #[serde(default)]
+    min: Option<f64>,
+  },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NumericRange {
+  pub min: f64,
+  pub max: f64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AggregationRequest {
+  pub field: String,
+  #[serde(default)]
+  pub operations: Vec<AggregationOp>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "lowercase")]
+pub enum AggregationOp {
+  Min,
+  Max,
+  Sum,
+  Avg,
 }
 
 pub use crate::index::manifest::{KeywordField, NumericField, Schema, TextField};

--- a/searchlite-core/src/query/facets.rs
+++ b/searchlite-core/src/query/facets.rs
@@ -1,0 +1,366 @@
+use std::collections::{BTreeMap, HashMap, HashSet};
+
+use crate::api::types::{AggregationOp, AggregationRequest, FacetKind, FacetRequest};
+use crate::index::fastfields::FastFieldsReader;
+use crate::index::manifest::Schema;
+use crate::DocId;
+
+#[derive(Debug, Clone)]
+pub struct FacetPlan {
+  configs: Vec<FacetConfig>,
+}
+
+impl FacetPlan {
+  pub fn new(reqs: &[FacetRequest], schema: &Schema) -> Option<Self> {
+    if reqs.is_empty() {
+      return None;
+    }
+    let numeric_types: HashMap<&str, bool> = schema
+      .numeric_fields
+      .iter()
+      .map(|f| (f.name.as_str(), f.i64))
+      .collect();
+    let mut configs = Vec::with_capacity(reqs.len());
+    for r in reqs.iter() {
+      let config = match &r.facet {
+        FacetKind::Keyword => FacetConfig::Keyword {
+          field: r.field.clone(),
+        },
+        FacetKind::Range { ranges } => {
+          let bucketed: Vec<RangeBucket> = ranges
+            .iter()
+            .map(|rng| RangeBucket::new(rng.min, rng.max))
+            .collect();
+          FacetConfig::NumericRanges {
+            field: r.field.clone(),
+            buckets: bucketed,
+          }
+        }
+        FacetKind::Histogram { interval, min } => FacetConfig::Histogram {
+          field: r.field.clone(),
+          interval: *interval,
+          min: *min,
+          is_i64: *numeric_types.get(r.field.as_str()).unwrap_or(&false),
+        },
+      };
+      configs.push(config);
+    }
+    Some(Self { configs })
+  }
+
+  pub fn collector<'a>(&'a self, reader: &'a FastFieldsReader) -> FacetCollector<'a> {
+    FacetCollector {
+      reader,
+      configs: self.configs.as_slice(),
+      counts: vec![BTreeMap::new(); self.configs.len()],
+    }
+  }
+
+  pub fn len(&self) -> usize {
+    self.configs.len()
+  }
+
+  pub(crate) fn configs(&self) -> &[FacetConfig] {
+    &self.configs
+  }
+}
+
+#[derive(Debug)]
+pub struct FacetCollector<'a> {
+  reader: &'a FastFieldsReader,
+  configs: &'a [FacetConfig],
+  counts: Vec<BTreeMap<String, u64>>, // aligned with configs
+}
+
+impl<'a> FacetCollector<'a> {
+  pub fn collect(&mut self, doc_id: DocId) {
+    for (idx, config) in self.configs.iter().enumerate() {
+      match config {
+        FacetConfig::Keyword { field } => {
+          if let Some(val) = self.reader.keyword_value(field, doc_id) {
+            *self.counts[idx].entry(val.to_string()).or_insert(0) += 1;
+          }
+        }
+        FacetConfig::NumericRanges { field, buckets } => {
+          let value = self
+            .reader
+            .i64_value(field, doc_id)
+            .map(|v| v as f64)
+            .or_else(|| self.reader.f64_value(field, doc_id));
+          if let Some(val) = value {
+            for bucket in buckets.iter() {
+              if bucket.contains(val) {
+                *self.counts[idx].entry(bucket.label.clone()).or_insert(0) += 1;
+              }
+            }
+          }
+        }
+        FacetConfig::Histogram {
+          field,
+          interval,
+          min,
+          is_i64,
+        } => {
+          let raw = if *is_i64 {
+            self.reader.i64_value(field, doc_id).map(|v| v as f64)
+          } else {
+            self.reader.f64_value(field, doc_id)
+          };
+          if let Some(val) = raw {
+            let start = min.unwrap_or(0.0);
+            let offset_val = val - start;
+            let bucket = (offset_val / interval).floor();
+            let bucket_start = start + bucket * interval;
+            let bucket_end = bucket_start + interval;
+            let label = format!("{}..{}", bucket_start, bucket_end);
+            *self.counts[idx].entry(label).or_insert(0) += 1;
+          }
+        }
+      }
+    }
+  }
+
+  pub fn into_counts(self) -> Vec<BTreeMap<String, u64>> {
+    self.counts
+  }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum FacetConfig {
+  Keyword {
+    field: String,
+  },
+  NumericRanges {
+    field: String,
+    buckets: Vec<RangeBucket>,
+  },
+  Histogram {
+    field: String,
+    interval: f64,
+    min: Option<f64>,
+    is_i64: bool,
+  },
+}
+
+impl FacetConfig {
+  pub(crate) fn field_name(&self) -> &str {
+    match self {
+      FacetConfig::Keyword { field }
+      | FacetConfig::NumericRanges { field, .. }
+      | FacetConfig::Histogram { field, .. } => field.as_str(),
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+struct RangeBucket {
+  min: f64,
+  max: f64,
+  label: String,
+}
+
+impl RangeBucket {
+  fn new(min: f64, max: f64) -> Self {
+    Self {
+      min,
+      max,
+      label: format!("{}..{}", min, max),
+    }
+  }
+
+  fn contains(&self, v: f64) -> bool {
+    v >= self.min && v < self.max
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregationPlan {
+  states: Vec<AggregationState>,
+}
+
+impl AggregationPlan {
+  pub fn new(reqs: &[AggregationRequest], schema: &Schema) -> Option<Self> {
+    if reqs.is_empty() {
+      return None;
+    }
+    let mut numeric_types: HashMap<&str, bool> = HashMap::new();
+    for f in schema.numeric_fields.iter() {
+      numeric_types.insert(f.name.as_str(), f.i64);
+    }
+    let mut states = Vec::with_capacity(reqs.len());
+    for req in reqs.iter() {
+      let is_i64 = *numeric_types.get(req.field.as_str()).unwrap_or(&false);
+      let ops: HashSet<AggregationOp> = if req.operations.is_empty() {
+        [
+          AggregationOp::Min,
+          AggregationOp::Max,
+          AggregationOp::Sum,
+          AggregationOp::Avg,
+        ]
+        .into_iter()
+        .collect()
+      } else {
+        req.operations.iter().cloned().collect()
+      };
+      states.push(AggregationState::new(req.field.clone(), ops, is_i64));
+    }
+    Some(Self { states })
+  }
+
+  pub fn collector<'a>(&self, reader: &'a FastFieldsReader) -> AggregationCollector<'a> {
+    AggregationCollector {
+      reader,
+      states: self.states.clone(),
+    }
+  }
+
+  pub fn len(&self) -> usize {
+    self.states.len()
+  }
+}
+
+#[derive(Debug)]
+pub struct AggregationCollector<'a> {
+  reader: &'a FastFieldsReader,
+  states: Vec<AggregationState>,
+}
+
+impl<'a> AggregationCollector<'a> {
+  pub fn collect(&mut self, doc_id: DocId) {
+    for state in self.states.iter_mut() {
+      let val = if state.is_i64 {
+        self
+          .reader
+          .i64_value(&state.field, doc_id)
+          .map(|v| v as f64)
+      } else {
+        self.reader.f64_value(&state.field, doc_id)
+      };
+      if let Some(v) = val {
+        state.apply(v);
+      }
+    }
+  }
+
+  pub fn into_states(self) -> Vec<AggregationState> {
+    self.states
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregationState {
+  pub field: String,
+  pub doc_count: u64,
+  pub min: Option<f64>,
+  pub max: Option<f64>,
+  pub sum_f64: Option<f64>,
+  pub sum_i128: Option<i128>,
+  pub ops: HashSet<AggregationOp>,
+  pub is_i64: bool,
+}
+
+impl AggregationState {
+  fn new(field: String, ops: HashSet<AggregationOp>, is_i64: bool) -> Self {
+    Self {
+      field,
+      doc_count: 0,
+      min: None,
+      max: None,
+      sum_f64: None,
+      sum_i128: None,
+      ops,
+      is_i64,
+    }
+  }
+
+  fn apply(&mut self, value: f64) {
+    self.doc_count += 1;
+    if self.ops.contains(&AggregationOp::Min) {
+      self.min = Some(self.min.map(|m| m.min(value)).unwrap_or(value));
+    }
+    if self.ops.contains(&AggregationOp::Max) {
+      self.max = Some(self.max.map(|m| m.max(value)).unwrap_or(value));
+    }
+    if self.ops.contains(&AggregationOp::Sum) || self.ops.contains(&AggregationOp::Avg) {
+      if self.is_i64 {
+        let as_i128 = value as i128;
+        self.sum_i128 = Some(self.sum_i128.unwrap_or(0) + as_i128);
+      } else {
+        self.sum_f64 = Some(self.sum_f64.unwrap_or(0.0) + value);
+      }
+    }
+  }
+
+  pub fn merge_from(&mut self, other: &AggregationState) {
+    self.doc_count += other.doc_count;
+    if self.ops.contains(&AggregationOp::Min) {
+      if let Some(min) = other.min {
+        self.min = Some(self.min.map(|m| m.min(min)).unwrap_or(min));
+      }
+    }
+    if self.ops.contains(&AggregationOp::Max) {
+      if let Some(max) = other.max {
+        self.max = Some(self.max.map(|m| m.max(max)).unwrap_or(max));
+      }
+    }
+    if self.ops.contains(&AggregationOp::Sum) || self.ops.contains(&AggregationOp::Avg) {
+      if self.is_i64 {
+        if let Some(part) = other.sum_i128 {
+          self.sum_i128 = Some(self.sum_i128.unwrap_or(0) + part);
+        }
+      } else if let Some(part) = other.sum_f64 {
+        self.sum_f64 = Some(self.sum_f64.unwrap_or(0.0) + part);
+      }
+    }
+  }
+
+  pub fn finalize(&self) -> AggregationOutput {
+    let sum = if self.ops.contains(&AggregationOp::Sum) || self.ops.contains(&AggregationOp::Avg) {
+      if self.is_i64 {
+        self.sum_i128.map(|v| v as f64)
+      } else {
+        self.sum_f64
+      }
+    } else {
+      None
+    };
+    let avg = if self.ops.contains(&AggregationOp::Avg) {
+      match (sum, self.doc_count) {
+        (Some(total), count) if count > 0 => Some(total / count as f64),
+        _ => None,
+      }
+    } else {
+      None
+    };
+    AggregationOutput {
+      field: self.field.clone(),
+      doc_count: self.doc_count,
+      min: if self.ops.contains(&AggregationOp::Min) {
+        self.min
+      } else {
+        None
+      },
+      max: if self.ops.contains(&AggregationOp::Max) {
+        self.max
+      } else {
+        None
+      },
+      sum: if self.ops.contains(&AggregationOp::Sum) {
+        sum
+      } else {
+        None
+      },
+      avg,
+    }
+  }
+}
+
+#[derive(Debug, Clone)]
+pub struct AggregationOutput {
+  pub field: String,
+  pub doc_count: u64,
+  pub min: Option<f64>,
+  pub max: Option<f64>,
+  pub sum: Option<f64>,
+  pub avg: Option<f64>,
+}

--- a/searchlite-core/src/query/mod.rs
+++ b/searchlite-core/src/query/mod.rs
@@ -1,5 +1,6 @@
 pub mod bm25;
 pub mod boolean;
+pub mod facets;
 pub mod filters;
 pub mod phrase;
 pub mod planner;

--- a/searchlite-core/tests/coverage.rs
+++ b/searchlite-core/tests/coverage.rs
@@ -100,6 +100,8 @@ fn search_with_phrase_filters_and_compaction() {
       vector_query: None,
       return_stored: true,
       highlight_field: Some("body".into()),
+      facets: Vec::new(),
+      aggregations: Vec::new(),
     })
     .unwrap();
   assert_eq!(result.hits.len(), 2);

--- a/searchlite-core/tests/facets.rs
+++ b/searchlite-core/tests/facets.rs
@@ -1,0 +1,184 @@
+use searchlite_core::api::builder::IndexBuilder;
+use searchlite_core::api::types::{
+  AggregationOp, AggregationRequest, Document, ExecutionStrategy, FacetKind, FacetRequest,
+  IndexOptions, NumericField, NumericRange, Schema, SearchRequest, StorageType,
+};
+use searchlite_core::api::Filter;
+use searchlite_core::api::Index;
+
+fn build_schema() -> Schema {
+  Schema {
+    text_fields: vec![searchlite_core::api::TextField {
+      name: "body".into(),
+      tokenizer: "default".into(),
+      stored: true,
+      indexed: true,
+    }],
+    keyword_fields: vec![searchlite_core::api::KeywordField {
+      name: "category".into(),
+      stored: true,
+      indexed: true,
+      fast: true,
+    }],
+    numeric_fields: vec![
+      NumericField {
+        name: "year".into(),
+        i64: true,
+        fast: true,
+        stored: true,
+      },
+      NumericField {
+        name: "score".into(),
+        i64: false,
+        fast: true,
+        stored: true,
+      },
+    ],
+    #[cfg(feature = "vectors")]
+    vector_fields: Vec::new(),
+  }
+}
+
+fn add_docs(idx: &Index) {
+  let mut writer = idx.writer().unwrap();
+  let docs = vec![
+    ("Rust for search", "news", 2021, 1.0_f64),
+    ("Rust and performance", "sports", 2020, 2.5_f64),
+    ("Advanced rust systems", "news", 2023, 3.5_f64),
+  ];
+  for (body, category, year, score) in docs.into_iter() {
+    writer
+      .add_document(&Document {
+        fields: [
+          ("body".into(), serde_json::json!(body)),
+          ("category".into(), serde_json::json!(category)),
+          ("year".into(), serde_json::json!(year)),
+          ("score".into(), serde_json::json!(score)),
+        ]
+        .into_iter()
+        .collect(),
+      })
+      .unwrap();
+  }
+  writer.commit().unwrap();
+}
+
+fn opts(path: &std::path::Path) -> IndexOptions {
+  IndexOptions {
+    path: path.to_path_buf(),
+    create_if_missing: true,
+    enable_positions: true,
+    bm25_k1: 0.9,
+    bm25_b: 0.4,
+    storage: StorageType::Filesystem,
+    #[cfg(feature = "vectors")]
+    vector_defaults: None,
+  }
+}
+
+#[test]
+fn keyword_and_range_facets_respect_filters() {
+  let dir = tempfile::tempdir().unwrap();
+  let idx = IndexBuilder::create(dir.path(), build_schema(), opts(dir.path())).unwrap();
+  add_docs(&idx);
+  let reader = idx.reader().unwrap();
+  let resp = reader
+    .search(&SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filters: vec![Filter::I64Range {
+        field: "year".into(),
+        min: 2020,
+        max: 2022,
+      }],
+      limit: 5,
+      execution: ExecutionStrategy::Bm25,
+      bmw_block_size: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      return_stored: false,
+      highlight_field: None,
+      facets: vec![
+        FacetRequest {
+          field: "category".into(),
+          facet: FacetKind::Keyword,
+        },
+        FacetRequest {
+          field: "year".into(),
+          facet: FacetKind::Range {
+            ranges: vec![NumericRange {
+              min: 2019.0,
+              max: 2022.0,
+            }],
+          },
+        },
+      ],
+      aggregations: Vec::new(),
+    })
+    .unwrap();
+
+  let cat_counts = resp.facets.iter().find(|f| f.field == "category").unwrap();
+  assert_eq!(cat_counts.counts.get("news"), Some(&1));
+  assert_eq!(cat_counts.counts.get("sports"), Some(&1));
+
+  let range_counts = resp.facets.iter().find(|f| f.field == "year").unwrap();
+  assert_eq!(range_counts.counts.get("2019..2022"), Some(&2));
+}
+
+#[test]
+fn histogram_and_aggregations_cover_results() {
+  let dir = tempfile::tempdir().unwrap();
+  let idx = Index::create(dir.path(), build_schema(), opts(dir.path())).unwrap();
+  add_docs(&idx);
+  let reader = idx.reader().unwrap();
+  let resp = reader
+    .search(&SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filters: vec![Filter::I64Range {
+        field: "year".into(),
+        min: 2020,
+        max: 2025,
+      }],
+      limit: 1,
+      execution: ExecutionStrategy::Bm25,
+      bmw_block_size: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      return_stored: false,
+      highlight_field: None,
+      facets: vec![FacetRequest {
+        field: "score".into(),
+        facet: FacetKind::Histogram {
+          interval: 1.0,
+          min: Some(1.0),
+        },
+      }],
+      aggregations: vec![AggregationRequest {
+        field: "score".into(),
+        operations: vec![
+          AggregationOp::Min,
+          AggregationOp::Max,
+          AggregationOp::Sum,
+          AggregationOp::Avg,
+        ],
+      }],
+    })
+    .unwrap();
+
+  let hist = resp.facets.iter().find(|f| f.field == "score").unwrap();
+  assert_eq!(hist.counts.get("1..2"), Some(&1));
+  assert_eq!(hist.counts.get("2..3"), Some(&1));
+  assert_eq!(hist.counts.get("3..4"), Some(&1));
+
+  let agg = resp
+    .aggregations
+    .iter()
+    .find(|a| a.field == "score")
+    .unwrap();
+  assert_eq!(agg.doc_count, 3);
+  assert_eq!(agg.min, Some(1.0));
+  assert_eq!(agg.max, Some(3.5));
+  assert!(agg.sum.unwrap() - 7.0 < 1e-6);
+  assert!(agg.avg.unwrap() - (7.0 / 3.0) < 1e-6);
+}

--- a/searchlite-core/tests/pruning.rs
+++ b/searchlite-core/tests/pruning.rs
@@ -62,6 +62,8 @@ fn wand_and_bmw_match_bm25_on_random_corpora() {
       vector_query: None,
       return_stored: false,
       highlight_field: None,
+      facets: Vec::new(),
+      aggregations: Vec::new(),
     };
     let bm25 = reader.search(&req).unwrap();
 
@@ -102,6 +104,8 @@ fn empty_query_returns_no_hits() {
     vector_query: None,
     return_stored: false,
     highlight_field: None,
+    facets: Vec::new(),
+    aggregations: Vec::new(),
   };
   let resp = reader.search(&req).unwrap();
   assert!(resp.hits.is_empty());

--- a/searchlite-core/tests/smoke.rs
+++ b/searchlite-core/tests/smoke.rs
@@ -60,6 +60,8 @@ fn index_and_search() {
       vector_query: None,
       return_stored: true,
       highlight_field: Some("body".to_string()),
+      facets: Vec::new(),
+      aggregations: Vec::new(),
     })
     .unwrap();
   assert!(!resp.hits.is_empty());
@@ -104,6 +106,8 @@ fn in_memory_storage_keeps_disk_clean() {
       vector_query: None,
       return_stored: true,
       highlight_field: None,
+      facets: Vec::new(),
+      aggregations: Vec::new(),
     })
     .unwrap();
   assert_eq!(resp.hits.len(), 1);

--- a/searchlite-ffi/src/lib.rs
+++ b/searchlite-ffi/src/lib.rs
@@ -131,6 +131,8 @@ pub extern "C" fn searchlite_search(
     highlight_field: None,
     #[cfg(feature = "vectors")]
     vector_query: None,
+    facets: Vec::new(),
+    aggregations: Vec::new(),
   };
   let res = match reader.search(&req) {
     Ok(r) => r,


### PR DESCRIPTION
## Summary
- add facet and aggregation request options and expose results from search responses
- collect keyword/numeric facets and numeric aggregates using fast-field readers during search
- cover faceting, histograms, and aggregation behavior with new tests and client updates

## Testing
- cargo test --workspace *(fails: rustc 1.78 incompatible with dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946d6e81d4c832fab4e8c894ca68ac7)