### PR TITLE
fix: inline format args for clippy on Rust 1.88.0

### DIFF
--- a/searchlite-cli/src/main.rs
+++ b/searchlite-cli/src/main.rs
@@ -279,7 +279,7 @@ fn cmd_init(index: &Path, schema_path: &Path, write_key: Option<&str>) -> Result
   let schema_str = fs::read_to_string(schema_path)?;
   let schema: searchlite_core::api::types::Schema = serde_json::from_str(&schema_str)?;
   IndexBuilder::create_with_write_key(index, schema, opts, write_key)?;
-  println!("initialized index at {:?}", index);
+  println!("initialized index at {index:?}");
   Ok(())
 }
 
@@ -288,7 +288,7 @@ fn cmd_add(index: &Path, doc_path: &Path, write_key: Option<&str>) -> Result<()>
   let idx = Index::open(opts)?;
   let mut writer = idx.writer_with_key(write_key)?;
   let content =
-    fs::read_to_string(doc_path).with_context(|| format!("reading docs from {:?}", doc_path))?;
+    fs::read_to_string(doc_path).with_context(|| format!("reading docs from {doc_path:?}"))?;
   for (line_no, line) in content.lines().enumerate() {
     if line.trim().is_empty() {
       continue;
@@ -312,7 +312,7 @@ fn cmd_delete(index: &Path, ids_path: &Path, write_key: Option<&str>) -> Result<
   let idx = Index::open(opts)?;
   let mut writer = idx.writer_with_key(write_key)?;
   let content = fs::read_to_string(ids_path)
-    .with_context(|| format!("reading document ids from {:?}", ids_path))?;
+    .with_context(|| format!("reading document ids from {ids_path:?}"))?;
   let mut ids = Vec::new();
   for (line_no, line) in content.lines().enumerate() {
     let line = line.strip_suffix('\r').unwrap_or(line);
@@ -459,9 +459,9 @@ fn build_search_request_from_cli(args: SearchCliArgs) -> Result<SearchRequest> {
 fn read_request(path: Option<PathBuf>, request_stdin: bool) -> Result<Option<SearchRequest>> {
   if let Some(p) = path {
     let contents =
-      fs::read_to_string(&p).with_context(|| format!("reading search request from {:?}", p))?;
+      fs::read_to_string(&p).with_context(|| format!("reading search request from {p:?}"))?;
     let request = serde_json::from_str::<SearchRequest>(&contents)
-      .with_context(|| format!("parsing search request JSON from {:?}", p))?;
+      .with_context(|| format!("parsing search request JSON from {p:?}"))?;
     if request.limit == 0 && request.cursor.is_some() {
       bail!("cursor is not supported when limit is 0");
     }
@@ -487,7 +487,7 @@ fn load_aggs(
   aggs_file: Option<PathBuf>,
 ) -> Result<BTreeMap<String, Aggregation>> {
   let raw = if let Some(path) = aggs_file {
-    Some(fs::read_to_string(&path).with_context(|| format!("reading aggs from {:?}", path))?)
+    Some(fs::read_to_string(&path).with_context(|| format!("reading aggs from {path:?}"))?)
   } else {
     aggs
   };

--- a/searchlite-core/benches/datagen.rs
+++ b/searchlite-core/benches/datagen.rs
@@ -328,10 +328,7 @@ fn random_date(rng: &mut impl Rng) -> String {
 
   // Simple date calculation from days since 1970-01-01
   let (year, month, day) = days_to_ymd(days_since_epoch);
-  format!(
-    "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
-    year, month, day, hours, minutes, seconds
-  )
+  format!("{year:04}-{month:02}-{day:02}T{hours:02}:{minutes:02}:{seconds:02}Z")
 }
 
 /// Convert days since Unix epoch to (year, month, day).

--- a/searchlite-core/src/api/builder.rs
+++ b/searchlite-core/src/api/builder.rs
@@ -32,9 +32,9 @@ impl IndexBuilder {
     opts: IndexOptions,
   ) -> anyhow::Result<Index> {
     let data = fs::read_to_string(schema_path)
-      .with_context(|| format!("reading schema file {:?}", schema_path))?;
+      .with_context(|| format!("reading schema file {schema_path:?}"))?;
     let schema: Schema = serde_json::from_str(&data)
-      .with_context(|| format!("parsing schema file {:?}", schema_path))?;
+      .with_context(|| format!("parsing schema file {schema_path:?}"))?;
     Self::create(path, schema, opts)
   }
 

--- a/searchlite-core/src/api/pagination.rs
+++ b/searchlite-core/src/api/pagination.rs
@@ -72,10 +72,7 @@ impl PaginationCursor {
     let doc_id = u32::from_be_bytes(bytes[13..17].try_into().unwrap());
     let returned = u32::from_be_bytes(bytes[17..21].try_into().unwrap());
     if returned as usize > MAX_CURSOR_ADVANCE {
-      bail!(
-        "cursor requests {} hits, which exceeds max supported {MAX_CURSOR_ADVANCE}",
-        returned
-      );
+      bail!("cursor requests {returned} hits, which exceeds max supported {MAX_CURSOR_ADVANCE}");
     }
     Ok(Self {
       version,
@@ -222,7 +219,7 @@ pub(crate) fn decode_search_after_token(
   let segment_ord = parse_segment_ord(seg_value)?;
   let seg = segments
     .get(segment_ord as usize)
-    .ok_or_else(|| anyhow::anyhow!("search_after segment_ord {} out of range", segment_ord))?;
+    .ok_or_else(|| anyhow::anyhow!("search_after segment_ord {segment_ord} out of range"))?;
   let doc_id_str = match doc_id_value {
     serde_json::Value::String(s) => s.clone(),
     serde_json::Value::Number(n) => n.to_string(),

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -988,7 +988,7 @@ impl IndexReader {
       let seg = self
         .segments
         .get(seg_ord as usize)
-        .ok_or_else(|| anyhow::anyhow!("missing segment {}", seg_ord))?;
+        .ok_or_else(|| anyhow::anyhow!("missing segment {seg_ord}"))?;
       let key = sort_plan.build_key(seg, doc_id, final_score, seg_ord);
       if let Some(cur) = cursor_key {
         let ord = key.cmp(cur);
@@ -1080,10 +1080,7 @@ impl IndexReader {
       .unwrap_or(0);
     let page_cap = from.saturating_add(req.limit);
     if req.return_hits && page_cap > MAX_PAGE_SIZE {
-      bail!(
-        "from + size exceeds max page size {}; adjust pagination",
-        MAX_PAGE_SIZE
-      );
+      bail!("from + size exceeds max page size {MAX_PAGE_SIZE}; adjust pagination");
     }
     let default_fields: Vec<String> = if let Some(fields) = &req.fields {
       fields.clone()
@@ -1560,7 +1557,7 @@ impl IndexReader {
         let seg = self
           .segments
           .get(*seg_idx)
-          .ok_or_else(|| anyhow::anyhow!("segment {} missing for mget", seg_idx))?;
+          .ok_or_else(|| anyhow::anyhow!("segment {seg_idx} missing for mget"))?;
         if seg.is_deleted(*doc_idx) {
           continue;
         }
@@ -1573,7 +1570,7 @@ impl IndexReader {
       let seg = self
         .segments
         .get(seg_idx)
-        .ok_or_else(|| anyhow::anyhow!("segment {} missing for mget", seg_idx))?;
+        .ok_or_else(|| anyhow::anyhow!("segment {seg_idx} missing for mget"))?;
       let source = if return_stored {
         Some(seg.get_doc(doc_idx)?)
       } else {
@@ -3688,9 +3685,7 @@ mod tests {
     assert_eq!(
       seen_matches.len(),
       5,
-      "accepted: {:?}, ranked: {:?}",
-      seen_matches,
-      ranked_ids
+      "accepted: {seen_matches:?}, ranked: {ranked_ids:?}"
     );
     let res = reader
       .search(&SearchRequest {
@@ -3745,7 +3740,7 @@ mod tests {
       })
       .unwrap();
     let ids: Vec<_> = res.hits.iter().map(|h| h.doc_id.as_str()).collect();
-    assert_eq!(ids.len(), 5, "hits: {:?}", ids);
+    assert_eq!(ids.len(), 5, "hits: {ids:?}");
   }
 
   #[test]
@@ -4104,9 +4099,7 @@ mod tests {
     let total_candidates: usize = plan.clauses.iter().map(|c| c.candidate_size).sum();
     assert!(
       total_candidates <= DEFAULT_MAX_VECTOR_GLOBAL_CANDIDATES,
-      "total vector candidates {} exceeds cap {}",
-      total_candidates,
-      DEFAULT_MAX_VECTOR_GLOBAL_CANDIDATES
+      "total vector candidates {total_candidates} exceeds cap {DEFAULT_MAX_VECTOR_GLOBAL_CANDIDATES}"
     );
     assert!(
       plan.candidate_size <= DEFAULT_MAX_VECTOR_GLOBAL_CANDIDATES,

--- a/searchlite-core/src/api/writer.rs
+++ b/searchlite-core/src/api/writer.rs
@@ -367,18 +367,15 @@ impl IndexWriter {
       if let Err(truncate_err) = self.wal.truncate_to(wal_len) {
         log::error!(
           "WAL rollback failed while handling commit error: \
-           unable to truncate WAL back to length {}: {}",
-          wal_len,
-          truncate_err
+           unable to truncate WAL back to length {wal_len}: {truncate_err}"
         );
       }
       if let Err(manifest_err) =
         manifest_snapshot.store(self.inner.storage.as_ref(), &manifest_path)
       {
         log::error!(
-          "Manifest rollback failed while handling commit error: {}. \
-           The on-disk manifest and WAL may be inconsistent.",
-          manifest_err
+          "Manifest rollback failed while handling commit error: {manifest_err}. \
+           The on-disk manifest and WAL may be inconsistent."
         );
       }
       if !new_segments.is_empty() {
@@ -650,7 +647,7 @@ fn validate_patch_fields(
   let patchable_paths = patchable_schema_paths(schema);
   for path in set.keys().chain(unset.iter()) {
     if path == doc_id_field {
-      bail!("cannot update doc_id_field `{}`", doc_id_field);
+      bail!("cannot update doc_id_field `{doc_id_field}`");
     }
     if !patchable_paths.contains(path) {
       bail!("unknown field {path}");

--- a/searchlite-core/src/index/directory.rs
+++ b/searchlite-core/src/index/directory.rs
@@ -16,29 +16,17 @@ pub fn wal_path(root: &Path) -> PathBuf {
 pub fn segment_paths(root: &Path, id: &str) -> SegmentPaths {
   SegmentPaths {
     terms: root
-      .join(format!("seg_{}.terms", id))
+      .join(format!("seg_{id}.terms"))
       .to_string_lossy()
       .into(),
-    postings: root
-      .join(format!("seg_{}.post", id))
-      .to_string_lossy()
-      .into(),
-    docstore: root
-      .join(format!("seg_{}.docs", id))
-      .to_string_lossy()
-      .into(),
-    fast: root
-      .join(format!("seg_{}.fast", id))
-      .to_string_lossy()
-      .into(),
-    meta: root
-      .join(format!("seg_{}.meta", id))
-      .to_string_lossy()
-      .into(),
+    postings: root.join(format!("seg_{id}.post")).to_string_lossy().into(),
+    docstore: root.join(format!("seg_{id}.docs")).to_string_lossy().into(),
+    fast: root.join(format!("seg_{id}.fast")).to_string_lossy().into(),
+    meta: root.join(format!("seg_{id}.meta")).to_string_lossy().into(),
     #[cfg(feature = "vectors")]
     vector_dir: Some(
       root
-        .join(format!("seg_{}_vectors", id))
+        .join(format!("seg_{id}_vectors"))
         .to_string_lossy()
         .into(),
     ),
@@ -47,7 +35,7 @@ pub fn segment_paths(root: &Path, id: &str) -> SegmentPaths {
 
 #[allow(dead_code)]
 pub fn segment_meta_path(root: &Path, id: &str) -> PathBuf {
-  root.join(format!("seg_{}.meta", id))
+  root.join(format!("seg_{id}.meta"))
 }
 
 #[allow(dead_code)]

--- a/searchlite-core/src/index/docstore.rs
+++ b/searchlite-core/src/index/docstore.rs
@@ -83,11 +83,7 @@ impl<R: Read + Seek> DocStoreReader<R> {
     self.file.read_exact(&mut len_bytes)?;
     let len = u32::from_le_bytes(len_bytes) as usize;
     if len > MAX_DOCSTORE_BYTES {
-      bail!(
-        "stored document length {} exceeds maximum {}",
-        len,
-        MAX_DOCSTORE_BYTES
-      );
+      bail!("stored document length {len} exceeds maximum {MAX_DOCSTORE_BYTES}");
     }
     let mut buf = vec![0u8; len];
     self.file.read_exact(&mut buf)?;

--- a/searchlite-core/src/index/fastfields.rs
+++ b/searchlite-core/src/index/fastfields.rs
@@ -204,7 +204,7 @@ impl FastFieldsWriter {
             }
             entries[idx] = vec![v];
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::F64(v) => {
@@ -225,7 +225,7 @@ impl FastFieldsWriter {
             }
             entries[idx] = vec![v];
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::I64List(values) => {
@@ -252,7 +252,7 @@ impl FastFieldsWriter {
             list_entries[idx] = values;
             *col = ColumnBuilder::I64List(list_entries);
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::I64Nested { object, values } => {
@@ -271,7 +271,7 @@ impl FastFieldsWriter {
             }
             doc_entries[object] = values;
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::F64List(values) => {
@@ -298,7 +298,7 @@ impl FastFieldsWriter {
             list_entries[idx] = values;
             *col = ColumnBuilder::F64List(list_entries);
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::F64Nested { object, values } => {
@@ -317,7 +317,7 @@ impl FastFieldsWriter {
             }
             doc_entries[object] = values;
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::Str(v) => {
@@ -331,7 +331,7 @@ impl FastFieldsWriter {
             let single = [v];
             builder.push(idx, &single);
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::StrList(values) => {
@@ -356,7 +356,7 @@ impl FastFieldsWriter {
             list_builder.push(idx, &values);
             *col = ColumnBuilder::StrList(list_builder);
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::StrNested { object, values } => {
@@ -366,7 +366,7 @@ impl FastFieldsWriter {
           .or_insert_with(|| ColumnBuilder::StrNested(StrNestedColumnBuilder::default()));
         match col {
           ColumnBuilder::StrNested(builder) => builder.push(idx, object, &values),
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::NestedCount { objects } => {
@@ -381,7 +381,7 @@ impl FastFieldsWriter {
             }
             counts[idx] = objects as u32;
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
       FastValue::NestedParent { object, parent } => {
@@ -400,7 +400,7 @@ impl FastFieldsWriter {
             }
             doc_entries[object] = parent as u32;
           }
-          _ => panic!("fast field type mismatch for {}", field),
+          _ => panic!("fast field type mismatch for {field}"),
         }
       }
     }

--- a/searchlite-core/src/index/manifest.rs
+++ b/searchlite-core/src/index/manifest.rs
@@ -67,9 +67,9 @@ impl Manifest {
   pub fn load(storage: &dyn Storage, path: &Path) -> Result<Self> {
     let data = storage
       .read_to_end(path)
-      .with_context(|| format!("reading manifest at {:?}", path))?;
+      .with_context(|| format!("reading manifest at {path:?}"))?;
     let manifest: Manifest =
-      serde_json::from_slice(&data).with_context(|| format!("parsing manifest at {:?}", path))?;
+      serde_json::from_slice(&data).with_context(|| format!("parsing manifest at {path:?}"))?;
     Ok(manifest)
   }
 
@@ -77,7 +77,7 @@ impl Manifest {
     let data = serde_json::to_vec_pretty(self)?;
     storage
       .atomic_write(path, &data)
-      .with_context(|| format!("writing manifest at {:?}", path))
+      .with_context(|| format!("writing manifest at {path:?}"))
   }
 
   pub fn manifest_path(root: &Path) -> PathBuf {

--- a/searchlite-core/src/index/mod.rs
+++ b/searchlite-core/src/index/mod.rs
@@ -115,7 +115,7 @@ impl Index {
       m.store(storage.as_ref(), &manifest_path)?;
       m
     } else {
-      bail!("index does not exist at {:?}", manifest_path);
+      bail!("index does not exist at {manifest_path:?}");
     };
     let inner = Arc::new(InnerIndex {
       path: opts.path.clone(),

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -935,8 +935,8 @@ impl<'a> SegmentWriter<'a> {
       let (vec_path, hnsw_path) = vector_paths(&paths, field)?;
       let vec_buf = self.storage.read_to_end(&vec_path)?;
       let hnsw_buf = self.storage.read_to_end(&hnsw_path)?;
-      checksums.insert(format!("vector_{}_bin", field), checksum(&vec_buf));
-      checksums.insert(format!("vector_{}_hnsw", field), checksum(&hnsw_buf));
+      checksums.insert(format!("vector_{field}_bin"), checksum(&vec_buf));
+      checksums.insert(format!("vector_{field}_hnsw"), checksum(&hnsw_buf));
     }
 
     let meta = SegmentMeta {
@@ -1089,48 +1089,29 @@ fn read_vector_file(
   let mut cursor = Cursor::new(bytes);
   let magic = cursor.read_u32::<LittleEndian>()?;
   if magic != VECTOR_FILE_MAGIC {
-    bail!("invalid vector file magic for {:?}", path);
+    bail!("invalid vector file magic for {path:?}");
   }
   let version = cursor.read_u32::<LittleEndian>()?;
   if version != VECTOR_FILE_VERSION {
-    bail!("unsupported vector file version {} for {:?}", version, path);
+    bail!("unsupported vector file version {version} for {path:?}");
   }
   let dim = cursor.read_u32::<LittleEndian>()? as usize;
   if dim != expected_dim {
-    bail!(
-      "vector dim mismatch for {:?}: expected {}, found {}",
-      path,
-      expected_dim,
-      dim
-    );
+    bail!("vector dim mismatch for {path:?}: expected {expected_dim}, found {dim}");
   }
   let metric_code_raw = cursor.read_u8()?;
   let Some(metric) = metric_from_code(metric_code_raw) else {
-    bail!(
-      "unknown vector metric code {} in {:?}",
-      metric_code_raw,
-      path
-    );
+    bail!("unknown vector metric code {metric_code_raw} in {path:?}");
   };
   if &metric != expected_metric {
-    bail!(
-      "vector metric mismatch for {:?}: expected {:?}, found {:?}",
-      path,
-      expected_metric,
-      metric
-    );
+    bail!("vector metric mismatch for {path:?}: expected {expected_metric:?}, found {metric:?}");
   }
   // skip reserved bytes
   let _ = cursor.read_u8()?;
   let _ = cursor.read_u16::<LittleEndian>()?;
   let doc_count = cursor.read_u32::<LittleEndian>()? as usize;
   if doc_count != expected_docs {
-    bail!(
-      "vector doc count mismatch for {:?}: expected {}, found {}",
-      path,
-      expected_docs,
-      doc_count
-    );
+    bail!("vector doc count mismatch for {path:?}: expected {expected_docs}, found {doc_count}");
   }
   let vector_count = cursor.read_u32::<LittleEndian>()? as usize;
   let mut offsets = Vec::with_capacity(doc_count);
@@ -1222,15 +1203,15 @@ fn verify_checksums(
         for field in seg_meta.vector_fields.keys() {
           let (vec_path, hnsw_path) = vector_paths(&meta.paths, field)?;
           verify(
-            &format!("vector {} bin", field),
+            &format!("vector {field} bin"),
             &vec_path,
-            meta.checksums.get(&format!("vector_{}_bin", field)),
+            meta.checksums.get(&format!("vector_{field}_bin")),
             None,
           )?;
           verify(
-            &format!("vector {} hnsw", field),
+            &format!("vector {field} hnsw"),
             &hnsw_path,
-            meta.checksums.get(&format!("vector_{}_hnsw", field)),
+            meta.checksums.get(&format!("vector_{field}_hnsw")),
             None,
           )?;
         }

--- a/searchlite-core/src/index/terms.rs
+++ b/searchlite-core/src/index/terms.rs
@@ -26,7 +26,7 @@ pub fn write_terms(storage: &dyn Storage, path: &Path, terms: &[(String, u64)]) 
 pub fn read_terms(storage: &dyn Storage, path: &Path) -> Result<TinyFst> {
   let buf = storage.read_to_end(path)?;
   if buf.len() < 12 {
-    bail!("terms file at {:?} is truncated", path);
+    bail!("terms file at {path:?} is truncated");
   }
   let term_count = u64::from_le_bytes([
     buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7],
@@ -36,7 +36,7 @@ pub fn read_terms(storage: &dyn Storage, path: &Path) -> Result<TinyFst> {
   let expected = u32::from_le_bytes([crc_bytes[0], crc_bytes[1], crc_bytes[2], crc_bytes[3]]);
   let actual = checksum(data);
   if expected != actual {
-    bail!("terms file at {:?} failed checksum validation", path);
+    bail!("terms file at {path:?} failed checksum validation");
   }
   let mut cursor = 0usize;
   let mut pairs = Vec::with_capacity(term_count as usize);
@@ -45,18 +45,12 @@ pub fn read_terms(storage: &dyn Storage, path: &Path) -> Result<TinyFst> {
     cursor += consumed;
     let end = cursor + len as usize;
     if end > data.len() {
-      bail!(
-        "terms file at {:?} ended unexpectedly while reading term",
-        path
-      );
+      bail!("terms file at {path:?} ended unexpectedly while reading term");
     }
     let term = String::from_utf8_lossy(&data[cursor..end]).into_owned();
     cursor = end;
     if cursor + 8 > data.len() {
-      bail!(
-        "terms file at {:?} ended unexpectedly while reading offset",
-        path
-      );
+      bail!("terms file at {path:?} ended unexpectedly while reading offset");
     }
     let offset = u64::from_le_bytes([
       data[cursor],

--- a/searchlite-core/src/index/wal.rs
+++ b/searchlite-core/src/index/wal.rs
@@ -27,7 +27,7 @@ impl Wal {
   pub fn open(storage: Arc<dyn Storage>, path: &Path) -> Result<Self> {
     let file = storage
       .open_append(path)
-      .with_context(|| format!("opening wal at {:?}", path))?;
+      .with_context(|| format!("opening wal at {path:?}"))?;
     Ok(Self {
       _storage: storage,
       _path: path.to_path_buf(),

--- a/searchlite-core/src/storage/mod.rs
+++ b/searchlite-core/src/storage/mod.rs
@@ -192,7 +192,7 @@ impl Storage for InMemoryStorage {
 
   fn open_read(&self, path: &Path) -> Result<DynFile> {
     if !self.exists(path) {
-      return Err(anyhow!("file {:?} missing in memory storage", path));
+      return Err(anyhow!("file {path:?} missing in memory storage"));
     }
     self.open_with_mode(path, false, false)
   }
@@ -209,7 +209,7 @@ impl Storage for InMemoryStorage {
     if let Some(buf) = self.files.read().get(path) {
       return Ok(buf.read().clone());
     }
-    Err(anyhow!("file {:?} missing in memory storage", path))
+    Err(anyhow!("file {path:?} missing in memory storage"))
   }
 
   fn write_all(&self, path: &Path, data: &[u8]) -> Result<()> {

--- a/searchlite-core/tests/concurrent.rs
+++ b/searchlite-core/tests/concurrent.rs
@@ -101,13 +101,11 @@ fn concurrent_reads_during_writes() {
           Ok(res) => {
             assert!(
               !res.hits.is_empty(),
-              "reader {} iter {}: search returned 0 hits",
-              reader_id,
-              iter,
+              "reader {reader_id} iter {iter}: search returned 0 hits",
             );
           }
           Err(e) => {
-            panic!("reader {} iter {} got error: {:?}", reader_id, iter, e);
+            panic!("reader {reader_id} iter {iter} got error: {e:?}");
           }
         }
       }
@@ -172,8 +170,7 @@ fn rapid_commit_cycles() {
     // We should get some hits (at least up to the limit of 10)
     assert!(
       !result.hits.is_empty() || result.total_hits_estimate > 0,
-      "cycle {}: search returned no results",
-      cycle
+      "cycle {cycle}: search returned no results"
     );
   }
 
@@ -255,10 +252,7 @@ fn readers_survive_compaction() {
             );
           }
           Err(e) => {
-            panic!(
-              "reader {} iter {} got error: {:?}",
-              reader_id, iterations, e
-            );
+            panic!("reader {reader_id} iter {iterations} got error: {e:?}");
           }
         }
         iterations += 1;

--- a/searchlite-core/tests/multi_field.rs
+++ b/searchlite-core/tests/multi_field.rs
@@ -164,21 +164,13 @@ fn multi_match_most_fields_counts_across_fields() {
     boost: None,
   };
   let body_ids = ids(&reader.search(&request(body_only)).unwrap());
-  assert!(body_ids.contains("doc-3"), "{:?}", body_ids);
+  assert!(body_ids.contains("doc-3"), "{body_ids:?}");
   let best_res = reader.search(&request(best)).unwrap();
   let most_res = reader.search(&request(most)).unwrap();
   let best_ids = ids(&best_res);
   let most_ids = ids(&most_res);
-  assert!(
-    best_ids.contains("doc-2"),
-    "best_fields ids: {:?}",
-    best_ids
-  );
-  assert!(
-    most_ids.contains("doc-2"),
-    "most_fields ids: {:?}",
-    most_ids
-  );
+  assert!(best_ids.contains("doc-2"), "best_fields ids: {best_ids:?}");
+  assert!(most_ids.contains("doc-2"), "most_fields ids: {most_ids:?}");
   let best_score = score_for(&best_res, "doc-2").unwrap();
   let most_score = score_for(&most_res, "doc-2").unwrap();
   assert!(most_score > best_score);
@@ -274,8 +266,8 @@ fn cross_fields_operator_and_matches_split_terms() {
     boost: None,
   };
   let hits = ids(&reader.search(&request(query)).unwrap());
-  assert!(hits.contains("doc-2"), "hits: {:?}", hits);
-  assert!(!hits.contains("doc-4"), "hits: {:?}", hits);
+  assert!(hits.contains("doc-2"), "hits: {hits:?}");
+  assert!(!hits.contains("doc-4"), "hits: {hits:?}");
 }
 
 #[test]
@@ -301,7 +293,7 @@ fn cross_fields_fuzziness_auto_recovers_typo() {
     boost: None,
   });
   let exact_hits = ids(&reader.search(&exact).unwrap());
-  assert!(exact_hits.is_empty(), "exact hits: {:?}", exact_hits);
+  assert!(exact_hits.is_empty(), "exact hits: {exact_hits:?}");
 
   exact.query = Query::Node(QueryNode::MultiMatch {
     query: "rust serch".into(),
@@ -323,12 +315,8 @@ fn cross_fields_fuzziness_auto_recovers_typo() {
     boost: None,
   });
   let fuzzy_hits = ids(&reader.search(&exact).unwrap());
-  assert!(fuzzy_hits.contains("doc-2"), "fuzzy hits: {:?}", fuzzy_hits);
-  assert!(
-    !fuzzy_hits.contains("doc-4"),
-    "fuzzy hits: {:?}",
-    fuzzy_hits
-  );
+  assert!(fuzzy_hits.contains("doc-2"), "fuzzy hits: {fuzzy_hits:?}");
+  assert!(!fuzzy_hits.contains("doc-4"), "fuzzy hits: {fuzzy_hits:?}");
 }
 
 #[test]

--- a/searchlite-core/tests/smoke.rs
+++ b/searchlite-core/tests/smoke.rs
@@ -466,8 +466,7 @@ fn compact_removes_old_segments() {
   for p in old_paths {
     assert!(
       !p.exists(),
-      "expected old segment file {:?} to be removed after compaction",
-      p
+      "expected old segment file {p:?} to be removed after compaction"
     );
   }
 }
@@ -578,7 +577,7 @@ fn cursor_paginates_ordered_hits() {
       let repeats = 6 - i;
       writer
         .add_document(&doc(
-          &format!("{}", i),
+          &format!("{i}"),
           vec![("body", json!("rust ".repeat(repeats)))],
         ))
         .unwrap();
@@ -591,7 +590,7 @@ fn cursor_paginates_ordered_hits() {
       let repeats = 6 - i;
       writer
         .add_document(&doc(
-          &format!("{}", i),
+          &format!("{i}"),
           vec![("body", json!("rust ".repeat(repeats)))],
         ))
         .unwrap();

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -346,9 +346,9 @@ impl ManagedIndex {
         let (loaded_committed_at, loaded_doc_count) = tokio::task::spawn_blocking(move || {
           let manifest_path = Manifest::manifest_path(&path);
           let bytes = std::fs::read(&manifest_path)
-            .with_context(|| format!("reading manifest metadata at {:?}", manifest_path))?;
+            .with_context(|| format!("reading manifest metadata at {manifest_path:?}"))?;
           let manifest: Manifest = serde_json::from_slice(&bytes)
-            .with_context(|| format!("parsing manifest metadata at {:?}", manifest_path))?;
+            .with_context(|| format!("parsing manifest metadata at {manifest_path:?}"))?;
           let (live_docs, _) = manifest_doc_counts(&manifest);
           Ok::<(String, u64), anyhow::Error>((manifest.committed_at.clone(), live_docs))
         })
@@ -523,7 +523,7 @@ impl IndexRegistry {
       cursor = target;
     }
     self.indexes.get(cursor).cloned().ok_or_else(|| {
-      HttpError::not_found("unknown_index", format!("index `{}` not registered", name))
+      HttpError::not_found("unknown_index", format!("index `{name}` not registered"))
     })
   }
 
@@ -540,19 +540,13 @@ impl IndexRegistry {
         }
         if !visited.insert(cursor.to_string()) {
           anyhow::bail!(
-            "alias cycle detected involving `{}` while validating alias `{}`",
-            cursor,
-            alias_name
+            "alias cycle detected involving `{cursor}` while validating alias `{alias_name}`"
           );
         }
         match aliases.get(cursor) {
           Some(next) => cursor = next,
           None => {
-            anyhow::bail!(
-              "alias `{}` targets unknown index or alias `{}`",
-              alias_name,
-              initial_target
-            );
+            anyhow::bail!("alias `{alias_name}` targets unknown index or alias `{initial_target}`");
           }
         }
       }
@@ -682,9 +676,9 @@ impl MaintenanceRuntime {
     }
     let manifest_path = Manifest::manifest_path(&managed.path);
     let bytes = std::fs::read(&manifest_path)
-      .with_context(|| format!("reading manifest metadata at {:?}", manifest_path))?;
+      .with_context(|| format!("reading manifest metadata at {manifest_path:?}"))?;
     let manifest: Manifest = serde_json::from_slice(&bytes)
-      .with_context(|| format!("parsing manifest metadata at {:?}", manifest_path))?;
+      .with_context(|| format!("parsing manifest metadata at {manifest_path:?}"))?;
     if write_key_required(&manifest) {
       anyhow::bail!(
         "index `{}` requires a write key; disable auto-commit for this index or remove write-key protection",
@@ -1030,8 +1024,7 @@ async fn map_413(max_body: usize, req: Request, next: Next) -> Response {
       "body_too_large",
       StatusCode::PAYLOAD_TOO_LARGE,
       anyhow::anyhow!(format!(
-        "request body exceeded configured limit of {} bytes",
-        max_body
+        "request body exceeded configured limit of {max_body} bytes"
       )),
     )
     .into_response();
@@ -1249,7 +1242,7 @@ async fn add_ndjson(
       let value: serde_json::Value = serde_json::from_str(trimmed).map_err(|e| {
         HttpError::bad_request(
           "invalid_document",
-          format!("invalid JSON document on NDJSON line {}: {e}", line_number),
+          format!("invalid JSON document on NDJSON line {line_number}: {e}"),
         )
       })?;
 
@@ -1470,7 +1463,7 @@ async fn update_document(
   if let Err(err) = validate_doc_id(&body.id) {
     return Err(HttpError::bad_request(
       "invalid_id",
-      format!("invalid document id: {}", err),
+      format!("invalid document id: {err}"),
     ));
   }
   let managed = state.registry().resolve(&index_name)?;
@@ -1701,15 +1694,14 @@ async fn bulk_update(
         let action: BulkUpdateAction = serde_json::from_str(trimmed).map_err(|e| {
           HttpError::bad_request(
             "invalid_bulk_update",
-            format!("invalid update action on NDJSON line {}: {e}", line_number),
+            format!("invalid update action on NDJSON line {line_number}: {e}"),
           )
         })?;
         if let Err(err) = validate_doc_id(&action.update.id) {
           return Err(HttpError::bad_request(
             "invalid_bulk_update",
             format!(
-              "invalid update action on NDJSON line {}: invalid document id: {}",
-              line_number, err
+              "invalid update action on NDJSON line {line_number}: invalid document id: {err}"
             ),
           ));
         }
@@ -1718,7 +1710,7 @@ async fn bulk_update(
         let patch: BulkUpdatePatch = serde_json::from_str(trimmed).map_err(|e| {
           HttpError::bad_request(
             "invalid_bulk_update",
-            format!("invalid update body on NDJSON line {}: {e}", line_number),
+            format!("invalid update body on NDJSON line {line_number}: {e}"),
           )
         })?;
         let id = pending_action
@@ -2322,7 +2314,7 @@ fn validate_ids(ids: &[String]) -> ApiResult<()> {
     if let Err(err) = validate_doc_id(id) {
       return Err(HttpError::bad_request(
         "invalid_id",
-        format!("id at position {} is invalid: {}", idx, err),
+        format!("id at position {idx} is invalid: {err}"),
       ));
     }
   }
@@ -2424,8 +2416,8 @@ mod tests {
     let state = build_app_state(registry).unwrap();
     let (addr, handle) = spawn_server(args.clone(), state.clone()).await.unwrap();
     let client = Client::new();
-    let base = format!("http://{}", addr);
-    let index_base = format!("{}/indexes/{}", base, INDEX_NAME);
+    let base = format!("http://{addr}");
+    let index_base = format!("{base}/indexes/{INDEX_NAME}");
     (client, base, index_base, handle, state, args)
   }
 
@@ -2640,7 +2632,7 @@ mod tests {
     let state = build_app_state(registry).unwrap();
     let (addr, handle) = spawn_server(args.clone(), state).await.unwrap();
     let client = Client::new();
-    let base = format!("http://{}", addr);
+    let base = format!("http://{addr}");
     let index_base = format!("{base}/indexes/{INDEX_NAME}");
 
     client
@@ -3108,7 +3100,7 @@ mod tests {
     let state = build_app_state(registry).unwrap();
     let (addr, handle) = spawn_server(args.clone(), state.clone()).await.unwrap();
     let client = Client::new();
-    let base = format!("http://{}", addr);
+    let base = format!("http://{addr}");
     let index_base = format!("{base}/indexes/{INDEX_NAME}");
 
     let schema: Schema = serde_json::from_value(json!({
@@ -3918,7 +3910,7 @@ mod tests {
     let state = build_app_state(registry).unwrap();
     let (addr, handle) = spawn_server(args.clone(), state.clone()).await.unwrap();
     let client = Client::new();
-    let base = format!("http://{}", addr);
+    let base = format!("http://{addr}");
     let index_base = format!("{base}/indexes/{INDEX_NAME}");
 
     client
@@ -4265,7 +4257,7 @@ mod tests {
     // Create 2500 documents (2 full batches + 1 partial)
     let mut ndjson = String::new();
     for i in 0..2500 {
-      ndjson.push_str(&format!("{{\"_id\":\"{}\",\"body\":\"doc {}\"}}\n", i, i));
+      ndjson.push_str(&format!("{{\"_id\":\"{i}\",\"body\":\"doc {i}\"}}\n"));
     }
 
     let res = client
@@ -4468,7 +4460,7 @@ mod tests {
     let state = build_app_state(registry).unwrap();
     let (addr, handle) = spawn_server(args.clone(), state.clone()).await.unwrap();
     let client = Client::new();
-    let base = format!("http://{}", addr);
+    let base = format!("http://{addr}");
     let index_base = format!("{base}/indexes/alias");
 
     client


### PR DESCRIPTION
## Summary
- Inlines format arguments across 19 files to satisfy the `uninlined_format_args` clippy lint on Rust 1.88.0
- Rust 1.88.0's clippy enforces this lint more strictly than newer toolchains (1.92.0, stable, nightly), causing CI `lint-test` failures with `-D warnings`
- All 326 tests pass, clippy is clean on both 1.88.0 and 1.92.0, and `cargo fmt` passes

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` passes on Rust 1.88.0
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` passes on Rust 1.92.0
- [x] `cargo test --all --all-features` — all 326 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)