### PR TITLE
chore/skills

### DIFF
--- a/.codex/skills/bug-hunting/SKILL.md
+++ b/.codex/skills/bug-hunting/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: bug-hunting
+description: Structured workflow for discovering, reproducing, and fixing bugs in Searchlite by inspecting real code paths (CLI/HTTP/core), validating durability invariants, and producing regression tests; use when investigating incorrect results, crashes, data loss risks, or “it sometimes fails” reports.
+---
+
+# Bug Hunting Workflow
+
+## Intent
+
+This skill is for **finding real bugs in the implementation**, not guessing. It forces a discovery phase (build a mental model, reproduce, narrow scope) before making changes.
+
+You must prioritize:
+
+1. correctness and durability
+2. clear reproduction
+3. minimal fix + regression test
+
+---
+
+## Non-negotiable rules
+
+- **No fix without a reproduction** (a failing test, a minimal repro program, or a deterministic HTTP/CLI script).
+- **No durability regressions**: do not weaken WAL/manifest/atomic rename/fsync ordering.
+- **No “drive-by refactors”** while bug hunting; keep patches tight and reviewable.
+- After changes, you must run the full quality suite from `code-quality`.
+
+---
+
+## Discovery phase (required)
+
+### 0) Establish the boundaries
+
+Before opening files, answer (in notes) these questions:
+
+- Which surface is affected? **CLI**, **HTTP**, **embedded API**, **wasm**, or **ffi**?
+- Is it a **correctness** issue (wrong results), **durability** issue (lost/duplicated data), or **stability** issue (panic/hang)?
+- Does it require a specific feature flag (`vectors`, `zstd`, `gpu`, wasm/IndexedDB, ffi)?
+- Is the failure deterministic or intermittent?
+
+### 1) Baseline the repo (don’t trust your local state)
+
+Run in workspace root:
+
+- `cargo fmt --all`
+- `cargo clippy --all --all-features --all-targets -- -D warnings`
+- `cargo test --all --all-features`
+
+If anything fails here, you may be chasing a known failure; fix/resolve that first.
+
+### 2) Map the architecture you’re about to debug
+
+Create a quick map in notes (1–2 minutes):
+
+- `searchlite-core`: schema, indexing, WAL/manifest, segments, query execution, filters/aggs, vectors
+- `searchlite-cli`: user-facing commands and JSON output formatting
+- `searchlite-http`: endpoints (/init, /add, /bulk, /delete, /commit, /refresh, /search, /inspect, /stats, /compact), limits/timeouts/concurrency
+- `searchlite-wasm`: bindings + IndexedDB storage semantics (no fsync)
+- `searchlite-ffi`: C ABI / safety edges
+
+This map guides where you look first.
+
+### 3) Reproduce the bug with the smallest possible corpus
+
+Produce a “minimal reproducible case” artifact set:
+
+- a schema JSON (small)
+- a small NDJSON/doc list (5–50 docs)
+- one request (HTTP JSON or CLI command) that fails
+
+For HTTP:
+
+- include the server flags/env (bind addr, index path, max-body-bytes, max-concurrency, request-timeout, refresh-on-commit)
+
+For CLI:
+
+- include exact commands and any flags
+
+**Goal:** a script a teammate can run in <60 seconds.
+
+### 4) Turn on observability (don’t add prints yet)
+
+Use existing debugging features first:
+
+- For search correctness: add `explain: true` to the request.
+- For performance/odd slowdowns while reproducing: add `profile: true`.
+- For server behavior: run with `RUST_LOG=debug` (or more targeted module filters) and capture the relevant lines.
+
+If your issue is “writes not visible,” verify lifecycle:
+
+- you must `commit`
+- you may need `/refresh` in HTTP depending on config
+
+### 5) Narrow the fault line by bisecting the pipeline
+
+Pick one axis at a time:
+
+**Correctness axis**
+
+- Does the doc get ingested successfully?
+- Does it appear in `/stats` documents?
+- Does `/inspect` show a new segment after commit?
+- Does the query match in bm25 mode vs wand/bmw mode?
+
+**Durability axis**
+
+- Is WAL appended correctly?
+- Is manifest updated atomically?
+- Is WAL truncated only after manifest persistence?
+- After restart, does replay do the expected thing?
+
+**HTTP axis**
+
+- Is the request being rejected due to max body / timeouts / concurrency?
+- Is NDJSON streaming partial and rolling back?
+- Are errors correctly surfaced as `{"error":{"type","reason"}}`?
+
+### 6) Perform a targeted static sweep of the suspected modules
+
+Once you know the rough area, do a deliberate scan for bug smells:
+
+Search patterns to grep/ripgrep for in the relevant crate:
+
+- panics: `unwrap()`, `expect(`, `panic!`, `unreachable!`, `todo!`
+- suspicious error handling: `map_err(|_|`, `ok()?` in non-optional contexts, silent `let _ =`
+- integer edge cases: casts (`as usize`), underflow (`- 1`), unchecked indexing
+- concurrency hazards: `Mutex`/`RwLock` lock ordering, `.await` while holding locks, channels without bounds
+- IO hazards: missing `fsync`, non-atomic file replace, partial writes not handled, directory fsync omissions
+- schema mismatch hazards: stringly-typed field lookups, analyzer lookup defaults, missing nested path validation
+- vector hazards: dimension mismatch, normalization assumptions, unchecked candidate sizing, `NaN` propagation
+
+You are not “fixing” in this step—just identifying suspects.
+
+### 7) Dynamic bug probes by subsystem (choose what fits)
+
+#### A) WAL / manifest / commit / rollback
+
+If you suspect commit/durability issues:
+
+- Reproduce a crash-window scenario:
+  1. ingest docs
+  2. start commit
+  3. force termination mid-way (or simulate via test hooks if present)
+  4. restart and observe replay
+- Validate the invariants:
+  - manifest atomic update (rename) and directory sync
+  - WAL truncation happens after manifest sync
+  - rollback cleans new segment artifacts
+
+If you can’t safely crash in tests, create a unit test around writer/commit phases and validate state.
+
+#### B) Segment lifecycle / compaction / cleanup
+
+If you see duplicates, ghosts, or bloat:
+
+- Inspect segments via `inspect` and compare to `stats`
+- Run compaction and verify:
+  - live docs preserved
+  - deleted/tombstoned dropped
+  - old segment files removed (or expected to remain until cleanup)
+
+#### C) Query execution modes
+
+If you suspect scoring/pruning bugs:
+
+- Run the same query with `execution=bm25`, `execution=wand`, `execution=bmw`
+- Results should match for deterministic corpora (unless the contract explicitly says otherwise)
+- If they diverge, you likely have a pruning-bound bug or block-max metadata mismatch
+
+#### D) Filters/aggs/nested correctness
+
+If filters/aggs are wrong:
+
+- Verify required fields are `fast: true`
+- For nested, verify the filter uses a `Nested` block and that clauses bind to the same object instance
+- Add a repro doc with two nested objects that would catch “cross-object” leakage
+
+#### E) Vectors (feature `vectors`)
+
+If vector behavior is wrong:
+
+- Check dimension mismatch handling
+- Check cosine normalization expectations
+- Confirm ANN parameters (`candidate_size`, `ef_search`) don’t overflow or accept nonsensical values
+- Verify hybrid search doesn’t double-count or drop vector scores
+
+---
+
+## Fix phase (required)
+
+### 1) Write the failing regression test first
+
+- Prefer a unit test in the most local crate if possible.
+- If the bug is surface-level behavior (HTTP contract, CLI output), add an integration test.
+- Make it deterministic and small.
+- Assert on structure, not strings (parse JSON output).
+
+### 2) Implement the minimal fix
+
+- Tight patch, minimal diff.
+- Keep durability semantics intact.
+- Avoid introducing allocations/locks in hot paths unless justified.
+
+### 3) Prove it
+
+Run:
+
+- `cargo test --all --all-features`
+- Any relevant examples (e.g. pruning example if you touched pruning logic)
+- If the bug touched performance-sensitive code, run the relevant bench before/after.
+
+### 4) Add a “root cause” note
+
+In the PR description or internal notes, include:
+
+- symptom
+- root cause
+- why the fix is correct
+- what test prevents regressions
+
+---
+
+## Output format (what Codex should produce)
+
+When using this skill, produce:
+
+1. **Repro artifact** (schema + docs + request/command)
+2. **Fault localization** (files + functions involved)
+3. **Root cause analysis**
+4. **Fix plan** (minimal changes)
+5. **Regression test** (where it lives and what it asserts)
+6. **Validation commands run** (from code-quality)

