### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1788,7 +1788,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1835,7 +1835,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -1867,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.0...searchlite-cli-v0.1.1) - 2026-01-09
+
+### Added
+
+- supporting http server via cli
+
+### Other
+
+- Merge branch 'main' into feat/p8-ranking-controls
+
 ## [0.1.0](https://github.com/davidkelley/searchlite/releases/tag/searchlite-cli-v0.1.0) - 2026-01-08
 
 ### Added

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.1.0...searchlite-core-v0.2.0) - 2026-01-09
+
+### Added
+
+- add multi-vector ranking and scoring hooks
+- implemented http service
+
+### Fixed
+
+- address additional review feedback
+- address review feedback
+- return estimate counts regardless of limit value
+
 ## [0.1.0](https://github.com/davidkelley/searchlite/releases/tag/searchlite-core-v0.1.0) - 2026-01-08
 
 ### Added

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.0...searchlite-ffi-v0.1.1) - 2026-01-09
+
+### Added
+
+- add multi-vector ranking and scoring hooks
+
 ## [0.1.0](https://github.com/davidkelley/searchlite/releases/tag/searchlite-ffi-v0.1.0) - 2026-01-08
 
 ### Added

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.0...searchlite-wasm-v0.1.1) - 2026-01-09
+
+### Added
+
+- add multi-vector ranking and scoring hooks
+
 ## [0.1.0](https://github.com/davidkelley/searchlite/releases/tag/searchlite-wasm-v0.1.0) - 2026-01-08
 
 ### Added

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.1.0 -> 0.2.0 (⚠ API breaking changes)
* `searchlite-http`: 0.1.0
* `searchlite-cli`: 0.1.0 -> 0.1.1
* `searchlite-ffi`: 0.1.0 -> 0.1.1
* `searchlite-wasm`: 0.1.0 -> 0.1.1

### ⚠ `searchlite-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SearchRequest.candidate_size in /tmp/.tmpTwvs1f/searchlite/searchlite-core/src/api/types.rs:406
  field SearchRequest.candidate_size in /tmp/.tmpTwvs1f/searchlite/searchlite-core/src/api/types.rs:406

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant QueryNode:RankFeature in /tmp/.tmpTwvs1f/searchlite/searchlite-core/src/api/types.rs:335
  variant QueryNode:ScriptScore in /tmp/.tmpTwvs1f/searchlite/searchlite-core/src/api/types.rs:344
  variant QueryNode:RankFeature in /tmp/.tmpTwvs1f/searchlite/searchlite-core/src/api/types.rs:335
  variant QueryNode:ScriptScore in /tmp/.tmpTwvs1f/searchlite/searchlite-core/src/api/types.rs:344
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.1.0...searchlite-core-v0.2.0) - 2026-01-09

### Added

- add multi-vector ranking and scoring hooks
- implemented http service

### Fixed

- address additional review feedback
- address review feedback
- return estimate counts regardless of limit value
</blockquote>

## `searchlite-http`

<blockquote>

## [0.1.0](https://github.com/davidkelley/searchlite/releases/tag/searchlite-http-v0.1.0) - 2026-01-08

### Added

- implemented http service

### Fixed

- address http review feedback
- various fixes for the branch
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.0...searchlite-cli-v0.1.1) - 2026-01-09

### Added

- supporting http server via cli

### Other

- Merge branch 'main' into feat/p8-ranking-controls
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.0...searchlite-ffi-v0.1.1) - 2026-01-09

### Added

- add multi-vector ranking and scoring hooks
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.0...searchlite-wasm-v0.1.1) - 2026-01-09

### Added

- add multi-vector ranking and scoring hooks
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).