### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.2.0...searchlite-core-v0.2.1) - 2026-01-14
+
+### Fixed
+
+- harden nested validation and collapse grouping ([#55](https://github.com/davidkelley/searchlite/pull/55))
+- harden core replay and aggs
+- address review feedback
+- address review feedback
+- harden core durability and bounds
+- fsync vector files via storage helper
+- harden fsync durability and wal cleanup
+- guard compaction and writer consistency
+- harden core validation and durability
+- improve vector recall and durability
+
+### Other
+
+- avoid Debug bound in zstd guard
+- add wal coverage; clean rollback artifacts
+- satisfy clippy seek-from-current
+- add wal is_empty for clippy
+- log WAL sync errors on drop
+
 ## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.1.0...searchlite-core-v0.2.0) - 2026-01-09
 
 ### Added

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.0...searchlite-http-v0.1.1) - 2026-01-14
+
+### Added
+
+- add return_hits toggle and limit validation
+- supporting http server via cli
+
+### Fixed
+
+- address review feedback on return_hits
+
+### Other
+
+- Merge branch 'main' into feat/p8-ranking-controls
+
 ## [0.1.0](https://github.com/davidkelley/searchlite/releases/tag/searchlite-http-v0.1.0) - 2026-01-08
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `searchlite-http`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.2.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.2.0...searchlite-core-v0.2.1) - 2026-01-14

### Fixed

- harden nested validation and collapse grouping ([#55](https://github.com/davidkelley/searchlite/pull/55))
- harden core replay and aggs
- address review feedback
- address review feedback
- harden core durability and bounds
- fsync vector files via storage helper
- harden fsync durability and wal cleanup
- guard compaction and writer consistency
- harden core validation and durability
- improve vector recall and durability

### Other

- avoid Debug bound in zstd guard
- add wal coverage; clean rollback artifacts
- satisfy clippy seek-from-current
- add wal is_empty for clippy
- log WAL sync errors on drop
</blockquote>

## `searchlite-http`

<blockquote>

## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.0...searchlite-http-v0.1.1) - 2026-01-14

### Added

- add return_hits toggle and limit validation
- supporting http server via cli

### Fixed

- address review feedback on return_hits

### Other

- Merge branch 'main' into feat/p8-ranking-controls
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).