### PR TITLE
feat(searchlite-js): typed search with Zod schema validation

### DIFF
--- a/searchlite-node/CHANGELOG.md
+++ b/searchlite-node/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.1.5...searchlite-node-v0.2.0) - 2026-04-09
+
+### Added
+
+- add searchlite-js Node.js native addon ([#109](https://github.com/davidkelley/searchlite/pull/109))

--- a/searchlite-node/src/index.ts
+++ b/searchlite-node/src/index.ts
@@ -10,12 +10,7 @@ import {
 	expandSchema,
 } from "./schemas";
 
-import type {
-	SchemaDefinition,
-	SearchRequest,
-	SearchResult,
-	TypedSearchResult,
-} from "./schemas";
+import type { SchemaDefinition, SearchRequest, SearchResult, TypedSearchResult } from "./schemas";
 
 export type {
 	FieldDefinition,
@@ -258,11 +253,9 @@ export class Index {
 
 		// Validate each hit's fields against the user's schema
 		if (fieldsSchema) {
-			const validateHitFields = (
-				hit: SearchResult["hits"][number],
-				path: string,
-			): void => {
-				const parsed = fieldsSchema!.safeParse(hit.fields);
+			const schema = fieldsSchema;
+			const validateHitFields = (hit: SearchResult["hits"][number], path: string): void => {
+				const parsed = schema.safeParse(hit.fields);
 				if (!parsed.success) {
 					throw new Error(
 						`Invalid fields on ${path} (docId: "${hit.docId}"):\n${prettifyError(parsed.error)}`,

--- a/searchlite-node/src/index.ts
+++ b/searchlite-node/src/index.ts
@@ -10,7 +10,12 @@ import {
 	expandSchema,
 } from "./schemas";
 
-import type { SchemaDefinition, SearchRequest, SearchResult } from "./schemas";
+import type {
+	SchemaDefinition,
+	SearchRequest,
+	SearchResult,
+	TypedSearchResult,
+} from "./schemas";
 
 export type {
 	FieldDefinition,
@@ -23,6 +28,8 @@ export type {
 	SearchRequest,
 	SearchResult,
 	TextFieldDef,
+	TypedHit,
+	TypedSearchResult,
 } from "./schemas";
 
 // --- Zod validation helper ---
@@ -206,18 +213,77 @@ export class Index {
 		this.#native.commit();
 	}
 
+	search<T>(schema: ZodType<T>, query: string): TypedSearchResult<T>;
+	search<T>(schema: ZodType<T>, query: SearchRequest): TypedSearchResult<T>;
 	search(query: string): SearchResult;
 	search(query: SearchRequest): SearchResult;
-	search(query: string | SearchRequest): SearchResult {
-		if (typeof query === "string") {
-			const raw = this.#native.search(query) as RawSearchResult;
-			return validate(SearchResultSchema, transformResult(raw), "search result");
+	search<T = unknown>(
+		queryOrSchema: string | SearchRequest | ZodType<T>,
+		maybeQuery?: string | SearchRequest,
+	): SearchResult | TypedSearchResult<T> {
+		let fieldsSchema: ZodType<T> | undefined;
+		let query: string | SearchRequest;
+
+		if (maybeQuery !== undefined) {
+			fieldsSchema = queryOrSchema as ZodType<T>;
+			query = maybeQuery;
+		} else {
+			query = queryOrSchema as string | SearchRequest;
 		}
 
-		const validated = validate(SearchRequestSchema, query, "search request");
-		const snaked = requestToSnake(validated);
-		const raw = this.#native.search(snaked) as RawSearchResult;
-		return validate(SearchResultSchema, transformResult(raw), "search result");
+		// Auto-set returnStored when a fields schema is provided
+		if (fieldsSchema) {
+			if (typeof query === "string") {
+				query = { query, returnStored: true };
+			} else {
+				query = { ...query, returnStored: true };
+			}
+		}
+
+		// Execute the search
+		let raw: RawSearchResult;
+		if (typeof query === "string") {
+			raw = this.#native.search(query) as RawSearchResult;
+		} else {
+			const validated = validate(SearchRequestSchema, query, "search request");
+			const snaked = requestToSnake(validated);
+			raw = this.#native.search(snaked) as RawSearchResult;
+		}
+
+		const result = validate(
+			SearchResultSchema,
+			transformResult(raw),
+			"search result",
+		) as SearchResult;
+
+		// Validate each hit's fields against the user's schema
+		if (fieldsSchema) {
+			const validateHitFields = (
+				hit: SearchResult["hits"][number],
+				path: string,
+			): void => {
+				const parsed = fieldsSchema!.safeParse(hit.fields);
+				if (!parsed.success) {
+					throw new Error(
+						`Invalid fields on ${path} (docId: "${hit.docId}"):\n${prettifyError(parsed.error)}`,
+					);
+				}
+				(hit as { fields: T }).fields = parsed.data;
+
+				if (hit.innerHits) {
+					for (let j = 0; j < hit.innerHits.length; j++) {
+						validateHitFields(hit.innerHits[j], `${path}.innerHits[${j}]`);
+					}
+				}
+			};
+
+			for (let i = 0; i < result.hits.length; i++) {
+				validateHitFields(result.hits[i], `hit ${i}`);
+			}
+			return result as unknown as TypedSearchResult<T>;
+		}
+
+		return result;
 	}
 
 	compact(): void {

--- a/searchlite-node/src/schemas.ts
+++ b/searchlite-node/src/schemas.ts
@@ -238,8 +238,43 @@ export const SearchResultSchema = z.object({
 
 export type OpenOptions = z.infer<typeof OpenOptionsSchema>;
 export type SearchRequest = z.input<typeof SearchRequestSchema>;
-export type SearchResult = z.infer<typeof SearchResultSchema>;
-export type Hit = z.infer<typeof HitSchema>;
+
+// --- Explicit generic interfaces (replaces z.infer which resolved to `unknown`) ---
+
+export interface Hit<TFields = unknown> {
+	docId: string;
+	score: number;
+	vectorScore?: number;
+	sortKey?: unknown[];
+	fields?: TFields | null;
+	snippet?: string | null;
+	explanation?: unknown;
+	highlights?: Record<string, string[]>;
+	innerHits?: Hit<TFields>[];
+}
+
+export interface SearchResult<TFields = unknown> {
+	totalHits: number;
+	totalGroups?: number;
+	hits: Hit<TFields>[];
+	nextCursor?: string;
+	nextSearchAfter?: unknown[];
+	aggregations: Record<string, unknown>;
+	suggest: Record<string, unknown>;
+	profile?: unknown;
+}
+
+// --- Typed variants returned when a Zod schema is provided to search() ---
+// `fields` is guaranteed non-optional because the schema validates it.
+
+export interface TypedHit<TFields> extends Omit<Hit<TFields>, "fields" | "innerHits"> {
+	fields: TFields;
+	innerHits?: TypedHit<TFields>[];
+}
+
+export interface TypedSearchResult<TFields> extends Omit<SearchResult<TFields>, "hits"> {
+	hits: TypedHit<TFields>[];
+}
 
 export type FieldShorthand = "text" | "keyword" | "integer" | "float";
 

--- a/searchlite-node/test/index.test.mjs
+++ b/searchlite-node/test/index.test.mjs
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import { afterEach, describe, expect, it } from "vitest";
 import { Index } from "../dist/index.js";
 
@@ -719,6 +720,166 @@ describe("result shape", () => {
 
 		const result = idx.search({ query: "numeric", returnStored: true });
 		expect(result.hits[0].fields).toBeTruthy();
+		idx.close();
+	});
+});
+
+// =============================================================================
+// Typed search (Zod schema)
+// =============================================================================
+
+describe("typed search", () => {
+	const BodySchema = z.object({
+		body: z.string(),
+	});
+
+	it("validates and returns typed fields with request object", () => {
+		const idx = createIndex();
+		idx.add({ _id: "1", body: "hello world" });
+		idx.commit();
+
+		const result = idx.search(BodySchema, { query: "hello" });
+		expect(result.totalHits).toBe(1);
+		expect(result.hits[0].fields).toEqual({ body: "hello world" });
+		idx.close();
+	});
+
+	it("validates and returns typed fields with string query", () => {
+		const idx = createIndex();
+		idx.add({ _id: "1", body: "hello world" });
+		idx.commit();
+
+		const result = idx.search(BodySchema, "hello");
+		expect(result.totalHits).toBe(1);
+		expect(result.hits[0].fields).toEqual({ body: "hello world" });
+		idx.close();
+	});
+
+	it("auto-sets returnStored when schema is provided", () => {
+		const idx = createIndex();
+		idx.add({ _id: "1", body: "auto stored" });
+		idx.commit();
+
+		// No need to manually set returnStored
+		const result = idx.search(BodySchema, { query: "auto" });
+		expect(result.hits[0].fields).toBeTruthy();
+		expect(result.hits[0].fields.body).toBe("auto stored");
+		idx.close();
+	});
+
+	it("throws with context when fields do not match schema", () => {
+		const idx = createIndex();
+		idx.add({ _id: "doc-42", body: "mismatch test" });
+		idx.commit();
+
+		const StrictSchema = z.object({
+			body: z.string(),
+			missing: z.number(),
+		});
+
+		expect(() => idx.search(StrictSchema, "mismatch")).toThrowError(/hit 0.*docId.*doc-42/s);
+		idx.close();
+	});
+
+	it("succeeds with empty results", () => {
+		const idx = createIndex();
+		idx.commit();
+
+		const result = idx.search(BodySchema, "nonexistent_xyz");
+		expect(result.hits).toHaveLength(0);
+		idx.close();
+	});
+
+	it("works with optional fields in schema", () => {
+		const idx = createIndex({ body: "text", tag: "keyword" });
+		idx.add({ _id: "1", body: "optional test" });
+		idx.commit();
+
+		const FlexSchema = z.object({
+			body: z.string(),
+			tag: z.string().optional(),
+		});
+
+		const result = idx.search(FlexSchema, "optional");
+		expect(result.hits[0].fields.body).toBe("optional test");
+		idx.close();
+	});
+
+	it("works with multiple hits", () => {
+		const idx = createIndex();
+		idx.addMany([
+			{ _id: "1", body: "alpha beta" },
+			{ _id: "2", body: "alpha gamma" },
+		]);
+		idx.commit();
+
+		const result = idx.search(BodySchema, "alpha");
+		expect(result.totalHits).toBe(2);
+		for (const hit of result.hits) {
+			expect(hit.fields.body).toBeTruthy();
+		}
+		idx.close();
+	});
+
+	it("applies Zod transforms to fields", () => {
+		const idx = createIndex();
+		idx.add({ _id: "1", body: "transform test" });
+		idx.commit();
+
+		const UpperSchema = z.object({
+			body: z.string().transform((s) => s.toUpperCase()),
+		});
+
+		const result = idx.search(UpperSchema, "transform");
+		expect(result.hits[0].fields.body).toBe("TRANSFORM TEST");
+		idx.close();
+	});
+
+	it("applies Zod defaults for missing fields", () => {
+		const idx = createIndex();
+		idx.add({ _id: "1", body: "defaults test" });
+		idx.commit();
+
+		const WithDefault = z.object({
+			body: z.string(),
+			extra: z.string().default("fallback"),
+		});
+
+		const result = idx.search(WithDefault, "defaults");
+		expect(result.hits[0].fields.body).toBe("defaults test");
+		expect(result.hits[0].fields.extra).toBe("fallback");
+		idx.close();
+	});
+
+	it("strips unknown keys by default (z.object behavior)", () => {
+		const idx = createIndex({ body: "text", tag: "keyword" });
+		idx.add({ _id: "1", body: "strip test", tag: "hello" });
+		idx.commit();
+
+		const PartialSchema = z.object({
+			body: z.string(),
+		});
+
+		const result = idx.search(PartialSchema, "strip");
+		expect(result.hits[0].fields.body).toBe("strip test");
+		// tag was stored but not in the schema — stripped by Zod
+		expect("tag" in result.hits[0].fields).toBe(false);
+		idx.close();
+	});
+
+	it("preserves unknown keys with passthrough", () => {
+		const idx = createIndex({ body: "text", tag: "keyword" });
+		idx.add({ _id: "1", body: "passthrough test", tag: "kept" });
+		idx.commit();
+
+		const PassthroughSchema = z.object({
+			body: z.string(),
+		}).passthrough();
+
+		const result = idx.search(PassthroughSchema, "passthrough");
+		expect(result.hits[0].fields.body).toBe("passthrough test");
+		// tag is preserved because of passthrough
+		expect(result.hits[0].fields.tag).toBe("kept");
 		idx.close();
 	});
 });

--- a/searchlite-node/test/index.test.mjs
+++ b/searchlite-node/test/index.test.mjs
@@ -1,8 +1,8 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { z } from "zod";
 import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
 import { Index } from "../dist/index.js";
 
 let cleanup = [];
@@ -872,9 +872,11 @@ describe("typed search", () => {
 		idx.add({ _id: "1", body: "passthrough test", tag: "kept" });
 		idx.commit();
 
-		const PassthroughSchema = z.object({
-			body: z.string(),
-		}).passthrough();
+		const PassthroughSchema = z
+			.object({
+				body: z.string(),
+			})
+			.passthrough();
 
 		const result = idx.search(PassthroughSchema, "passthrough");
 		expect(result.hits[0].fields.body).toBe("passthrough test");


### PR DESCRIPTION
## Summary

- Adds a new `search()` overload that accepts a Zod schema as the first argument, enabling **runtime field validation** and **compile-time type inference** on search results
- Introduces `TypedHit<T>` and `TypedSearchResult<T>` interfaces so typed searches return `fields: T` (non-optional), while untyped searches retain `fields?: unknown | null`
- Fixes the existing `Hit` and `SearchResult` type aliases which resolved to `unknown` due to the unparameterized `HitSchema: z.ZodType` declaration — replaced with explicit generic interfaces

### API

```typescript
const ArticleFields = z.object({ title: z.string(), author: z.string() });

// Typed search — fields is { title: string; author: string }, no optional chaining needed
const result = index.search(ArticleFields, { query: "hello" });
result.hits[0].fields.title; // ✅ fully typed, non-optional

// Untyped search — unchanged
const result = index.search("hello");
```

**Behaviors when a Zod schema is provided:**
- `returnStored` is automatically set to `true`
- Each hit's `fields` is validated via `safeParse` with contextual error messages (hit index + docId)
- Zod transforms (`.transform()`, `.default()`) are applied to the result
- `z.object()` strips unknown keys by default; `.passthrough()` preserves them

## Test plan

- [x] Typed search with request object returns validated fields
- [x] Typed search with string query auto-sets `returnStored`
- [x] Schema validation failure throws with hit index and docId context
- [x] Empty result sets pass without validation errors
- [x] Optional fields in schema work correctly
- [x] Multiple hits all validated
- [x] Zod `.transform()` applied to field values
- [x] Zod `.default()` fills missing fields
- [x] Default `z.object()` strips unknown keys
- [x] `.passthrough()` preserves all stored fields
- [x] All 81 existing + new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)