### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.3...searchlite-cli-v0.1.4) - 2026-01-16
+
+### Other
+
+- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
+
 ## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.2...searchlite-cli-v0.1.3) - 2026-01-14
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.3.0...searchlite-core-v0.3.1) - 2026-01-16
+
+### Other
+
+- perf/optimize wand and http ([#63](https://github.com/davidkelley/searchlite/pull/63))
+
 ## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.2.1...searchlite-core-v0.3.0) - 2026-01-15
 
 ### Other

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.2...searchlite-http-v0.1.3) - 2026-01-16
+
+### Other
+
+- perf/optimize wand and http ([#63](https://github.com/davidkelley/searchlite/pull/63))
+- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
+
 ## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.1...searchlite-http-v0.1.2) - 2026-01-14
 
 ### Other

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.2...searchlite-wasm-v0.1.3) - 2026-01-16
+
+### Other
+
+- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
+
 ## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.1...searchlite-wasm-v0.1.2) - 2026-01-14
 
 ### Fixed

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `searchlite-http`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `searchlite-cli`: 0.1.3 -> 0.1.4
* `searchlite-wasm`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.3.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.3.0...searchlite-core-v0.3.1) - 2026-01-16

### Other

- perf/optimize wand and http ([#63](https://github.com/davidkelley/searchlite/pull/63))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.2...searchlite-http-v0.1.3) - 2026-01-16

### Other

- perf/optimize wand and http ([#63](https://github.com/davidkelley/searchlite/pull/63))
- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.3...searchlite-cli-v0.1.4) - 2026-01-16

### Other

- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.2...searchlite-wasm-v0.1.3) - 2026-01-16

### Other

- remove filters final ([#62](https://github.com/davidkelley/searchlite/pull/62))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).