--- a/.codex/skills/code-quality/SKILL.md
+++ b/.codex/skills/code-quality/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: code-quality
+description: Guardrails for keeping the Searchlite Rust workspace compliant with formatting, lint, build, test, and perf expectations; use when preparing or reviewing changes to ensure they meet project quality bars.
+---
+
+# Code Quality Guardrails
+
+## What this skill is for
+
+Use this skill any time you:
+
+- touch core indexing/query code, storage/durability, schema parsing, or the JSON request model
+- add/modify CLI flags or HTTP endpoints
+- change behavior that could affect correctness, durability, or performance
+- add feature-gated functionality (`vectors`, `gpu`, `zstd`, `ffi`, wasm/IndexedDB storage)
+
+This is not a “nice-to-have.” The point is to make changes **reviewable, reproducible, and safe**.
+
+---
+
+## Non-negotiables (definition of done)
+
+A change is “done” only when:
+
+1. **Formatting** is applied to the whole workspace
+2. **Clippy** passes with warnings denied
+3. **Build** passes with `--all-features` (and ideally default features too)
+4. **Tests** pass with `--all-features`
+5. **Perf-sensitive changes** have at least one concrete validation (bench, profiling, or a before/after metric)
+6. **API/schema changes** update the artifacts that define the contract (`openapi.yaml`, `search-request.schema.json`, and docs/README examples)
+
+---
+
+## Required commands (workspace root)
+
+### Canonical Cargo commands
+
+Run these in the repo root:
+
+- Format:
+  - `cargo fmt --all`
+
+- Lint (deny warnings):
+  - `cargo clippy --all --all-features --all-targets -- -D warnings`
+
+- Build:
+  - `cargo build --all --all-features`
+
+- Test:
+  - `cargo test --all --all-features`
+
+- Bench (when touching ranking/index/query hot paths):
+  - `cargo bench -p searchlite-core`
+
+### `just` shortcuts
+
+If you use the workspace `Justfile`, keep the “one-liner” workflows working and equivalent:
+
+- `just fmt`
+- `just lint`
+- `just build`
+- `just test`
+- `just bench`
+
+> If you update one side (Cargo vs `just`), update the other.
+
+---
+
+## Toolchain policy (MSRV/pinned toolchain)
+
+- The repo pins a specific Rust toolchain via `rust-toolchain.toml` and documents that setup explicitly (currently `1.92.0`).
+- Treat that as the “works everywhere” baseline unless you intentionally raise it.
+
+**If you need a newer language/library feature:**
+
+- Prefer an alternative implementation compatible with the pinned toolchain.
+- If you must bump the toolchain (currently pinned in `rust-toolchain.toml` to `1.92.0`):
+  - change the toolchain file
+  - update README “Development setup”
+  - ensure CI (if any) uses the same toolchain
+  - call out the bump explicitly in the changelog/release notes
+
+---
+
+## Feature matrix expectations
+
+Searchlite is explicitly feature-gated in key areas:
+
+- `vectors` (vector fields + ANN/HNSW behavior)
+- `gpu` (GPU stubs / rerank integration points)
+- `zstd` (docstore compression behavior)
+- `ffi` (C ABI)
+- wasm bindings (`searchlite-wasm`, IndexedDB-backed storage)
+
+**Quality bar:**
+
+- Don’t break non-default combinations.
+- If you add code under a feature flag, add at least one:
+  - unit test gated with `#[cfg(feature = "...")]`, and/or
+  - integration test that runs only when the feature is enabled.
+
+---
+
+## “Hot path” performance rules
+
+Searchlite advertises small footprint + fast top-k via WAND/BMW pruning and block maxes. That implies real constraints:
+
+### When touching query evaluation / ranking
+
+- Avoid allocations in inner loops.
+- Prefer reusing buffers (e.g., keep scratch vectors on the struct, clear not reallocate).
+- Avoid iterator-heavy abstractions in the deepest loops if they obscure costs.
+- Measure with Searchlite’s built-in profiling modes when possible (see debugging-playbook).
+
+### Validate pruning modes didn’t regress
+
+Search supports multiple execution strategies:
+
+- `bm25` (full evaluation)
+- `wand` (exact WAND pruning)
+- `bmw` (block-max WAND)
+
+When changing ranking/pruning logic, verify correctness/perf by:
+
+- running the pruning example:
+  - `cargo run -p searchlite-core --example pruning`
+- and/or comparing the same query under `execution=bm25` vs `wand` vs `bmw`.
+
+---
+
+## Durability & storage invariants (do not weaken)
+
+Searchlite’s durability story is a core product claim. Preserve it:
+
+### Core guarantees
+
+- Segment files/manifests are flushed (`fsync`) on write.
+- WAL is truncated **only after** the manifest is persisted and synced.
+- Manifest updates use atomic rename + directory fsync.
+- Crash window is explicitly documented: a crash after manifest write but before WAL truncation causes WAL replay to reapply the last batch (no data loss; compaction cleans it up).
+
+### What this means for PRs that touch storage/commit logic
+
+If you change anything in:
+
+- segment writing
+- manifest writing
+- WAL appending/truncation
+- compaction + cleanup
+- storage backends (FS vs in-memory vs IndexedDB)
+
+…you must:
+
+- state the durability invariant(s) you preserved in the PR description
+- add/adjust tests that cover the crash window / replay behavior
+- keep atomic rename + directory fsync semantics for on-disk storage
+- keep in-memory storage explicitly “no durability” (don’t accidentally add fsync-ish behavior there)
+
+---
+
+## API contract sync checklist
+
+When you change any of:
+
+- HTTP endpoints, request/response shapes, error format
+- CLI flags or subcommand behavior
+- JSON request schema (query/filter/aggs/suggest/collapse/etc)
+
+You must update:
+
+- `openapi.yaml` (HTTP contract)
+- `search-request.schema.json` (JSON request contract)
+- at least one runnable example (README or docs) that exercises the new behavior
+
+Also preserve:
+
+- HTTP errors return the structured form:
+  - `{"error":{"type":"...","reason":"..."}}`
+
+---
+
+## Review checklist (copy into PRs)
+
+- [ ] `cargo fmt --all` clean
+- [ ] `cargo clippy --all --all-features --all-targets -- -D warnings` clean
+- [ ] `cargo build --all --all-features` clean
+- [ ] `cargo test --all --all-features` clean
+- [ ] If perf-sensitive: bench/profiling evidence included
+- [ ] If API/schema touched: `openapi.yaml` + schema JSON updated
+- [ ] If durability touched: atomic rename/fsync/WAL ordering preserved + test coverage updated
+- [ ] Feature flags respected (vectors/gpu/zstd/ffi/wasm)
+- [ ] Docs/examples updated and copy/paste runnable
+
+---
+
+## Commit & changelog hygiene
+
+- Prefer Conventional Commit prefixes: `feat:`, `fix:`, `perf:`, `refactor:`, `docs:`, `test:`, `chore:`.
+- If change impacts compatibility or durability semantics, call it out explicitly.

