### PR TITLE
docs: describe CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Set an index location once:
 INDEX=/tmp/searchlite_idx
 ```
 
+## CLI commands
+Use `cargo run -p searchlite-cli -- <command> ...` to invoke the CLI. Each command maps to a lifecycle step:
+
+- `init <index> <schema>`: creates a new index directory and writes the schema manifest so the index is ready to accept documents.
+- `add <index> <doc.jsonl>`: ingests newline-delimited JSON documents into the writer buffer; changes are not visible to readers until you run `commit`.
+- `commit <index>`: flushes buffered documents, writes new segment files, and updates the manifest so searches can see the newly added data.
+- `search <index> [options]`: executes a query, returning JSON hits (and optional aggregations) using either CLI flags or a full request payload.
+- `inspect <index>`: prints the current manifest and segment metadata to help debug index contents and state.
+- `compact <index>`: merges segments to reduce fragmentation and improve search performance.
+
 - Create an index from a schema:
 ```bash
 cargo run -p searchlite-cli -- init "$INDEX" schema.json


### PR DESCRIPTION
### Motivation
- Improve user documentation around the CLI so users know what each subcommand does and when to run it.
- Clarify the lifecycle of documents (ingest vs visible to readers) to avoid confusion about `add` vs `commit`.
- Provide a quick reference for the main maintenance and debugging commands (`inspect`, `compact`).

### Description
- Added a `CLI commands` section to `README.md` with usage guidance for `cargo run -p searchlite-cli -- <command> ...`.
- Documented each subcommand and its purpose: `init`, `add`, `commit`, `search`, `inspect`, and `compact`.
- Explained lifecycle semantics such as `add` buffering documents and `commit` flushing segments and updating the manifest so searches see new data.

### Testing
- Ran `cargo fmt --all` and it completed successfully.
- Ran `cargo clippy --all --all-features --all-targets -- -D warnings` and it passed with no warnings.
- Ran `cargo build --all --all-features` and `cargo test --all --all-features`, and the build completed and all tests passed.
- Ran `cargo bench -p searchlite-core` and the benchmark suite completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ba1448744832fba9390b0e212e257)