### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1797,7 +1797,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -1856,7 +1856,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.4...searchlite-cli-v0.1.5) - 2026-01-28
+
+### Fixed
+
+- address remaining limit=0 review feedback
+- unify doc id validation   across ingest and delete paths
+
 ## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.3...searchlite-cli-v0.1.4) - 2026-01-16
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.3.1...searchlite-core-v0.3.2) - 2026-01-28
+
+### Fixed
+
+- address remaining limit=0 review feedback
+- unify doc id validation   across ingest and delete paths
+- default search request limit and return_stored
+- stream ndjson batches with single writer ([#65](https://github.com/davidkelley/searchlite/pull/65))
+
 ## [0.3.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.3.0...searchlite-core-v0.3.1) - 2026-01-16
 
 ### Other

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.2...searchlite-ffi-v0.1.3) - 2026-01-28
+
+### Fixed
+
+- *(ffi)* contain panics across   C boundary and stabilize ffi tests
+
 ## [0.1.2](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.1...searchlite-ffi-v0.1.2) - 2026-01-15
 
 ### Other

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.3...searchlite-http-v0.1.4) - 2026-01-28
+
+### Fixed
+
+- address remaining limit=0 review feedback
+- unify doc id validation   across ingest and delete paths
+- stream ndjson batches with single writer ([#65](https://github.com/davidkelley/searchlite/pull/65))
+
 ## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.2...searchlite-http-v0.1.3) - 2026-01-16
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.3.1 -> 0.3.2 (✓ API compatible changes)
* `searchlite-http`: 0.1.3 -> 0.1.4 (✓ API compatible changes)
* `searchlite-cli`: 0.1.4 -> 0.1.5
* `searchlite-ffi`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.3.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.3.1...searchlite-core-v0.3.2) - 2026-01-28

### Fixed

- address remaining limit=0 review feedback
- unify doc id validation   across ingest and delete paths
- default search request limit and return_stored
- stream ndjson batches with single writer ([#65](https://github.com/davidkelley/searchlite/pull/65))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.3...searchlite-http-v0.1.4) - 2026-01-28

### Fixed

- address remaining limit=0 review feedback
- unify doc id validation   across ingest and delete paths
- stream ndjson batches with single writer ([#65](https://github.com/davidkelley/searchlite/pull/65))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.4...searchlite-cli-v0.1.5) - 2026-01-28

### Fixed

- address remaining limit=0 review feedback
- unify doc id validation   across ingest and delete paths
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.2...searchlite-ffi-v0.1.3) - 2026-01-28

### Fixed

- *(ffi)* contain panics across   C boundary and stabilize ffi tests
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).