--- a/.codex/skills/debugging-playbook/SKILL.md
+++ b/.codex/skills/debugging-playbook/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: debugging-playbook
+description: Playbook for diagnosing Searchlite issues across CLI/HTTP, storage, and indexing; use when triaging failures or odd search results.
+---
+
+# Debugging Playbook
+
+## High-level mental model
+
+Searchlite is a single-index, single-writer system with:
+
+- buffered writes (CLI or HTTP)
+- durability via WAL + atomic manifest updates
+- immutable segments + periodic compaction
+- “refresh” semantics for making new commits visible to readers (especially in HTTP mode)
+
+Most “weirdness” is one of:
+
+1. **you didn’t commit** (writes are buffered)
+2. **you didn’t refresh** (reader is stale)
+3. **your schema isn’t configured for what you’re asking** (e.g., missing `fast` fields for filters/aggs)
+4. **you’re seeing crash-window replay artifacts** (extra segments until compaction)
+5. **you’re hitting HTTP limits** (body size, concurrency, timeouts)
+
+---
+
+## 10-minute triage checklist
+
+1. **Identify surface area**
+   - CLI? embedded Rust API? HTTP server?
+
+2. **Capture exact versions + features**
+   - git SHA/tag (if known)
+   - build flags / enabled features (`vectors` changes behavior materially)
+
+3. **Get a minimal reproduction**
+   - schema JSON
+   - the smallest NDJSON/JSON doc set that reproduces
+   - the exact search request JSON or CLI flags
+
+4. **Check index state**
+   - CLI: `searchlite inspect <index>` and `searchlite compact <index>`
+   - HTTP: `GET /inspect`, `GET /stats`, optionally `POST /compact`
+
+5. **Confirm lifecycle steps**
+   - Writes are queued → must call `commit`
+   - Depending on config, may need `refresh` for immediate visibility
+
+---
+
+## CLI debugging moves
+
+### A) “I added docs but search returns nothing”
+
+Common causes:
+
+- Documents missing the required ID field (`doc_id_field`, default `_id`)
+- You didn’t run `commit`
+- Query is hitting an analyzer mismatch or field mismatch
+
+Checklist:
+
+- Verify you ran:
+  - `searchlite add …`
+  - `searchlite commit …`
+- Run:
+  - `searchlite inspect <index>`
+  - `searchlite search <index> --q "..." --return-stored` (or request JSON with `return_stored: true`)
+- If segments ballooned after a crash, run:
+  - `searchlite compact <index>`
+
+### B) “Filters/aggs don’t work / always empty”
+
+Filters and aggregations depend on `fast` fields.
+
+- Ensure the target keyword/numeric fields are `"fast": true` in schema.
+- For nested filters, ensure nested subfields are `fast` too and use `Nested` filters properly.
+
+---
+
+## HTTP debugging moves
+
+### A) Safety + environment sanity
+
+HTTP server has **no auth / no rate limiting**; don’t expose it to untrusted networks.
+When debugging production-ish behavior, always capture:
+
+- bind addr (`--bind` / `SEARCHLITE_BIND_ADDR`)
+- index path (`--index` / `SEARCHLITE_INDEX_PATH`)
+- resource limits:
+  - `--max-body-bytes`
+  - `--max-concurrency`
+  - `--request-timeout-secs`
+  - shutdown grace
+- refresh behavior:
+  - `--refresh-on-commit`
+
+### B) Confirm lifecycle and visibility
+
+Writes issued via:
+
+- `POST /add` (NDJSON streaming)
+- `POST /bulk` (JSON bulk)
+- `POST /delete`
+
+…are queued and only become durable/searchable after:
+
+- `POST /commit`
+
+Then visibility depends on staleness needs:
+
+- if `--refresh-on-commit` is enabled, new data becomes visible immediately
+- otherwise call:
+  - `POST /refresh`
+
+### C) Use maintenance endpoints for ground truth
+
+- `POST /refresh` — reload readers
+- `POST /compact` — merge segments + clean up fragmentation
+- `GET  /inspect` — manifest + segments info
+- `GET  /stats` — doc/segment counts
+
+### D) Interpret HTTP errors
+
+All errors return:
+
+- `{"error":{"type":"...","reason":"..."}}`
+
+If you see a 413/timeout-ish behavior:
+
+- check `--max-body-bytes` and `--request-timeout-secs`
+- for NDJSON streaming, reduce batch sizes / request size
+
+---
+
+## Ranking correctness + “why did this score happen?”
+
+Search supports explicit debugging aids:
+
+### `explain: true`
+
+- Returns per-hit score breakdowns.
+- Use this for correctness (“why did doc X win?”), not for performance runs.
+
+### `profile: true`
+
+- Adds execution stats like:
+  - candidates examined
+  - scored docs
+  - postings advances
+  - timing buckets (search vs rescore)
+- Use this for performance triage (“why is this query slow?”).
+
+Both are off by default for overhead reasons.
+
+---
+
+## “This query is slow” playbook
+
+1. Enable `profile: true` on the request and capture the profile blob.
+2. Compare execution modes:
+   - `execution=bm25` (baseline full scoring)
+   - `execution=wand` (default exact pruning)
+   - `execution=bmw` (block-max pruning)
+3. Confirm you’re not forcing expensive features:
+   - rescore windows
+   - heavy highlighting
+   - large aggregations on high-cardinality fields
+4. If using aggregations:
+   - confirm required fields are `fast`
+   - consider sampling knobs where supported
+5. If using vector search (feature `vectors`):
+   - remember ANN is approximate; raising `candidate_size`/`ef_search` increases recall but costs CPU
+
+---
+
+## Vector search “it errors / results look wrong”
+
+Common causes:
+
+- wrong vector dimension (rejected)
+- using cosine without normalization assumptions (Searchlite normalizes cosine vectors automatically)
+- expecting exact results from ANN (HNSW is approximate)
+
+Knobs to tune:
+
+- `candidate_size` (oversampling)
+- `ef_search` (beam width)
+- `vector_filter` (reduce candidate set)
+
+---
+
+## Nested filter “it matches too much / too little”
+
+Key rule: nested filters are evaluated per object, not across the entire document.
+
+Correct pattern:
+
+- wrap clauses under `Nested` with `path`
+- for deeper nesting, use a nested `Nested` inside the parent nested filter
+
+Common gotcha:
+
+- forgetting to mark nested filter fields as `fast: true`
+
+---
+
+## Storage/durability anomalies
+
+Symptoms:
+
+- “extra segments” after crash
+- “duplicate generation” feeling after restart
+
+Remember the documented crash window:
+
+- if the process dies after manifest persisted but before WAL truncation, WAL replay reapplies last batch
+- data isn’t lost, but you may see extra segment generations until compaction
+
+Fix:
+
+- run `compact` (CLI or HTTP) to merge and clean up
+
+---
+
+## What to attach to a bug report
+
+- schema JSON
+- small docs ndjson/json
+- exact request JSON (include `execution`, `profile`, `explain` if relevant)
+- output of `inspect` + `stats`
+- server flags/env (HTTP)
+- if durability related: note whether crash/restart occurred

