### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2084,7 +2084,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2138,7 +2138,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -2148,7 +2148,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2170,7 +2170,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.1.5"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "napi",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/integration/CHANGELOG.md
+++ b/integration/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/davidkelley/searchlite/compare/integration-v0.1.5...integration-v0.2.0) - 2026-04-10
+
+### Other
+
+- add cross-surface integration suite and CI workflow ([#106](https://github.com/davidkelley/searchlite/pull/106))

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.6...searchlite-cli-v0.1.7) - 2026-04-10
+
+### Added
+
+- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
+- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
+- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
+
+### Fixed
+
+- inline format args for clippy on Rust 1.88.0 ([#113](https://github.com/davidkelley/searchlite/pull/113))
+
 ## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.5...searchlite-cli-v0.1.6) - 2026-01-30
 
 ### Added

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.5.0...searchlite-core-v0.6.0) - 2026-04-10
+
+### Added
+
+- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
+- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
+- feat/nested aggregations ([#102](https://github.com/davidkelley/searchlite/pull/102))
+- partial update APIs ([#101](https://github.com/davidkelley/searchlite/pull/101))
+- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
+
+### Fixed
+
+- inline format args for clippy on Rust 1.88.0 ([#113](https://github.com/davidkelley/searchlite/pull/113))
+- fix/mget doc id response ([#105](https://github.com/davidkelley/searchlite/pull/105))
+
+### Other
+
+- overhaul README, benchmarks, and documentation suite ([#108](https://github.com/davidkelley/searchlite/pull/108))
+
 ## [0.5.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.4.1...searchlite-core-v0.5.0) - 2026-01-30
 
 ### Added

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.5...searchlite-ffi-v0.1.6) - 2026-04-10
+
+### Added
+
+- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
+- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
+- feat/mget documentation ([#100](https://github.com/davidkelley/searchlite/pull/100))
+- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
+
 ## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.4...searchlite-ffi-v0.1.5) - 2026-01-30
 
 ### Added

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.5...searchlite-http-v0.2.0) - 2026-04-10
+
+### Added
+
+- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
+- auto commit refresh indexes ([#104](https://github.com/davidkelley/searchlite/pull/104))
+- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
+- feat/nested aggregations ([#102](https://github.com/davidkelley/searchlite/pull/102))
+- partial update APIs ([#101](https://github.com/davidkelley/searchlite/pull/101))
+- feat/mget documentation ([#100](https://github.com/davidkelley/searchlite/pull/100))
+- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
+
+### Fixed
+
+- inline format args for clippy on Rust 1.88.0 ([#113](https://github.com/davidkelley/searchlite/pull/113))
+
 ## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.4...searchlite-http-v0.1.5) - 2026-01-30
 
 ### Added

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.1.5",
+	"version": "0.2.0",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.5...searchlite-wasm-v0.1.6) - 2026-04-10
+
+### Added
+
+- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
+
 ## [0.1.5](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.4...searchlite-wasm-v0.1.5) - 2026-01-28
 
 ### Fixed

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.5.0 -> 0.6.0 (⚠ API breaking changes)
* `searchlite-http`: 0.1.5 -> 0.2.0 (⚠ API breaking changes)
* `integration`: 0.1.5 -> 0.2.0
* `searchlite-cli`: 0.1.6 -> 0.1.7
* `searchlite-ffi`: 0.1.5 -> 0.1.6
* `searchlite-wasm`: 0.1.5 -> 0.1.6
* `searchlite-node`: 0.1.5 -> 0.2.0

### ⚠ `searchlite-core` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field Hit.sort_key in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/reader.rs:62
  field Hit.sort_key in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/reader.rs:62
  field SearchResult.next_search_after in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/reader.rs:108
  field SearchResult.next_search_after in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/reader.rs:108
  field SearchRequest.from in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:507
  field SearchRequest.search_after in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:520
  field SearchRequest.track_total_hits in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:528
  field SearchRequest.from in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:507
  field SearchRequest.search_after in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:520
  field SearchRequest.track_total_hits in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:528

--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field fuzziness of variant QueryNode::MultiMatch in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:340
  field fuzziness of variant QueryNode::MultiMatch in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:340

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant AggregationResponse:Nested in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:1385
  variant AggregationResponse:Nested in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:1385
  variant AggregationIntermediate:Nested in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/query/aggs/mod.rs:462
  variant Aggregation:Nested in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:1107
  variant Aggregation:Nested in /tmp/.tmpNzTgux/searchlite/searchlite-core/src/api/types.rs:1107
```

### ⚠ `searchlite-http` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ServeArgs.auto_commit_interval_secs in /tmp/.tmpNzTgux/searchlite/searchlite-http/src/lib.rs:209
  field ServeArgs.auto_refresh_interval_secs in /tmp/.tmpNzTgux/searchlite/searchlite-http/src/lib.rs:217
  field IndexSpec.auto_commit_interval_secs in /tmp/.tmpNzTgux/searchlite/searchlite-http/src/lib.rs:53
  field IndexSpec.auto_refresh_interval_secs in /tmp/.tmpNzTgux/searchlite/searchlite-http/src/lib.rs:54
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.6.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.5.0...searchlite-core-v0.6.0) - 2026-04-10

### Added

- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
- feat/nested aggregations ([#102](https://github.com/davidkelley/searchlite/pull/102))
- partial update APIs ([#101](https://github.com/davidkelley/searchlite/pull/101))
- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))

### Fixed

- inline format args for clippy on Rust 1.88.0 ([#113](https://github.com/davidkelley/searchlite/pull/113))
- fix/mget doc id response ([#105](https://github.com/davidkelley/searchlite/pull/105))

### Other

- overhaul README, benchmarks, and documentation suite ([#108](https://github.com/davidkelley/searchlite/pull/108))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.5...searchlite-http-v0.2.0) - 2026-04-10

### Added

- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
- auto commit refresh indexes ([#104](https://github.com/davidkelley/searchlite/pull/104))
- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
- feat/nested aggregations ([#102](https://github.com/davidkelley/searchlite/pull/102))
- partial update APIs ([#101](https://github.com/davidkelley/searchlite/pull/101))
- feat/mget documentation ([#100](https://github.com/davidkelley/searchlite/pull/100))
- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))

### Fixed

- inline format args for clippy on Rust 1.88.0 ([#113](https://github.com/davidkelley/searchlite/pull/113))
</blockquote>

## `integration`

<blockquote>

## [0.2.0](https://github.com/davidkelley/searchlite/compare/integration-v0.1.5...integration-v0.2.0) - 2026-04-10

### Other

- add cross-surface integration suite and CI workflow ([#106](https://github.com/davidkelley/searchlite/pull/106))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.7](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.6...searchlite-cli-v0.1.7) - 2026-04-10

### Added

- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))

### Fixed

- inline format args for clippy on Rust 1.88.0 ([#113](https://github.com/davidkelley/searchlite/pull/113))
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.5...searchlite-ffi-v0.1.6) - 2026-04-10

### Added

- product readiness — modularize reader, scale benchmarks, merge policy ([#107](https://github.com/davidkelley/searchlite/pull/107))
- Fuzzy/cross-field search + exact total hits ([#103](https://github.com/davidkelley/searchlite/pull/103))
- feat/mget documentation ([#100](https://github.com/davidkelley/searchlite/pull/100))
- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.6](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.5...searchlite-wasm-v0.1.6) - 2026-04-10

### Added

- mget & `search_after` ([#95](https://github.com/davidkelley/searchlite/pull/95))
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.1.5...searchlite-node-v0.2.0) - 2026-04-09

### Added

- add searchlite-js Node.js native addon ([#109](https://github.com/davidkelley/searchlite/pull/109))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).