### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.2...searchlite-cli-v0.1.3) - 2026-01-14
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.1...searchlite-cli-v0.1.2) - 2026-01-14
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.1...searchlite-http-v0.1.2) - 2026-01-14
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.0...searchlite-http-v0.1.1) - 2026-01-14
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `searchlite-http`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `searchlite-cli`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-http`

<blockquote>

## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.1...searchlite-http-v0.1.2) - 2026-01-14

### Other

- update Cargo.lock dependencies
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.2...searchlite-cli-v0.1.3) - 2026-01-14

### Other

- update Cargo.lock dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).