--- a/.codex/skills/docs-style/SKILL.md
+++ b/.codex/skills/docs-style/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: docs-style
+description: Style guide for writing Searchlite documentation and examples; use when creating or editing docs/ guides.
+---
+
+# Documentation Style
+
+## Goal
+
+Docs should be **copy/paste runnable** and should teach the lifecycle:
+init → ingest → commit → (refresh) → search → maintain (inspect/compact)
+
+Assume a junior/mid developer integrating Searchlite for the first time.
+
+---
+
+## Required conventions (use everywhere)
+
+### 1) Always introduce an index path variable
+
+Prefer:
+
+- CLI docs: `INDEX=/tmp/searchlite_idx`
+- HTTP docs: `SEARCHLITE_INDEX_PATH=/tmp/searchlite_idx`
+
+### 2) Always mention the required ID field
+
+- Every document must include the schema’s `doc_id_field` (default `_id`)
+- If a doc is missing it, it will be rejected
+
+### 3) Always include an explicit **commit** step after writes
+
+Searchlite buffers writes. Your examples must show:
+
+- `commit` after `add`/`bulk`/`delete`
+
+### 4) Always call out refresh semantics for HTTP
+
+- If `--refresh-on-commit` is disabled, readers may be stale until `POST /refresh`.
+
+### 5) Always call out fast vs stored
+
+- `stored: true` controls what can be returned
+- `fast: true` controls what can be filtered/aggregated efficiently
+
+---
+
+## Safety warnings (must appear in HTTP docs)
+
+The HTTP server:
+
+- provides **no authentication**
+- provides **no authorization**
+- provides **no rate limiting**
+
+Docs must include a bold warning:
+
+- “Do not expose directly to untrusted networks; place behind a proxy/API gateway that enforces auth + rate limiting.”
+
+Also include the “bind safely” recommendation:
+
+- default bind is localhost; show how to bind `0.0.0.0` only when behind a firewall/proxy.
+
+---
+
+## Examples must be complete
+
+Every guide/example must include all three artifacts:
+
+1. **schema JSON**
+2. **documents** (NDJSON or JSON)
+3. **request JSON** (search / filter / aggs / etc)
+
+Do not show “…”-style pseudo snippets for the main flow. If you must omit details, provide:
+
+- a minimal working version
+- then an “extended” version
+
+---
+
+## Code block conventions
+
+- Use fenced blocks with language tags:
+  - `bash`, `json`, `yaml`
+- Prefer 1 command per line
+- When showing multi-step flows, number them
+
+---
+
+## Docs structure templates
+
+### Quickstart / tutorial
+
+1. Install / build
+2. Init index
+3. Add docs
+4. Commit
+5. Search (show return_stored + highlight)
+6. Inspect / stats
+7. Compact (explain why)
+
+### HTTP serving guide
+
+1. Security warning (no auth)
+2. Run server (CLI flag form + env var form)
+3. `/init` example
+4. `/add` (NDJSON streaming) + `/commit` (+ optional `/refresh`)
+5. `/search` example
+6. Maintenance endpoints (`/inspect`, `/stats`, `/compact`, `/refresh`)
+7. Troubleshooting section (body size, timeouts, commit/refresh)
+
+### Reference docs (query/filter/aggs)
+
+- Start with “Field requirements”
+  - aggs require fast fields (terms = keyword fast; percentiles = numeric fast; etc.)
+- Include at least one runnable example per feature:
+  - fuzzy
+  - phrase/slop
+  - collapse + inner_hits
+  - rescore
+  - profile/explain
+  - vectors (feature-gated)
+
+---
+
+## Consistency + contract sync
+
+Whenever docs mention HTTP behavior:
+
+- ensure it matches `openapi.yaml`
+- errors should be shown as `{"error":{"type":"...","reason":"..."}}`
+
+Whenever docs mention request JSON shape:
+
+- ensure it matches `search-request.schema.json`
+
+---
+
+## “Docs review” checklist
+
+- [ ] Uses `INDEX` or `SEARCHLITE_INDEX_PATH`
+- [ ] Includes schema + docs + request JSON
+- [ ] Includes commit step
+- [ ] HTTP docs include security warning + refresh semantics
+- [ ] Notes fast vs stored requirements
+- [ ] Commands work as written (no placeholders)
+- [ ] Cross-links or references to related guides/endpoints

