### PR TITLE
fix: WASM getrandom error and Docker missing workspace members

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,8 +841,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2112,6 +2114,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "criterion",
+ "getrandom 0.2.16",
  "hashbrown 0.14.5",
  "hmac",
  "log",

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,14 +16,18 @@ COPY searchlite-cli/Cargo.toml searchlite-cli/Cargo.toml
 COPY searchlite-http/Cargo.toml searchlite-http/Cargo.toml
 COPY searchlite-ffi/Cargo.toml searchlite-ffi/Cargo.toml
 COPY searchlite-wasm/Cargo.toml searchlite-wasm/Cargo.toml
+COPY searchlite-node/Cargo.toml searchlite-node/Cargo.toml
+COPY integration/Cargo.toml integration/Cargo.toml
 
 # Create dummy source files so cargo can resolve the workspace without pulling full sources yet.
-RUN mkdir -p searchlite-core/src searchlite-cli/src searchlite-http/src searchlite-ffi/src searchlite-wasm/src \
+RUN mkdir -p searchlite-core/src searchlite-cli/src searchlite-http/src searchlite-ffi/src searchlite-wasm/src searchlite-node/src integration/src \
  && echo "fn main() {}" > searchlite-cli/src/main.rs \
  && echo "pub fn placeholder() {}" > searchlite-core/src/lib.rs \
  && echo "pub fn placeholder() {}" > searchlite-http/src/lib.rs \
  && echo "pub fn placeholder() {}" > searchlite-ffi/src/lib.rs \
- && echo "pub fn placeholder() {}" > searchlite-wasm/src/lib.rs
+ && echo "pub fn placeholder() {}" > searchlite-wasm/src/lib.rs \
+ && echo "pub fn placeholder() {}" > searchlite-node/src/lib.rs \
+ && echo "pub fn placeholder() {}" > integration/src/lib.rs
 
 RUN cargo fetch --locked
 

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -51,6 +51,7 @@ memmap2 = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"] }
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 rand = { workspace = true }


### PR DESCRIPTION
## Summary

- Add `getrandom = { version = "0.2", features = ["js"] }` to wasm32 target deps in `searchlite-core/Cargo.toml`, fixing the WASM build failure (`rand` → `rand_core` → `getrandom` 0.2.16 needs `"js"` for `wasm32-unknown-unknown`)
- Add `integration` and `searchlite-node` COPY + dummy source lines to `Dockerfile`, fixing Docker builds that fail on `cargo fetch` because these workspace members are missing

## Test plan

- [ ] CI passes (Rust lint/build/test + Node.js)
- [ ] Re-run failed Release Artifacts workflows after merge to verify fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)