### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1814,7 +1814,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -1846,7 +1846,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -1878,7 +1878,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "futures",

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.4.0...searchlite-core-v0.4.1) - 2026-01-28
+
+### Fixed
+
+- make ffi/wasm search requests atomic and align   return_stored defaults ([#73](https://github.com/davidkelley/searchlite/pull/73))
+
 ## [0.4.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.3.1...searchlite-core-v0.4.0) - 2026-01-28
 
 ### Added

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.3...searchlite-ffi-v0.1.4) - 2026-01-28
+
+### Fixed
+
+- make ffi/wasm search requests atomic and align   return_stored defaults ([#73](https://github.com/davidkelley/searchlite/pull/73))
+
 ## [0.1.3](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.2...searchlite-ffi-v0.1.3) - 2026-01-28
 
 ### Added

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.4...searchlite-wasm-v0.1.5) - 2026-01-28
+
+### Fixed
+
+- make ffi/wasm search requests atomic and align   return_stored defaults ([#73](https://github.com/davidkelley/searchlite/pull/73))
+
 ## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.3...searchlite-wasm-v0.1.4) - 2026-01-28
 
 ### Added

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `searchlite-ffi`: 0.1.3 -> 0.1.4
* `searchlite-wasm`: 0.1.4 -> 0.1.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.4.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.4.0...searchlite-core-v0.4.1) - 2026-01-28

### Fixed

- make ffi/wasm search requests atomic and align   return_stored defaults ([#73](https://github.com/davidkelley/searchlite/pull/73))
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.3...searchlite-ffi-v0.1.4) - 2026-01-28

### Fixed

- make ffi/wasm search requests atomic and align   return_stored defaults ([#73](https://github.com/davidkelley/searchlite/pull/73))
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.4...searchlite-wasm-v0.1.5) - 2026-01-28

### Fixed

- make ffi/wasm search requests atomic and align   return_stored defaults ([#73](https://github.com/davidkelley/searchlite/pull/73))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).