--- a/.codex/skills/index-lifecycle/SKILL.md
+++ b/.codex/skills/index-lifecycle/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: index-lifecycle
+description: Understanding and modifying Searchlite’s storage/indexing pipeline (WAL → segment build → manifest/compaction) and storage backends; use when working on ingest, durability, fast fields, or segment layouts.
+---
+
+# Index Lifecycle Cheatsheet
+
+## The Searchlite mental model (one paragraph)
+
+Searchlite serves **one index directory** per instance (CLI path or HTTP `--index`). A **single writer** buffers operations, appends them to a WAL, and on `commit` writes a new immutable segment and atomically updates a manifest. Readers consult the manifest to know which segments exist; compaction merges segments and drops deleted/obsolete data.
+
+---
+
+## Glossary
+
+- **Schema**: declares fields, analyzers, what’s stored vs fast vs indexed.
+- **WAL**: write-ahead log for durability of add/delete operations.
+- **Segment**: immutable set of postings/docstore/fast fields written on commit.
+- **Manifest**: authoritative list of segments that define the current index state.
+- **Refresh**: reload readers so they observe the latest manifest.
+- **Compaction**: rewrite live docs into fewer segments; cleans duplicates/old versions.
+
+---
+
+## Lifecycle steps (authoritative sequence)
+
+### 1) Init
+
+- Creates the index directory and writes schema/manifest state so it can accept docs.
+
+### 2) Ingest (add/update/delete)
+
+- Docs are upserted by primary key (`doc_id_field`, default `_id`)
+- Deletes are queued by id
+- Important: writes are buffered/queued; they are not visible to search yet
+
+### 3) Commit
+
+Commit is the “durable + visible” boundary:
+
+- writer flushes buffered ops
+- builds new segment files
+- persists them
+- atomically updates manifest
+
+Durability contract:
+
+- segment files/manifests are fsync’d on write
+- WAL truncation only happens after manifest is persisted/synced
+- manifest uses atomic rename + directory fsync
+
+Crash window (expected behavior):
+
+- if the process dies after manifest persisted but before WAL truncation, WAL replay re-applies the last batch
+- no data loss; compaction cleans extra generations
+
+### 4) Refresh (reader visibility)
+
+- With HTTP, visibility may require explicit `POST /refresh` unless configured with `--refresh-on-commit`.
+
+### 5) Search
+
+Search uses:
+
+- BM25 scoring by default (with pruning modes)
+- phrase and fuzzy matching
+- filters on fast fields
+- aggregations on fast fields
+- optional highlights, collapse/inner_hits, suggest, rescore, profile/explain
+
+Execution modes (perf/correctness relevant):
+
+- `bm25` full evaluation
+- `wand` exact pruning (default)
+- `bmw` block-max WAND pruning (tunable block size)
+
+### 6) Maintain
+
+- Inspect: see manifest + segments
+- Stats: see doc/segment counts
+- Compact: merge segments and drop tombstoned/obsolete docs
+
+---
+
+## File layout expectations (conceptual)
+
+The exact file names are an implementation detail, but the directory contains:
+
+- a manifest file (authoritative segment list)
+- a WAL file
+- per-segment files (postings/docstore/fast/meta/etc)
+- optional vector index structures when `vectors` is enabled
+
+When changing segment layout, preserve:
+
+- compatibility with existing indexes or provide a migration story
+- checksum/validation (if present)
+- atomicity during commit and cleanup after rollback/failed commit
+
+---
+
+## Schema invariants that drive the whole system
+
+- `doc_id_field` is required and is the key for upsert/delete semantics.
+- `stored: true` controls whether values can be returned/highlighted.
+- `fast: true` controls filters + aggregations performance/feasibility.
+- Nested fields flatten to dotted paths (e.g. `comment.author`) while preserving stored nested structure in responses.
+- Nested filters must be expressed with `Nested` blocks so clauses bind to the same object instance.
+
+---
+
+## Aggregations/filters coupling (easy to break)
+
+- `terms`, `significant_terms`, `rare_terms` require a fast keyword field.
+- numeric/date aggregations require fast numeric fields.
+- multi-valued fields contribute multiple values to metrics (doc_count remains per-doc).
+
+If you modify fast-field encoding, bucket iteration, or numeric parsing:
+
+- add tests that validate aggs outputs (not just existence of buckets).
+
+---
+
+## Vector search (feature `vectors`)
+
+Vector search is approximate ANN (HNSW):
+
+- dimension mismatches are rejected
+- cosine vectors are normalized automatically
+- tune recall/perf with `candidate_size` and `ef_search`
+- `vector_filter` can reduce candidate selection set
+
+If you touch vector integration:
+
+- test both vector-only and hybrid search paths
+- confirm response includes `vector_score` when vector search runs
+
+---
+
+## “Where to make changes” guidance
+
+- Core indexing/query/durability lives in `searchlite-core`
+- CLI wiring + UX lives in `searchlite-cli`
+- HTTP server wiring + limits + endpoints live in `searchlite-http` (and/or the CLI `http` subcommand)
+- wasm storage backend + bindings live in `searchlite-wasm`
+- C ABI lives in `searchlite-ffi`
+
+Keep boundaries clean:
+
+- `searchlite-core` should remain the source of truth for correctness; CLI/HTTP adapt surfaces around it.

--- a/.codex/skills/integration-testing/SKILL.md
+++ b/.codex/skills/integration-testing/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: integration-testing
+description: Guidance for end-to-end and integration tests across CLI/HTTP surfaces; use when exercising Searchlite flows through external interfaces.
+---
+
+# Integration Testing Guide
+
+## What counts as an integration test here?
+
+An integration test should:
+
+- create a real index (filesystem or in-memory, depending on surface)
+- drive Searchlite through a public interface (CLI args or HTTP requests)
+- validate observable behavior (hits, counts, errors, lifecycle)
+
+Avoid “testing internals through integration.” If you need to validate internals, write a unit test.
+
+---
+
+## Core end-to-end flows to cover
+
+### HTTP flow (minimum happy path)
+
+1. Start server on ephemeral port bound to localhost.
+2. `POST /init` with schema JSON.
+3. `POST /add` with NDJSON (or `POST /bulk` with JSON).
+4. `POST /commit`.
+5. `POST /refresh` (unless refresh-on-commit is enabled).
+6. `POST /search` with `return_stored: true`.
+7. `GET /stats` and `GET /inspect` sanity assertions.
+8. `POST /compact` then re-check stats/inspect invariants.
+
+Assertions that matter:
+
+- status codes
+- error payload shape: `{"error":{"type":"...","reason":"..."}}`
+- `stats` documents/segments move in expected direction
+- search returns `_id` and stored fields when requested
+- highlight presence when requested
+
+### CLI flow (minimum happy path)
+
+1. `init <index> <schema>`
+2. `add <index> <docs.ndjson>`
+3. `commit <index>`
+4. `search <index> ...`
+5. `inspect <index>`
+6. `compact <index>`
+
+Recommended harness:
+
+- `assert_cmd` + temp directories
+- parse JSON output and assert on structure not just string contains
+
+---
+
+## Integration tests for “easy to break” features
+
+### Filters + fast fields
+
+- Ensure filtering on keyword + numeric fields works only when `fast: true`.
+- Include at least one negative case (filter on non-fast field returns an error or empty, depending on contract).
+
+### Aggregations
+
+- Terms agg on a fast keyword field
+- Percentiles/stats on a fast numeric field
+- Composite pagination (assert `after_key` behavior if exposed)
+
+### Nested fields
+
+- Nested filter that requires binding to the same nested object
+- Deeper nested (nested inside nested) if supported
+
+### Debug flags (HTTP/JSON API)
+
+- `explain: true` returns a score breakdown blob
+- `profile: true` returns timing/stats fields
+- assert flags are off by default (no extra fields unless requested)
+
+### Execution modes
+
+- Same query under `bm25`, `wand`, `bmw` returns same top-k doc ids for deterministic fixtures
+- (allow differences only if the contract explicitly permits)
+
+### Vector search (feature-gated)
+
+- Guard with `#[cfg(feature = "vectors")]`
+- Assert dimension mismatch errors
+- Assert `vector_score` presence when vector path runs
+
+---
+
+## Resource-limit and shutdown coverage (HTTP)
+
+These are common production footguns; cover at least one:
+
+- max body bytes (expect rejection when exceeded)
+- request timeout (simulate with slow client / large payload)
+- max concurrency (hammer with parallel requests; expect graceful rejection/backpressure)
+- shutdown grace (if the test harness can trigger shutdown)
+
+---
+
+## Determinism rules (don’t write flaky tests)
+
+- Use fixed doc IDs and small, explicit corpora.
+- Avoid time-based assertions.
+- When testing sampling, fix seeds and assert “shape” (e.g., `sampled: true`) rather than exact counts unless contract guarantees exactness.
+- Sort results before comparing unless stable ordering is guaranteed by request `sort`.
+
+---
+
+## Running and maintaining the suite
+
+- Integration tests must pass with `cargo test --all --all-features`.
+- Keep runtime reasonable:
+  - prefer small fixtures
+  - avoid huge corpora
+  - use targeted assertions

