### PR TITLE
docs: add Node.js/TypeScript to quickstart and enhance searchlite-js README

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ npm install searchlite-js
 ```
 
 ```javascript
-const { EmbeddedIndex } = require('searchlite-js');
+import { EmbeddedIndex } from 'searchlite-js';
 
 const index = new EmbeddedIndex('./my-index', {
   schema: { title: 'text', body: 'text', tag: 'keyword' },
@@ -148,7 +148,7 @@ console.log(results.hits[0].docId); // "1"
 await index.close();
 ```
 
-See the [quickstart](docs/quickstart.md#node-js--typescript) for a full TypeScript example with Zod-validated typed search.
+See the [quickstart](docs/quickstart.md#nodejs--typescript) for a full TypeScript example with Zod-validated typed search.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,33 @@ for hit in &results.hits {
 }
 ```
 
+### As an npm package
+
+```bash
+npm install searchlite-js
+```
+
+```javascript
+const { EmbeddedIndex } = require('searchlite-js');
+
+const index = new EmbeddedIndex('./my-index', {
+  schema: { title: 'text', body: 'text', tag: 'keyword' },
+});
+
+await index.addMany([
+  { _id: '1', title: 'Getting Started', body: 'Hello, world!', tag: 'intro' },
+  { _id: '2', title: 'Advanced Search', body: 'Filters, facets, and more', tag: 'guide' },
+]);
+await index.commit();
+
+const results = await index.search('hello');
+console.log(results.hits[0].docId); // "1"
+
+await index.close();
+```
+
+See the [quickstart](docs/quickstart.md#node-js--typescript) for a full TypeScript example with Zod-validated typed search.
+
 ---
 
 ## Features
@@ -162,6 +189,7 @@ Benchmarked on Apple M3 Max (36 GB), Rust 1.92.0, in-memory storage. All times a
 | **CLI** | [`searchlite-cli`](searchlite-cli/) | Stable &mdash; init, add, commit, search, compact |
 | **HTTP** | [`searchlite-http`](searchlite-http/) | Stable &mdash; REST API over one or more indexes |
 | **C FFI** | [`searchlite-ffi`](searchlite-ffi/) | Stable &mdash; shared library + C header |
+| **Node.js** | [`searchlite-js`](searchlite-node/) | Stable &mdash; native bindings + HTTP client, TypeScript + Zod |
 | **WASM** | [`searchlite-wasm`](searchlite-wasm/) | Experimental &mdash; IndexedDB-backed, browser search |
 
 ---
@@ -227,6 +255,7 @@ Benchmarked on Apple M3 Max (36 GB), Rust 1.92.0, in-memory storage. All times a
 | Feature flags | [docs/feature-flags.md](docs/feature-flags.md) |
 | Benchmarks | [BENCHMARKS.md](BENCHMARKS.md) |
 | Architecture deep-dive | [docs/intro.md](docs/intro.md) |
+| Node.js bindings | [searchlite-node/README.md](searchlite-node/README.md) |
 | Binding behaviors | [docs/bindings.md](docs/bindings.md) |
 
 ---

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -161,10 +161,81 @@ Keep the server bound to localhost unless you front it with a proxy or firewall.
   searchlite compact "$INDEX"
   ```
 
+## Node.js / TypeScript
+
+You can also use Searchlite directly from Node.js with native Rust performance and full TypeScript type safety. The `searchlite-js` package includes Zod-powered typed search — pass a schema to `search()` and get validated, fully-typed results back.
+
+### Prerequisites
+
+- Node.js 18+ with npm.
+
+### 1) Set up a project
+
+```bash
+mkdir searchlite-demo && cd searchlite-demo
+npm init -y
+npm install searchlite-js zod tsx typescript
+```
+
+### 2) Create `search.ts`
+
+```typescript
+import { EmbeddedIndex } from "searchlite-js";
+import { z } from "zod";
+
+// 1. Create an index with a shorthand schema
+const index = new EmbeddedIndex("./my-index", {
+  schema: {
+    title: "text",
+    body: "text",
+    lang: "keyword",
+    year: "integer",
+  },
+});
+
+// 2. Add documents and commit
+await index.addMany([
+  { _id: "1", title: "Rust Search Engine", body: "Searchlite is a fast embedded search engine.", lang: "en", year: 2024 },
+  { _id: "2", title: "SQLite Vibes", body: "Single-node search with WAL durability.", lang: "en", year: 2023 },
+  { _id: "3", title: "Edge Ready", body: "Run full-text search at the edge.", lang: "en", year: 2022 },
+]);
+await index.commit();
+
+// 3. Define a Zod schema for the fields you expect back
+const ArticleFields = z.object({
+  title: z.string(),
+  body: z.string(),
+  lang: z.string(),
+  year: z.number(),
+});
+
+// 4. Typed search — results are validated and fully typed
+const results = await index.search(ArticleFields, {
+  query: "search",
+  filter: { I64Range: { field: "year", min: 2023, max: 2025 } },
+});
+
+for (const hit of results.hits) {
+  // hit.fields is typed as { title: string; body: string; lang: string; year: number }
+  console.log(`${hit.fields.title} (${hit.fields.year}) — score: ${hit.score.toFixed(2)}`);
+}
+
+await index.close();
+```
+
+### 3) Run it
+
+```bash
+npx tsx search.ts
+```
+
+You should see matching articles with scores, filtered to 2023+.
+
 ## Next Steps
 
 - Read [Searchlite in a Nutshell](intro.md) for a high-level overview of features, limits, and operational basics.
 - See the [Schema guide](schema.md) for field types, analyzers, and nested object configuration.
 - Explore [Queries](queries.md), [Filters](filters.md), and [Aggregations](aggregations.md) for the full search DSL.
 - See [HTTP Service](http.md) for the complete REST API reference.
+- See the [Node.js bindings](../searchlite-node/README.md) for the full API reference, typed search with Zod, and TypeScript examples.
 - See [Binding Lifecycle](bindings.md) for FFI and WASM-specific details.

--- a/searchlite-node/README.md
+++ b/searchlite-node/README.md
@@ -903,7 +903,7 @@ const StrictFields = z.object({
 try {
   await index.search(StrictFields, 'headphones');
 } catch (e) {
-  // Error: "typed result validation failed at hit 0 (doc_id=product-1): Required at "price""
+  // Error: 'Invalid fields on hit 0 (docId: "product-1"):\n Required at "price"'
 }
 ```
 

--- a/searchlite-node/README.md
+++ b/searchlite-node/README.md
@@ -797,29 +797,200 @@ console.log('Cuisines:', filtered.aggregations.byCuisine);
 index.close();
 ```
 
+## Typed Search with Zod
+
+Pass a [Zod](https://zod.dev) schema as the first argument to `search()` and every hit's `fields` property is validated and fully typed at compile time. No more `as any` casts or manual null checks on search results.
+
+When you pass a schema, `returnStored` is set automatically — you don't need to specify it.
+
+### Basic typed search
+
+```typescript
+import { EmbeddedIndex } from 'searchlite-js';
+import { z } from 'zod';
+
+const index = new EmbeddedIndex('./products', {
+  schema: { name: 'text', brand: 'keyword', price: 'float' },
+});
+
+// ... add documents and commit ...
+
+// Define the shape you expect back
+const ProductFields = z.object({
+  name: z.string(),
+  brand: z.string(),
+  price: z.number(),
+});
+
+// Pass the schema as the first argument — results are typed
+const results = await index.search(ProductFields, 'wireless headphones');
+
+for (const hit of results.hits) {
+  // hit.fields is { name: string; brand: string; price: number } — fully typed
+  console.log(`${hit.fields.name} by ${hit.fields.brand} — $${hit.fields.price}`);
+}
+```
+
+### Typed search with filters and aggregations
+
+The schema works with structured queries too:
+
+```typescript
+const BrandPrice = z.object({
+  brand: z.string(),
+  price: z.number(),
+});
+
+const results = await index.search(BrandPrice, {
+  query: 'headphones',
+  filter: { F64Range: { field: 'price', min: 20, max: 100 } },
+  sort: [{ price: 'asc' }],
+  aggs: {
+    brands: { type: 'terms', field: 'brand', size: 5 },
+  },
+});
+
+// Fields are typed, aggregations are available alongside
+for (const hit of results.hits) {
+  console.log(`${hit.fields.brand}: $${hit.fields.price.toFixed(2)}`);
+}
+console.log('Top brands:', results.aggregations?.brands);
+```
+
+### Transforms and defaults
+
+Zod transforms and defaults run during validation, so you can reshape data as it comes out of the index:
+
+```typescript
+const Product = z.object({
+  name: z.string().transform((s) => s.toUpperCase()),
+  price: z.number(),
+  currency: z.string().default('USD'),
+});
+
+const results = await index.search(Product, 'headphones');
+
+// Transforms are applied — name is uppercased, currency defaults to "USD"
+console.log(results.hits[0].fields.name);     // "WIRELESS HEADPHONES"
+console.log(results.hits[0].fields.currency);  // "USD"
+```
+
+### Optional and partial fields
+
+Use `.optional()` for fields that may not be stored on every document:
+
+```typescript
+const FlexProduct = z.object({
+  name: z.string(),
+  brand: z.string().optional(),
+  price: z.number().optional(),
+});
+
+const results = await index.search(FlexProduct, 'headphones');
+// hit.fields.brand is string | undefined — TypeScript knows
+```
+
+### Validation errors
+
+If a document's stored fields don't match your schema, `search()` throws with a clear error that includes the document ID and field path:
+
+```typescript
+const StrictFields = z.object({
+  name: z.string(),
+  price: z.number(), // will fail if price is missing or wrong type
+});
+
+try {
+  await index.search(StrictFields, 'headphones');
+} catch (e) {
+  // Error: "typed result validation failed at hit 0 (doc_id=product-1): Required at "price""
+}
+```
+
+### End-to-end example: typed product search
+
+```typescript
+import { EmbeddedIndex } from 'searchlite-js';
+import { z } from 'zod';
+
+// Schema for the index
+const index = new EmbeddedIndex('./shop', {
+  schema: {
+    name: 'text',
+    description: 'text',
+    category: 'keyword',
+    price: 'float',
+    inStock: 'integer',
+  },
+});
+
+// Index a product catalog
+await index.addMany([
+  { _id: 'sku-1', name: 'Wireless Earbuds', description: 'Bluetooth 5.3 with ANC', category: 'audio', price: 59.99, inStock: 142 },
+  { _id: 'sku-2', name: 'Studio Headphones', description: 'Over-ear open-back for mixing', category: 'audio', price: 199.99, inStock: 38 },
+  { _id: 'sku-3', name: 'USB Microphone', description: 'Condenser mic for podcasting', category: 'microphones', price: 89.99, inStock: 67 },
+  { _id: 'sku-4', name: 'Webcam 4K', description: 'Ultra HD with autofocus', category: 'video', price: 129.99, inStock: 0 },
+]);
+await index.commit();
+
+// Zod schema for validated results
+const CatalogItem = z.object({
+  name: z.string(),
+  category: z.string(),
+  price: z.number(),
+  inStock: z.number().transform((n) => n > 0),  // transform count to boolean
+});
+
+type CatalogItem = z.infer<typeof CatalogItem>;
+// { name: string; category: string; price: number; inStock: boolean }
+
+// Typed search with filter and facets
+const results = await index.search(CatalogItem, {
+  query: { type: 'multi_match', query: 'audio', fields: [{ field: 'name' }, { field: 'description', boost: 0.5 }] },
+  filter: { F64Range: { field: 'price', min: 0, max: 150 } },
+  aggs: {
+    categories: { type: 'terms', field: 'category' },
+    priceStats: { type: 'stats', field: 'price' },
+  },
+  highlightField: 'description',
+});
+
+for (const hit of results.hits) {
+  const { name, category, price, inStock } = hit.fields;
+  const badge = inStock ? 'In Stock' : 'Out of Stock';
+  console.log(`[${badge}] ${name} (${category}) — $${price}`);
+  if (hit.snippet) console.log(`  ${hit.snippet}`);
+}
+
+await index.close();
+```
+
 ## TypeScript
 
 Full type definitions are included. Import and use with full IntelliSense:
 
 ```typescript
-import { EmbeddedIndex, RemoteIndex, SearchResult, SchemaDefinition } from 'searchlite-js';
-import type { SearchIndex } from 'searchlite-js';
+import { EmbeddedIndex, RemoteIndex, SchemaDefinition } from 'searchlite-js';
+import type { SearchIndex, SearchResult, TypedSearchResult } from 'searchlite-js';
+import { z } from 'zod';
 
 // Both index types implement the same SearchIndex interface
-async function search(index: SearchIndex): Promise<SearchResult> {
-  return index.search({ query: 'hello', returnStored: true });
-}
-
-// EmbeddedIndex — local native engine
 const schema: SchemaDefinition = { title: 'text', tag: 'keyword' };
 const embedded = new EmbeddedIndex('./my-index', { schema });
 await embedded.add({ _id: '1', title: 'Hello', tag: 'greeting' });
 await embedded.commit();
-const local: SearchResult = await search(embedded);
 
-// RemoteIndex — HTTP client
+// Untyped search — returns SearchResult with optional fields
+const basic: SearchResult = await embedded.search({ query: 'hello', returnStored: true });
+
+// Typed search — returns TypedSearchResult<T> with validated fields
+const Fields = z.object({ title: z.string(), tag: z.string() });
+const typed: TypedSearchResult<z.infer<typeof Fields>> = await embedded.search(Fields, 'hello');
+// typed.hits[0].fields.title — string, guaranteed
+
+// RemoteIndex works the same way
 const remote = new RemoteIndex('http://localhost:8080', 'my-index');
-const results: SearchResult = await search(remote);
+const remoteTyped = await remote.search(Fields, 'hello');
 ```
 
 ## License


### PR DESCRIPTION
## Summary

- Adds Node.js to the root README: "Try it" section (npm package path), Multi-platform table, and Documentation index
- Adds a self-contained Node.js/TypeScript quickstart section to `docs/quickstart.md` with a runnable `search.ts` example using `EmbeddedIndex`, Zod typed search, and filters
- Adds comprehensive "Typed Search with Zod" documentation to `searchlite-node/README.md` covering basic usage, structured queries, transforms/defaults, optional fields, validation errors, and an end-to-end product catalog example
- Updates the TypeScript section to show both untyped and typed search patterns with proper type imports

## Test plan

- [ ] Verify all relative links resolve correctly in GitHub's markdown renderer
- [ ] Confirm the quickstart `search.ts` example runs with `npx tsx search.ts` against a real `searchlite-js` install
- [ ] Review that all API signatures match the actual exported types (`search<T>(schema, query)`, `TypedSearchResult`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)