### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1893,7 +1893,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1910,7 +1910,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -1947,7 +1947,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.5...searchlite-cli-v0.1.6) - 2026-01-30
+
+### Added
+
+- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
+
 ## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.4...searchlite-cli-v0.1.5) - 2026-01-28
 
 ### Added

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.4.1...searchlite-core-v0.5.0) - 2026-01-30
+
+### Added
+
+- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
+
 ## [0.4.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.4.0...searchlite-core-v0.4.1) - 2026-01-28
 
 ### Fixed

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.4...searchlite-ffi-v0.1.5) - 2026-01-30
+
+### Added
+
+- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
+
 ## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.3...searchlite-ffi-v0.1.4) - 2026-01-28
 
 ### Fixed

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.4...searchlite-http-v0.1.5) - 2026-01-30
+
+### Added
+
+- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
+
 ## [0.1.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.3...searchlite-http-v0.1.4) - 2026-01-28
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.4.1 -> 0.5.0 (⚠ API breaking changes)
* `searchlite-http`: 0.1.4 -> 0.1.5 (✓ API compatible changes)
* `searchlite-cli`: 0.1.5 -> 0.1.6
* `searchlite-ffi`: 0.1.4 -> 0.1.5

### ⚠ `searchlite-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Manifest.write_key in /tmp/.tmpFuhnpR/searchlite/searchlite-core/src/index/manifest.rs:24

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant WalEntry:WriteBinding in /tmp/.tmpFuhnpR/searchlite/searchlite-core/src/index/wal.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.5.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.4.1...searchlite-core-v0.5.0) - 2026-01-30

### Added

- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.4...searchlite-http-v0.1.5) - 2026-01-30

### Added

- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.5...searchlite-cli-v0.1.6) - 2026-01-30

### Added

- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.4...searchlite-ffi-v0.1.5) - 2026-01-30

### Added

- optional write keys ([#85](https://github.com/davidkelley/searchlite/pull/85))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).