--- a/.codex/skills/performance-improvements/SKILL.md
+++ b/.codex/skills/performance-improvements/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: performance-improvements
+description: Methodical workflow for discovering and fixing performance issues in Searchlite by measuring real workloads, using built-in profiling/explain tools, and optimizing hot paths without compromising durability or correctness; use when tuning indexing speed, query latency, memory, or throughput.
+---
+
+# Performance Improvements Workflow
+
+## Intent
+
+This skill is for improving performance by:
+
+- running a discovery phase to identify true hotspots
+- measuring before/after
+- making targeted optimizations that preserve correctness and durability
+- adding regression coverage (benchmarks or tests) when practical
+
+---
+
+## Non-negotiable rules
+
+- **Measure first**. No optimization without a baseline.
+- **One change at a time** (or a small coherent set) with before/after numbers.
+- **Do not weaken durability** (WAL/manifest/fsync/atomic write ordering stays intact).
+- After changes, run the full suite from `code-quality`.
+
+---
+
+## Discovery phase (required)
+
+### 0) Define what “better” means (pick a target)
+
+Pick one primary metric:
+
+- Search p50/p95 latency (ms)
+- Indexing throughput (docs/sec) or commit time
+- Memory usage (RSS / peak allocations)
+- HTTP ingestion throughput (MB/s) or request timeouts/rejections
+- Compaction runtime and resulting segment count/size
+
+Write it down as:  
+**Target:** “Improve X by ~Y without regressing correctness.”
+
+### 1) Choose a representative workload
+
+You need a workload that resembles reality:
+
+- For search: a set of queries including filters/aggs/highlights if used
+- For ingest: a doc set and commit cadence that matches production
+- For vectors: a vector corpus and ANN parameters
+
+Prefer:
+
+- small but realistic corpus for quick iteration (thousands of docs)
+- optional larger corpus for final validation (hundreds of thousands+)
+
+### 2) Build and run in release mode
+
+Performance work must be done in `--release`:
+
+- `cargo build --release --all-features`
+- run your workload with the release binary
+
+If you’re benchmarking, ensure the environment is stable (avoid noisy background work).
+
+### 3) Use Searchlite’s built-in query profiling tools
+
+For search workloads:
+
+- Add `profile: true` to capture execution stats and timing breakdowns.
+- Use `explain: true` only when investigating scoring/candidate issues (it adds overhead).
+
+Compare execution strategies:
+
+- `execution=bm25` (baseline)
+- `execution=wand` (default exact pruning)
+- `execution=bmw` (block-max pruning)
+
+If bm25 is similar to wand/bmw, pruning isn’t working as intended or your query pattern defeats it.
+
+### 4) Establish baselines and record them
+
+Capture:
+
+- command lines / request JSON used
+- corpus size (docs, fields, terms, vectors)
+- timings (at least 5 runs if feasible) and report min/median
+
+For `searchlite-core` hot path changes:
+
+- run `cargo bench -p searchlite-core`
+- store the before results in your notes/PR
+
+### 5) Identify where time is really going (don’t guess)
+
+Classify the hotspot into one bucket:
+
+#### A) Query evaluation CPU
+
+Symptoms: profile shows time in postings traversal, scoring, pruning, intersections.
+
+#### B) Candidate expansion / memory churn
+
+Symptoms: lots of allocations, large intermediate vectors, repeated sorting/heap ops.
+
+#### C) Docstore / highlight / JSON serialization
+
+Symptoms: time after scoring, fetching stored fields dominates, highlight is expensive.
+
+#### D) Filters/aggs
+
+Symptoms: time in aggregations; large cardinality terms aggs; missing fast fields causes slow fallback.
+
+#### E) IO / fsync overhead
+
+Symptoms: commit latency spikes; indexing throughput limited by disk flush behavior.
+
+#### F) HTTP ingestion
+
+Symptoms: parsing costs, backpressure stalls, concurrency limits hit, 413/timeout, high per-request overhead.
+
+#### G) Vectors (ANN)
+
+Symptoms: recall vs latency tradeoffs; ef_search/candidate_size too high; vector filtering not used.
+
+Pick the dominant bucket first; do not optimize secondary paths until the main bucket is improved.
+
+---
+
+## Implementation analysis checklist (required)
+
+Once you know the bucket, do a focused scan of the code involved.
+
+### General scan patterns (performance smells)
+
+Look for:
+
+- allocations inside tight loops:
+  - `Vec::new()` / `String::new()` inside per-doc/per-posting loops
+  - `.to_string()` / `.clone()` on hot data
+  - `collect::<Vec<_>>()` just to iterate again
+- repeated sorting where incremental selection would work (top-k heaps vs sort-all)
+- repeated hashing of the same keys (`HashMap` in inner loops)
+- converting between owned/borrowed forms repeatedly (String <-> &str)
+- lock contention:
+  - locks held across `.await`
+  - coarse locks around scoring or per-hit processing
+- IO inefficiencies:
+  - reopening files repeatedly
+  - small reads without buffering
+  - syncing too frequently (but do not weaken durability rules)
+
+### Query path specifics
+
+- Verify WAND/BMW pruning metadata is used effectively.
+- Ensure block-max metadata is not recomputed repeatedly.
+- Ensure per-hit work is minimized:
+  - fetch stored fields only if requested
+  - highlight only when requested
+  - avoid decoding docstore for filtered-out candidates
+
+### Aggregations specifics
+
+- Ensure aggs operate on fast fields and avoid per-doc dynamic dispatch.
+- Watch high-cardinality terms aggs:
+  - reduce allocations, reuse buffers
+  - avoid repeated string materialization if possible
+- If composite pagination exists, avoid re-sorting full bucket sets each page.
+
+### Indexing/commit specifics
+
+- Segment writing should be streaming and avoid holding the entire docset in memory.
+- Validate compression choices (`zstd`) only impact the intended paths.
+- Ensure fsync/atomic rename/directory sync semantics remain intact (don’t “optimize” them away).
+
+### HTTP specifics
+
+- NDJSON streaming should use bounded channels/backpressure.
+- Avoid buffering full bodies unnecessarily (respect `max-body-bytes`).
+- Ensure request timeouts and concurrency limits are enforced without excessive overhead.
+- Reduce serde overhead in hot request paths where possible (but keep correctness).
+
+### Vector specifics (`vectors`)
+
+- ANN parameters control CPU directly:
+  - lower `ef_search` reduces latency at cost of recall
+  - lower `candidate_size` reduces rescoring costs
+- Prefer vector filtering to shrink the candidate set before ANN where supported.
+- Ensure normalization happens once and doesn’t allocate repeatedly.
+
+---
+
+## Optimization playbook (apply in order)
+
+### 1) Remove unnecessary work
+
+- Short-circuit early (filters before expensive scoring if valid).
+- Don’t compute or serialize fields not requested.
+- Avoid repeated decoding of the same stored content.
+
+### 2) Reduce allocations
+
+- Reuse buffers on structs (clear instead of reallocate).
+- Pre-allocate vectors with `with_capacity` when sizes are known/estimable.
+- Prefer slices/borrowed views over owned clones in inner loops.
+
+### 3) Improve algorithmic complexity
+
+- For top-k: avoid “sort everything” when a heap/partial selection is enough.
+- For intersections: ensure the smallest postings list drives the loop.
+- For high-cardinality aggs: reduce key materialization and avoid repeated hashing.
+
+### 4) Optimize data locality
+
+- Keep hot structs small and contiguous.
+- Reduce indirection in tight loops (avoid iterator chains that hide branching/allocs).
+- Use integer IDs instead of strings where safe (e.g., field IDs vs field names).
+
+### 5) IO improvements (with durability preserved)
+
+- Batch reads/writes where safe.
+- Avoid redundant fsync calls, but never remove required ones:
+  - segment files must be persisted
+  - manifest update must be atomic and synced
+  - WAL truncation ordering must remain correct
+
+---
+
+## Validation phase (required)
+
+### 1) Prove correctness didn’t change
+
+- Run: `cargo test --all --all-features`
+- For query-path changes:
+  - verify same results across `bm25` vs `wand` vs `bmw` on a deterministic corpus
+  - use `explain` on a couple of hits to ensure scoring logic remains consistent
+
+### 2) Prove performance improved
+
+You must provide at least one of:
+
+- `cargo bench -p searchlite-core` before/after results (preferred)
+- recorded request latencies with `profile: true` before/after
+- ingest/commit timings before/after on a fixed corpus
+
+Include:
+
+- baseline numbers
+- new numbers
+- percent change
+- environment notes (release build, feature flags)
+
+### 3) Add a regression guard when feasible
+
+- Add/adjust a benchmark for the hot path you improved, OR
+- Add a test that prevents the pathological behavior (e.g., “does not allocate unboundedly” via size caps; “does not decode stored fields when return_stored=false”; etc.)
+
+---
+
+## Output format (what Codex should produce)
+
+When using this skill, produce:
+
+1. **Workload definition** (schema + corpus + queries/requests)
+2. **Baseline measurements**
+3. **Hotspot classification** (A–G bucket)
+4. **Code-level findings** (files/functions + why they’re hot)
+5. **Optimization plan** (ordered steps)
+6. **Patch summary** (what changed and why)
+7. **After measurements**
+8. **Risk assessment** (correctness/durability/feature-flag impact)
+9. **Commands run** (from code-quality)

