### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "searchlite-core",

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.2.1...searchlite-core-v0.3.0) - 2026-01-15
+
+### Other
+
+- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
+
 ## [0.2.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.2.0...searchlite-core-v0.2.1) - 2026-01-14
 
 ### Fixed

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.1...searchlite-ffi-v0.1.2) - 2026-01-15
+
+### Other
+
+- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
+
 ## [0.1.1](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.0...searchlite-ffi-v0.1.1) - 2026-01-09
 
 ### Added

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.2.1 -> 0.3.0 (⚠ API breaking changes)
* `searchlite-ffi`: 0.1.1 -> 0.1.2

### ⚠ `searchlite-core` breaking changes

```text
--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field filters of struct SearchRequest, previously in file /tmp/tmp.hOY8vZk5kk/searchlite-core/src/api/types.rs:403
  field filters of struct SearchRequest, previously in file /tmp/tmp.hOY8vZk5kk/searchlite-core/src/api/types.rs:403
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.2.1...searchlite-core-v0.3.0) - 2026-01-15

### Other

- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.1...searchlite-ffi-v0.1.2) - 2026-01-15

### Other

- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).