### PR TITLE
ci: fix release workflow failing on new workspace members

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,9 @@ jobs:
           prev_dir="$(mktemp -d)"
           git clone --depth 1 --branch "$latest_tag" . "$prev_dir"
 
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-core/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-http/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-cli/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-ffi/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-wasm/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-node/Cargo.lock"
+          for member in searchlite-core searchlite-http searchlite-cli searchlite-ffi searchlite-wasm searchlite-node; do
+            [ -d "$prev_dir/$member" ] && ln -sf ../Cargo.lock "$prev_dir/$member/Cargo.lock"
+          done
 
           echo "path=$prev_dir/Cargo.toml" >> "$GITHUB_OUTPUT"
       - name: Configure git user
@@ -92,12 +89,9 @@ jobs:
           prev_dir="$(mktemp -d)"
           git clone --depth 1 --branch "$latest_tag" . "$prev_dir"
 
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-core/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-http/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-cli/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-ffi/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-wasm/Cargo.lock"
-          ln -sf ../Cargo.lock "$prev_dir/searchlite-node/Cargo.lock"
+          for member in searchlite-core searchlite-http searchlite-cli searchlite-ffi searchlite-wasm searchlite-node; do
+            [ -d "$prev_dir/$member" ] && ln -sf ../Cargo.lock "$prev_dir/$member/Cargo.lock"
+          done
 
           echo "path=$prev_dir/Cargo.toml" >> "$GITHUB_OUTPUT"
       - name: Configure git user


### PR DESCRIPTION
## Summary
- The `Cargo.lock` symlink step in the Release-plz workflow hardcodes all workspace member directories, including `searchlite-node` which doesn't exist in older release tags (e.g. `searchlite-core-v0.5.0`)
- Under `set -euo pipefail`, the `ln -sf` command fails because the target directory is missing, causing both release jobs to fail
- Replaces the hardcoded symlink list with a loop that checks `[ -d "$prev_dir/$member" ]` before creating each symlink

## Test plan
- [ ] Verify Release-plz workflow passes on this PR's merge to main
- [ ] Confirm the symlink step skips `searchlite-node` gracefully when checking out the `searchlite-core-v0.5.0` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)