--- a/.codex/skills/unit-testing/SKILL.md
+++ b/.codex/skills/unit-testing/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: unit-testing
+description: Patterns for adding and maintaining unit tests in the Searchlite workspace; use when writing or updating Rust tests for core behaviors.
+---
+
+# Unit Testing Patterns
+
+## Principles
+
+Unit tests should be:
+
+- **Hermetic**: no network, no global state, no shared directories.
+- **Deterministic**: fixed ids, fixed inputs, stable assertions.
+- **Small**: quick to run; integration tests cover full flows.
+- **Behavior-focused**: assert externally visible behavior of the module/API you’re testing.
+
+---
+
+## Recommended fixture setup
+
+- Use `tempfile::tempdir()` for filesystem-backed tests.
+- Prefer a minimal schema:
+  - `_id` as `doc_id_field`
+  - one text field (indexed + stored if needed)
+  - one keyword fast field (filters/aggs)
+  - one numeric fast field (ranges/aggs)
+  - add nested/vector only when needed
+
+- Prefer NDJSON-style docs for realism, but for unit tests:
+  - construct docs via serde_json where possible
+  - keep docs minimal and explicit
+
+---
+
+## Common test categories to maintain
+
+### A) Schema validation
+
+- Missing `doc_id_field` in docs should be rejected.
+- Analyzer references must exist.
+- `fast` fields required for filters/aggs paths that depend on them.
+- Nested fields flattening/dotted paths behave as documented.
+
+### B) Write lifecycle correctness
+
+- Add docs → commit → search sees docs
+- Delete docs → commit → search hides docs
+- Upsert same `_id` → commit → newest version is returned
+
+### C) Durability/WAL replay semantics
+
+- Write + commit; reopen index; ensure data present.
+- Simulate crash-window behavior if the API allows:
+  - manifest persisted but WAL not truncated → replay creates extra generation
+  - compaction cleans duplicates / reduces segments
+
+These tests are crucial if you touch commit ordering, fsync behavior, or WAL encoding.
+
+### D) Query correctness (core matching)
+
+Include at least one test each for:
+
+- query_string on multiple fields
+- phrase queries (slop if supported)
+- fuzzy matching (max_edits/prefix_length behavior)
+- dis_max / multi_match “best fields” semantics (if implemented)
+
+### E) Ranking correctness and stability
+
+- Use a tiny corpus where expected top-k is obvious.
+- If testing WAND/BMW pruning:
+  - assert results match the full-evaluation baseline (bm25) for deterministic corpora.
+
+### F) Filters and aggregations
+
+Filters:
+
+- Keyword equality
+- Numeric range
+- And/Or composition
+
+Aggregations:
+
+- terms on keyword fast field
+- stats/percentiles on numeric fast field
+- test multi-valued semantics if supported
+
+### G) Nested filters binding semantics
+
+- Construct a doc with multiple nested objects.
+- Assert that nested constraints bind to the same object instance (not “cross-object” matches).
+- Add deeper nesting tests if supported (nested inside nested).
+
+### H) Debug outputs
+
+If you expose `explain` or `profile` at the core layer:
+
+- assert fields appear only when requested
+- assert they don’t panic on edge cases (no hits, empty segments, etc.)
+
+### I) Vector search (feature gated)
+
+- Wrap tests in `#[cfg(feature = "vectors")]`
+- Dimension mismatch rejects
+- ANN knobs don’t panic and return sensible results on small corpora
+
+---
+
+## Assertion style guidelines
+
+- Prefer structured assertions:
+  - parse JSON responses into structs or serde_json::Value
+  - compare sorted lists for unordered fields
+- When checking floats (scores):
+  - assert relative ordering, not exact values, unless values are contractually stable
+- Avoid “string contains” unless you’re testing human-readable CLI output intentionally.
+
+---
+
+## Where to place tests
+
+- Small module-specific tests: `#[cfg(test)] mod tests { … }` alongside code.
+- Cross-module but still “core”: `searchlite-core/tests/*.rs`
+- End-to-end surface tests: prefer integration-testing skill instead.
+
+---
+
+## Red flags (rewrite the test if you see these)
+
+- Sleeps/timeouts used for “eventual consistency”
+- Assertions that depend on hash iteration order
+- Tests that pass only when run alone
+- Huge fixtures that slow the suite
+- Tests that depend on external binaries or network

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -4,30 +4,17 @@ This guide gets you from zero to a working Searchlite index in a few minutes usi
 
 ## Prerequisites
 
-- Rust 1.88.0+ installed (`rustup show` to verify) if you are building from source.
-- An x86_64 Linux/macOS machine with local SSD/NVMe recommended.
-- Clone this repo and stay in its root directory.
+- Linux or macOS (x86_64 or aarch64) with `curl` and `tar` available.
+- Local SSD/NVMe recommended for best ingest/search performance.
+- No build tools, package managers, or Node.js required—the installer downloads prebuilt binaries.
 
-Prefer a prebuilt binary instead of building from source? Install it directly:
+## 1) Install the CLI
 
 ```bash
 curl -fsSL https://searchlite.dev/install | sh
 ```
 
-After installing, replace `cargo run -p searchlite-cli -- ...` in the commands below with `searchlite ...`.
-
-```bash
-git clone https://github.com/davidkelley/searchlite.git
-cd searchlite
-```
-
-## 1) Build the CLI
-
-```bash
-cargo build -p searchlite-cli --release
-```
-
-The CLI binary will be at `target/release/searchlite-cli`. You can also use `cargo run -p searchlite-cli -- ...` for the steps below.
+The script installs a `searchlite` binary to `/usr/local/bin` or `~/.local/bin`. If your shell does not already include that directory, add it to `PATH` before continuing.
 
 ## 2) Create an index
 
@@ -60,10 +47,12 @@ Create a schema file that defines your fields and analyzers. Save the JSON below
 }
 ```
 
+`stored: true` lets you return fields in results, and `fast: true` enables efficient filters/aggregations (used below for `lang` and `year`).
+
 Initialize the index with that schema:
 
 ```bash
-cargo run -p searchlite-cli -- init "$INDEX" /tmp/schema.json
+searchlite init "$INDEX" /tmp/schema.json
 ```
 
 ## 3) Add documents
@@ -81,7 +70,7 @@ EOF
 Ingest the documents (this buffers them):
 
 ```bash
-cargo run -p searchlite-cli -- add "$INDEX" /tmp/docs.jsonl
+searchlite add "$INDEX" /tmp/docs.jsonl
 ```
 
 ## 4) Commit the changes
@@ -89,7 +78,7 @@ cargo run -p searchlite-cli -- add "$INDEX" /tmp/docs.jsonl
 Commit makes buffered documents visible to readers:
 
 ```bash
-cargo run -p searchlite-cli -- commit "$INDEX"
+searchlite commit "$INDEX"
 ```
 
 ## 5) Run a search
@@ -97,7 +86,7 @@ cargo run -p searchlite-cli -- commit "$INDEX"
 Search by query string plus filters. This example looks for “search” in `title`/`body` and filters by `year`:
 
 ```bash
-cargo run -p searchlite-cli -- search "$INDEX" \
+searchlite search "$INDEX" \
   --q "search" \
   --filter '{"I64Range":{"field":"year","min":2022,"max":2024}}' \
   --return-stored
@@ -123,25 +112,59 @@ For more control (sorting, aggregations, highlighting), send a full JSON payload
 Run it:
 
 ```bash
-cargo run -p searchlite-cli -- search "$INDEX" --request /tmp/request.json
+searchlite search "$INDEX" --request /tmp/request.json
 ```
 
-## 7) Inspect and maintain
+## 7) Serve over HTTP
+
+**Security warning:** The HTTP server has no auth, no authorization, and no rate limiting. Keep it bound to localhost or behind a proxy/firewall that enforces access control.
+
+Run the bundled HTTP server straight from the installed binary (no Rust toolchain needed):
+
+```bash
+searchlite http --index "$INDEX" --bind 127.0.0.1:8080
+# Add --refresh-on-commit if you want searches to see new data immediately.
+```
+
+Send the same search over HTTP:
+
+```bash
+curl -s http://127.0.0.1:8080/search \
+  -H "content-type: application/json" \
+  -d @/tmp/request.json
+```
+
+You can also ingest over HTTP instead of the CLI:
+
+```bash
+curl -X POST \
+  -H "content-type: application/x-ndjson" \
+  --data-binary @/tmp/docs.jsonl \
+  http://127.0.0.1:8080/add
+curl -X POST http://127.0.0.1:8080/commit
+# If you did not start the server with --refresh-on-commit, also call:
+curl -X POST http://127.0.0.1:8080/refresh
+```
+
+Keep the server bound to localhost unless you front it with a proxy or firewall.
+
+## 8) Inspect and maintain
 
 - Inspect the index manifest and segments:
 
   ```bash
-  cargo run -p searchlite-cli -- inspect "$INDEX"
+  searchlite inspect "$INDEX"
   ```
 
 - Compact occasionally to merge segments and reclaim space:
 
   ```bash
-  cargo run -p searchlite-cli -- compact "$INDEX"
+  searchlite compact "$INDEX"
   ```
 
 ## Next Steps
 
+- Start with the outlines in `docs/beginner-overview.md`, `docs/cli-indexing-guide.md`, and `docs/http-serving-guide.md` for a slower, junior-friendly walkthrough.
 - Explore analyzers, nested filters, aggregations, and vectors in the feature docs.
 - Embed Searchlite via the Rust API or FFI if you want to integrate directly into your app.
 - Check the Searchlite documentation site for updates and cross-links to deeper guides once they land.


### PR DESCRIPTION
- **chore: add workspace lock symlinks for release-plz**
- **chore: temporarily force release-plz**
- **fix: pushed up changes to release workflow**
- **chore: release (#56)**
- **chore(searchlite-cli): release v0.1.2 (#57)**
- **fix: update release command**
- **fix: updated wasm build**
- **chore(searchlite-wasm): release v0.1.2 (#58)**
- **chore/updated examples (#60)**
- **chore: release (#59)**
- **remove filters final (#62)**
- **chore: release (#61)**
- **perf/optimize wand and http (#63)**
- **chore: release (#64)**
- **fix: stream ndjson batches with single writer (#65)**
- **fix: default search request limit and return_stored**
- **fix: unify doc id validation   across ingest and delete paths**
- **fix(ffi): contain panics across   C boundary and stabilize ffi tests**
- **fix: address remaining limit=0 review feedback**
- **chore: adding additional codex skills**
