### PR TITLE
feat: replace custom index schema with JSON Schema + searchlite: vocabulary

### DIFF
--- a/docs/filters.md
+++ b/docs/filters.md
@@ -10,7 +10,8 @@ the inverted index.
 - A job board filters by location, salary range, and employment type
 - A content platform restricts results to a specific language or publication date
 
-Filters require the field to have `"fast": true` in the [schema](schema.md).
+Filters require the field to have `searchlite:fast` enabled in the [schema](schema.md).
+Keyword and numeric fields have `searchlite:fast` set to `true` by default.
 
 ---
 
@@ -202,7 +203,7 @@ You can freely combine top-level field filters with nested filters.
 
 ## Tips
 
-- Mark every field you want to filter or sort on with `"fast": true` in the schema.
+- Ensure every field you want to filter or sort on has `searchlite:fast` enabled (keyword and numeric fields have it on by default).
 - For nested filters, wrap each condition in its own `Nested` block to enforce per-object binding.
 - Stored nested fields preserve their original structure in results; unstored fields are omitted.
 - Filters are applied after scoring, so they don't affect relevance rankings -- they only include/exclude documents.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -112,13 +112,16 @@ Schema excerpt:
 
 ```json
 {
-  "nested_fields": [{
-    "name": "review",
-    "fields": [
-      { "type": "keyword", "name": "author", "fast": true, "stored": true, "indexed": true },
-      { "type": "numeric", "name": "rating", "i64": true, "fast": true }
-    ]
-  }]
+  "review": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "author": { "type": "string", "searchlite:kind": "keyword" },
+        "rating": { "type": "integer" }
+      }
+    }
+  }
 }
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -28,22 +28,16 @@ Create a schema file that defines your fields and analyzers. Save the JSON below
 
 ```json
 {
-  "doc_id_field": "_id",
-  "analyzers": [
+  "type": "object",
+  "searchlite:analyzers": [
     { "name": "english", "tokenizer": "default", "filters": [{ "stopwords": "en" }, { "stemmer": "english" }] }
   ],
-  "text_fields": [
-    { "name": "title", "analyzer": "english", "stored": true, "indexed": true },
-    { "name": "body", "analyzer": "english", "stored": true, "indexed": true }
-  ],
-  "keyword_fields": [
-    { "name": "lang", "stored": true, "indexed": true, "fast": true }
-  ],
-  "numeric_fields": [
-    { "name": "year", "i64": true, "fast": true, "stored": true }
-  ],
-  "nested_fields": [],
-  "vector_fields": []
+  "properties": {
+    "title": { "type": "string", "searchlite:analyzer": "english" },
+    "body": { "type": "string", "searchlite:analyzer": "english" },
+    "lang": { "type": "string", "searchlite:kind": "keyword" },
+    "year": { "type": "integer", "searchlite:stored": true }
+  }
 }
 ```
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -41,7 +41,7 @@ Create a schema file that defines your fields and analyzers. Save the JSON below
 }
 ```
 
-`stored: true` lets you return fields in results, and `fast: true` enables efficient filters/aggregations (used below for `lang` and `year`).
+`searchlite:stored` lets you return fields in results, and `searchlite:fast` enables efficient filters and aggregations. Keyword and numeric fields have `searchlite:fast` on by default, so `lang` and `year` are filterable without any extra configuration.
 
 Initialize the index with that schema:
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -107,8 +107,8 @@ let doc = Document {
 writer.add_document(&doc)?;
 ```
 
-Every document must include the `_id` field (or whatever `doc_id_field` your schema
-specifies). Adding a document with an existing ID is an upsert -- the old version is
+Every document must include the `_id` field (or whatever `searchlite:docIdField` your
+schema specifies). Adding a document with an existing ID is an upsert -- the old version is
 replaced on commit.
 
 ### Batch adds (atomic)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -4,60 +4,97 @@ A schema defines the shape of your index: which fields exist, how text is analyz
 and which fields support filtering and aggregations. You write it once when you create
 an index, and every document you add is validated against it.
 
-Think of it like a database table definition, but tuned for search. A blog might define
-a `title` (text, searchable), `body` (text, searchable, highlighted), `author` (keyword,
-filterable), and `published_at` (numeric, sortable). An e-commerce catalog might add
-`price` (numeric, fast for range filters) and `category` (keyword, fast for faceted
-navigation).
+Schemas are standard **JSON Schema 2020-12** documents annotated with `searchlite:`
+vocabulary keywords. Think of it as a document shape definition with search
+annotations layered on top. The same file both validates your documents and
+configures how Searchlite indexes them.
+
+A blog might define a `title` (text, searchable), `body` (text, searchable,
+highlighted), `author` (keyword, filterable), and `published_at` (numeric, sortable).
+An e-commerce catalog might add `price` (numeric, fast for range filters) and
+`category` (keyword, fast for faceted navigation).
 
 ## Example schema
 
+Here is an abbreviated version of the recipes example schema:
+
 ```json
 {
-  "doc_id_field": "_id",
-  "analyzers": [
-    {
-      "name": "english",
-      "tokenizer": "default",
-      "filters": [{ "stopwords": "en" }, { "stemmer": "english" }]
-    },
-    {
-      "name": "title_prefix",
-      "tokenizer": "default",
-      "filters": [{ "edge_ngram": { "min": 1, "max": 5 } }]
-    }
-  ],
-  "text_fields": [
-    { "name": "body", "analyzer": "english", "stored": true, "indexed": true },
-    {
-      "name": "title",
-      "analyzer": "title_prefix",
-      "search_analyzer": "english",
-      "stored": true,
-      "indexed": true
-    }
-  ],
-  "keyword_fields": [
-    { "name": "lang", "stored": true, "indexed": true, "fast": true }
-  ],
-  "numeric_fields": [{ "name": "year", "i64": true, "fast": true }],
-  "nested_fields": [
-    {
-      "name": "comment",
-      "fields": [
-        {
-          "type": "keyword",
-          "name": "author",
-          "stored": true,
-          "indexed": true,
-          "fast": true
+  "$schema": "https://searchlite.dev/draft/2025/schema",
+  "type": "object",
+  "searchlite:docIdField": "doc_id",
+  "properties": {
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "cuisine": { "type": "string", "searchlite:kind": "keyword" },
+    "difficulty": { "type": "string", "searchlite:kind": "keyword" },
+    "prep_time_minutes": { "type": "integer", "searchlite:stored": true },
+    "servings": { "type": "integer", "searchlite:stored": true },
+    "ingredients": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "item": { "type": "string", "searchlite:kind": "keyword" },
+          "quantity": { "type": "number", "searchlite:stored": true },
+          "unit": { "type": "string", "searchlite:kind": "keyword" }
         }
-      ]
+      }
     }
-  ],
-  "vector_fields": []
+  }
 }
 ```
+
+This single file does double duty. As JSON Schema, it validates that every document
+has a `title` string, an `ingredients` array of objects, and so on. The `searchlite:`
+keywords tell the engine that `cuisine` is a keyword (exact-match, filterable),
+`prep_time_minutes` should be stored for retrieval, and `ingredients` is a nested
+field with its own sub-fields.
+
+## Type inference
+
+Searchlite infers the field type from the JSON Schema `type` value:
+
+| JSON Schema `type` | Searchlite field type | Notes |
+|---|---|---|
+| `"string"` | text | Full-text analyzed. Override with `searchlite:kind: "keyword"` for exact match. |
+| `"string"` + `searchlite:kind: "keyword"` | keyword | Unanalyzed, exact-match values. |
+| `"integer"` | numeric (i64) | Signed 64-bit integer. |
+| `"number"` | numeric (f64) | 64-bit floating point. |
+| `"object"` with `properties` | nested | Single nested object with typed sub-fields. |
+| `"array"` with `items.type: "object"` | nested | Array of nested objects (most common form). |
+| `"array"` with `items.type: "number"` + `searchlite:vector` | vector | Dense embedding vector. |
+| `["string", "null"]` | nullable text | Any base type can be made nullable this way. |
+
+## `searchlite:` keyword reference
+
+All configuration beyond standard JSON Schema uses `searchlite:` prefixed keywords.
+Any unknown `searchlite:` keyword on a property is rejected at parse time.
+
+### Root-level keywords
+
+These appear on the root schema object, alongside `type` and `properties`:
+
+| Keyword | Type | Default | Description |
+|---|---|---|---|
+| `searchlite:docIdField` | string | `"_id"` | Name of the string primary key field expected on every document. |
+| `searchlite:analyzers` | array | `[]` | Custom analyzer definitions (see [Analyzers](#analyzers)). |
+
+### Property-level keywords
+
+These appear on individual property definitions inside `properties`:
+
+| Keyword | Type | Default | Applies to | Description |
+|---|---|---|---|---|
+| `searchlite:kind` | `"keyword"` | -- | string fields | Marks a string as a keyword (exact-match) instead of text (analyzed). |
+| `searchlite:stored` | boolean | text: `true`, keyword: `true`, numeric: `false` | text, keyword, numeric | Save the raw value in the doc store for retrieval. |
+| `searchlite:indexed` | boolean | text: `true`, keyword: `true` | text, keyword | Add the field to the inverted index so it can be searched. |
+| `searchlite:fast` | boolean | keyword: `true`, numeric: `true` | keyword, numeric | Build a columnar store for fast filtering, sorting, and aggregations. |
+| `searchlite:analyzer` | string | `"default"` | text | Analyzer applied at index time (see [Analyzers](#analyzers)). |
+| `searchlite:searchAnalyzer` | string | same as analyzer | text | Separate analyzer applied at query time. |
+| `searchlite:searchAsYouType` | `{minGram, maxGram}` | -- | text | Enable automatic edge n-gram indexing (see [Search-as-you-type](#search-as-you-type)). |
+| `searchlite:nullable` | boolean | `false` | all | Allow the field to be absent from documents. |
+| `searchlite:vector` | `{dim, metric, hnsw?}` | -- | array-of-number | Configure dense vector storage (see [Vector fields](#vector-fields)). |
 
 ## Field types
 
@@ -68,19 +105,26 @@ When a user searches for "programming languages", a text field will match docume
 containing "language", "programming", or related stems.
 
 ```json
-{ "name": "body", "analyzer": "english", "stored": true, "indexed": true }
+{
+  "body": { "type": "string" },
+  "title": { "type": "string", "searchlite:analyzer": "english" }
+}
 ```
 
-- **`stored: true`** -- the original text is saved and can be returned in search results
-  (useful for displaying snippets, titles, or descriptions in your UI).
-- **`indexed: true`** -- the field is tokenized and added to the inverted index so it
-  can be searched.
-- **`analyzer`** -- controls how text is broken into tokens (see Analyzers below).
-- **`search_analyzer`** -- optional separate analyzer used at query time. Useful when
-  the index analyzer produces edge n-grams for autocomplete but you want the search
-  analyzer to match full words.
-- **`nullable: true`** -- allows the field to be omitted from documents. See
-  [Nullable fields](#nullable-fields) below.
+A bare `{"type": "string"}` creates a text field with all defaults: stored, indexed,
+using the `default` analyzer. Add `searchlite:` keywords only when you need to
+override a default:
+
+- **`searchlite:stored`** (default: `true`) -- the original text is saved and can be
+  returned in search results (useful for displaying snippets, titles, or descriptions
+  in your UI).
+- **`searchlite:indexed`** (default: `true`) -- the field is tokenized and added to
+  the inverted index so it can be searched.
+- **`searchlite:analyzer`** (default: `"default"`) -- controls how text is broken into
+  tokens (see [Analyzers](#analyzers) below).
+- **`searchlite:searchAnalyzer`** -- optional separate analyzer used at query time.
+  Useful when the index analyzer produces edge n-grams for autocomplete but you want
+  the search analyzer to match full words.
 
 ### Keyword fields
 
@@ -88,31 +132,43 @@ Keyword fields store exact, unanalyzed values. Use them for categorical data tha
 filter or aggregate on: language codes, product categories, tags, status labels, user IDs.
 
 ```json
-{ "name": "category", "stored": true, "indexed": true, "fast": true }
+{
+  "category": { "type": "string", "searchlite:kind": "keyword" },
+  "source": { "type": "string", "searchlite:kind": "keyword", "searchlite:fast": false }
+}
 ```
 
-- **`fast: true`** -- builds a columnar store (like a database column index) for the
-  field. Required for filters, sorting, and aggregations. This is what makes
+The `searchlite:kind: "keyword"` annotation is what distinguishes a keyword field from
+a text field. Default keyword settings are stored, indexed, and fast -- all `true`.
+Override only what you need:
+
+- **`searchlite:fast`** (default: `true`) -- builds a columnar store for the field.
+  Required for filters, sorting, and aggregations. This is what makes
   `KeywordEq { field: "category", value: "electronics" }` fast even over millions
   of documents.
-- **`nullable: true`** -- allows the field to be omitted from documents. See
-  [Nullable fields](#nullable-fields) below.
+- **`searchlite:stored`** (default: `true`) -- save the raw value for retrieval.
+- **`searchlite:indexed`** (default: `true`) -- add to the inverted index for term
+  matching.
 
 ### Numeric fields
 
-Numeric fields store integer (`i64`) or floating-point (`f64`) values. Use them for
-prices, ratings, timestamps, counters, or any value you want to filter by range or
-aggregate with stats.
+Numeric fields store integer or floating-point values. Use them for prices, ratings,
+timestamps, counters, or any value you want to filter by range or aggregate with stats.
 
 ```json
-{ "name": "price", "i64": true, "fast": true, "stored": true }
-{ "name": "rating", "i64": false, "fast": true, "stored": true }
+{
+  "year": { "type": "integer" },
+  "price": { "type": "number", "searchlite:stored": true },
+  "rating": { "type": "number", "searchlite:stored": true }
+}
 ```
 
-Setting `i64: false` stores the value as `f64` (floating point). The `fast` flag
+Use `"type": "integer"` for i64 (signed 64-bit integer) or `"type": "number"` for f64
+(floating point). Numeric fields are fast by default (`searchlite:fast: true`), which
 is required for range filters (`I64Range`, `F64Range`), sorting, and numeric
-aggregations like `stats`, `histogram`, and `percentiles`. As with other field types,
-set `nullable: true` if the field may be absent from some documents.
+aggregations like `stats`, `histogram`, and `percentiles`. Unlike text and keyword
+fields, numeric fields are **not** stored by default -- add `searchlite:stored: true`
+if you need to retrieve the value in search results.
 
 ### Nested fields
 
@@ -121,34 +177,69 @@ together. For example, a product with multiple reviews where you need to filter 
 "reviews where user=alice AND rating >= 4" (not "any review by alice" AND "any
 review with rating >= 4").
 
-Each nested field contains an array of property definitions. Properties can be keyword,
-numeric, text, or object (for deeper nesting):
+The most common form uses an array of objects:
 
 ```json
 {
-  "name": "review",
-  "fields": [
-    { "type": "keyword", "name": "author", "fast": true, "stored": true, "indexed": true },
-    { "type": "numeric", "name": "rating", "i64": true, "fast": true, "stored": true },
-    { "type": "text", "name": "comment", "analyzer": "default", "stored": true, "indexed": true },
-    {
-      "type": "object", "name": "reply",
-      "fields": [
-        { "type": "keyword", "name": "tag", "fast": true, "stored": true, "indexed": true }
-      ]
+  "ingredients": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "item": { "type": "string", "searchlite:kind": "keyword" },
+        "quantity": { "type": "number", "searchlite:stored": true },
+        "unit": { "type": "string", "searchlite:kind": "keyword" }
+      }
     }
-  ]
+  }
 }
 ```
 
-Nested objects are flattened into dotted field names internally (e.g., `review.author`,
-`review.reply.tag`). The `object` type creates another level of nesting for
-hierarchical data like threaded comments.
+You can also use a plain object for a single nested level:
 
-Set `"nullable": true` on the nested field itself to allow documents without the
-nested array.
+```json
+{
+  "metadata": {
+    "type": "object",
+    "properties": {
+      "author": { "type": "string", "searchlite:kind": "keyword" },
+      "version": { "type": "integer" }
+    }
+  }
+}
+```
+
+Nested objects are flattened into dotted field names internally (e.g.,
+`ingredients.item`, `metadata.author`). Properties inside nested objects follow the
+same type inference and `searchlite:` keyword rules as top-level properties -- you
+can nest text, keyword, numeric, and even deeper object fields.
 
 See [filters.md](filters.md) for nested filter examples.
+
+### Vector fields
+
+Vector fields store numeric embeddings for approximate nearest neighbor (ANN) search.
+They require the `vectors` feature flag. See [vectors.md](vectors.md) for search
+usage.
+
+```json
+{
+  "embedding": {
+    "type": "array",
+    "items": { "type": "number" },
+    "searchlite:vector": { "dim": 384, "metric": "Cosine" }
+  }
+}
+```
+
+The `searchlite:vector` object is what distinguishes a vector field from a nested
+array. It requires:
+
+- **`dim`** -- embedding dimension (must match your model output).
+- **`metric`** -- `"Cosine"` (similarity, best for normalized embeddings) or `"L2"`
+  (Euclidean distance, best for unnormalized embeddings).
+- **`hnsw`** -- optional HNSW tuning parameters (see [HNSW tuning](#hnsw-tuning)
+  below).
 
 ## Analyzers
 
@@ -156,8 +247,38 @@ Analyzers control how text is processed before being indexed and searched. Choos
 the right analyzer determines whether a search for "running" matches a document
 containing "ran".
 
-If you omit `analyzers`, Searchlite uses its built-in `default` analyzer (ASCII
-lowercase + alphanumeric tokenization).
+Define custom analyzers with the `searchlite:analyzers` array at the schema root:
+
+```json
+{
+  "$schema": "https://searchlite.dev/draft/2025/schema",
+  "type": "object",
+  "searchlite:analyzers": [
+    {
+      "name": "english",
+      "tokenizer": "default",
+      "filters": [{ "stopwords": "en" }, { "stemmer": "english" }]
+    },
+    {
+      "name": "autocomplete",
+      "tokenizer": "default",
+      "filters": [{ "edge_ngram": { "min": 1, "max": 10 } }]
+    }
+  ],
+  "properties": {
+    "body": { "type": "string", "searchlite:analyzer": "english" },
+    "title": {
+      "type": "string",
+      "searchlite:analyzer": "autocomplete",
+      "searchlite:searchAnalyzer": "english"
+    }
+  }
+}
+```
+
+If you omit `searchlite:analyzers`, Searchlite uses its built-in `default` analyzer
+(ASCII lowercase + alphanumeric tokenization). Reference a custom analyzer by name
+via `searchlite:analyzer` on any text field.
 
 ### Available tokenizers
 
@@ -200,78 +321,112 @@ Searching for "programming languages" will match documents containing "program",
 }
 ```
 
-Use this as the index analyzer with a standard `search_analyzer` so that typing "pro"
-in a search bar matches "programming", "production", "prometheus".
+Use this as the index analyzer with a separate `searchlite:searchAnalyzer` so that
+typing "pro" in a search bar matches "programming", "production", "prometheus".
 
-## Field storage and fast fields
+## Defaults
 
-These two flags control what you can do with a field at query time:
+When `searchlite:` keywords are omitted from a property, Searchlite applies
+sensible defaults. You only need to specify non-default values, which keeps schemas
+concise.
 
-- **`stored: true`** -- the raw value is saved in the docstore. Enable this on fields
-  you want to return in search results (titles, descriptions, prices). Without it, the
-  field is searchable but its original value is not returned.
-- **`fast: true`** -- builds a columnar store for the field. Enable this on fields you
-  want to filter, sort, or aggregate on. Fast fields are memory-mapped for zero-copy
-  access, making filter evaluation fast even at scale.
+| Field type | `stored` | `indexed` | `fast` | `analyzer` | `nullable` |
+|---|---|---|---|---|---|
+| text | `true` | `true` | -- | `"default"` | `false` |
+| keyword | `true` | `true` | `true` | -- | `false` |
+| numeric | `false` | -- | `true` | -- | `false` |
 
-Nested objects are flattened into dotted field names (e.g., `comment.author`). You can
-filter on the dotted path directly, or wrap the clause in a `Nested` filter to enforce
-per-object binding (see [filters](filters.md)).
+This means `{"type": "string"}` is equivalent to writing:
+
+```json
+{
+  "type": "string",
+  "searchlite:stored": true,
+  "searchlite:indexed": true,
+  "searchlite:analyzer": "default",
+  "searchlite:nullable": false
+}
+```
+
+And `{"type": "string", "searchlite:kind": "keyword"}` is equivalent to:
+
+```json
+{
+  "type": "string",
+  "searchlite:kind": "keyword",
+  "searchlite:stored": true,
+  "searchlite:indexed": true,
+  "searchlite:fast": true,
+  "searchlite:nullable": false
+}
+```
+
+When serializing a schema back to JSON, Searchlite omits keywords that match their
+default values. Only emit non-default values in your own schemas to keep them
+readable.
 
 ## Nullable fields
 
 By default, every field defined in the schema is **required** -- Searchlite rejects
-documents that omit a defined field. Set `nullable: true` on a field to make it
-optional.
+documents that omit a defined field. There are two ways to make a field optional.
 
-This is common in real-world data. Not every product has a sale price. Not every
-article has a subtitle. Not every user has a bio.
+### Option 1: JSON Schema type array
+
+Use the standard JSON Schema nullable pattern:
 
 ```json
 {
-  "text_fields": [
-    { "name": "title", "analyzer": "default", "stored": true, "indexed": true },
-    { "name": "subtitle", "analyzer": "default", "stored": true, "indexed": true, "nullable": true }
-  ],
-  "numeric_fields": [
-    { "name": "price", "i64": true, "fast": true, "stored": true },
-    { "name": "sale_price", "i64": true, "fast": true, "stored": true, "nullable": true }
-  ],
-  "keyword_fields": [
-    { "name": "category", "stored": true, "indexed": true, "fast": true },
-    { "name": "brand", "stored": true, "indexed": true, "fast": true, "nullable": true }
-  ]
+  "subtitle": { "type": ["string", "null"] },
+  "sale_price": { "type": ["integer", "null"] },
+  "brand": { "type": ["string", "null"], "searchlite:kind": "keyword" }
 }
 ```
 
-With this schema, a document like `{"_id": "1", "title": "Widget", "price": 999, "category": "gadgets"}`
-is valid even though it omits `subtitle`, `sale_price`, and `brand`.
+### Option 2: `searchlite:nullable`
+
+Use the `searchlite:nullable` keyword directly:
+
+```json
+{
+  "subtitle": { "type": "string", "searchlite:nullable": true },
+  "sale_price": { "type": "integer", "searchlite:nullable": true }
+}
+```
+
+Both approaches are equivalent. If either one signals nullable, the field is optional.
+
+With these definitions, a document like
+`{"_id": "1", "title": "Widget", "price": 999, "category": "gadgets"}` is valid
+even though it omits `subtitle`, `sale_price`, and `brand`.
 
 **Behavior of nullable fields:**
-- Nullable text fields: documents without the field are simply not indexed for that field.
-  Searches against the field won't match those documents.
+
+- Nullable text fields: documents without the field are simply not indexed for that
+  field. Searches against the field will not match those documents.
 - Nullable keyword/numeric fields: missing values produce no fast-field entry.
   Filters and aggregations skip documents without a value.
-- Nullable nested fields: documents without the nested array are valid.
-  Nested filters and aggregations simply don't match those documents.
+- Nullable nested fields: documents without the nested array are valid. Nested
+  filters and aggregations simply do not match those documents.
 
 ## Vector fields
 
 Vector fields store numeric embeddings for approximate nearest neighbor (ANN) search.
-They require the `vectors` feature flag. See [vectors.md](vectors.md) for search
-usage.
+They are declared as a JSON Schema array of numbers with the `searchlite:vector`
+annotation:
 
 ```json
 {
-  "vector_fields": [
-    { "name": "embedding", "dim": 384, "metric": "Cosine" }
-  ]
+  "embedding": {
+    "type": "array",
+    "items": { "type": "number" },
+    "searchlite:vector": { "dim": 384, "metric": "Cosine" }
+  }
 }
 ```
 
-- **`dim`** -- embedding dimension (must match your model output)
-- **`metric`** -- `Cosine` (similarity, best for normalized embeddings) or `L2`
-  (Euclidean distance, best for unnormalized embeddings)
+- **`dim`** -- embedding dimension (must match your model output).
+- **`metric`** -- `"Cosine"` (similarity, best for normalized embeddings) or `"L2"`
+  (Euclidean distance, best for unnormalized embeddings).
 
 ### HNSW tuning
 
@@ -280,12 +435,15 @@ index parameters for your recall/speed tradeoff:
 
 ```json
 {
-  "vector_fields": [
-    {
-      "name": "embedding", "dim": 384, "metric": "Cosine",
+  "embedding": {
+    "type": "array",
+    "items": { "type": "number" },
+    "searchlite:vector": {
+      "dim": 384,
+      "metric": "Cosine",
       "hnsw": { "m": 16, "ef_construction": 64 }
     }
-  ]
+  }
 }
 ```
 
@@ -299,35 +457,58 @@ The defaults work well for most workloads (up to ~1M vectors). Increase `m` to 3
 time, you can further tune recall with the `ef_search` and `candidate_size` parameters
 on the search request (see [vectors.md](vectors.md)).
 
-## Document ID
-
-Every document must include a string primary key under the field named by `doc_id_field`
-(defaults to `_id`). This ID is stored automatically and used for upserts, deletes,
-and multi-get lookups. Don't list it in your field definitions.
-
-```json
-{"_id": "product-42", "title": "Wireless Mouse", "price": 2999, "category": "electronics"}
-```
-
 ## Search-as-you-type
 
 For building autocomplete UIs, text fields can opt into automatic edge n-gram
-indexing. This means typing just a few characters in a search box will immediately
-match full words.
+indexing with `searchlite:searchAsYouType`. This means typing just a few characters
+in a search box will immediately match full words.
 
 ```json
 {
-  "name": "title",
-  "analyzer": "default",
-  "stored": true,
-  "indexed": true,
-  "search_as_you_type": { "min_gram": 1, "max_gram": 10 }
+  "title": {
+    "type": "string",
+    "searchlite:searchAsYouType": { "minGram": 1, "maxGram": 10 }
+  }
 }
 ```
 
 With this configuration, searching for `"ru"` matches documents with `"rustacean"`,
 `"ruby"`, or `"runtime"` in the title -- perfect for powering a live search dropdown.
 
+| Parameter | Default | Description |
+|---|---|---|
+| `minGram` | 1 | Minimum prefix length to generate. |
+| `maxGram` | 15 | Maximum prefix length to generate. |
+
 You can also build this manually by defining an analyzer with an `edge_ngram` filter
-as the index analyzer and a normal analyzer as the search analyzer. The built-in
-`search_as_you_type` option is a shorthand that does this for you.
+as the index analyzer and a separate `searchlite:searchAnalyzer` for query time. The
+`searchlite:searchAsYouType` keyword is a shorthand that does this for you.
+
+## Document ID
+
+Every document must include a string primary key under the field named by
+`searchlite:docIdField` (defaults to `"_id"`). This ID is stored automatically and
+used for upserts, deletes, and multi-get lookups. Do not list it in your `properties`.
+
+```json
+{
+  "$schema": "https://searchlite.dev/draft/2025/schema",
+  "type": "object",
+  "searchlite:docIdField": "doc_id",
+  "properties": {
+    "title": { "type": "string" }
+  }
+}
+```
+
+With this schema, documents must include a `doc_id` field:
+
+```json
+{"doc_id": "product-42", "title": "Wireless Mouse"}
+```
+
+If you omit `searchlite:docIdField`, the default is `"_id"`:
+
+```json
+{"_id": "product-42", "title": "Wireless Mouse"}
+```

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -26,13 +26,15 @@ searchlite-core = { version = "0.5", features = ["vectors"] }
 
 ## Schema
 
-Add a `vector_fields` entry to your schema with the embedding dimension and distance metric:
+Add a vector property to your schema with the embedding dimension and distance metric:
 
 ```json
 {
-  "vector_fields": [
-    { "name": "embedding", "dim": 384, "metric": "Cosine" }
-  ]
+  "embedding": {
+    "type": "array",
+    "items": { "type": "number" },
+    "searchlite:vector": { "dim": 384, "metric": "Cosine" }
+  }
 }
 ```
 

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -30,10 +30,14 @@ Add a vector property to your schema with the embedding dimension and distance m
 
 ```json
 {
-  "embedding": {
-    "type": "array",
-    "items": { "type": "number" },
-    "searchlite:vector": { "dim": 384, "metric": "Cosine" }
+  "$schema": "https://searchlite.dev/draft/2025/schema",
+  "type": "object",
+  "properties": {
+    "embedding": {
+      "type": "array",
+      "items": { "type": "number" },
+      "searchlite:vector": { "dim": 384, "metric": "Cosine" }
+    }
   }
 }
 ```

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -38,9 +38,11 @@ await init();
 
 // Create an index backed by IndexedDB (persists across page reloads)
 const schema = {
-  doc_id_field: "_id",
-  text_fields: [{ name: "title", analyzer: "default", stored: true, indexed: true }],
-  keyword_fields: [{ name: "category", stored: true, indexed: true, fast: true }],
+  type: "object",
+  properties: {
+    title: { type: "string" },
+    category: { type: "string", "searchlite:kind": "keyword" },
+  },
 };
 const db = await Searchlite.init("my-search-db", JSON.stringify(schema), "indexeddb");
 

--- a/examples/recipes/schema.json
+++ b/examples/recipes/schema.json
@@ -1,59 +1,62 @@
 {
-  "doc_id_field": "doc_id",
-  "text_fields": [
-    { "name": "text", "tokenizer": "default", "stored": true, "indexed": true },
-    { "name": "title", "tokenizer": "default", "stored": true, "indexed": true },
-    { "name": "description", "tokenizer": "default", "stored": true, "indexed": true },
-    { "name": "instructions", "tokenizer": "default", "stored": true, "indexed": true }
-  ],
-  "keyword_fields": [
-    { "name": "cuisine", "stored": true, "indexed": true, "fast": true },
-    { "name": "region", "stored": true, "indexed": true, "fast": true },
-    { "name": "meal_type", "stored": true, "indexed": true, "fast": true },
-    { "name": "difficulty", "stored": true, "indexed": true, "fast": true },
-    { "name": "dietary_tags", "stored": true, "indexed": true, "fast": true },
-    { "name": "allergens", "stored": true, "indexed": true, "fast": true },
-    { "name": "equipment", "stored": true, "indexed": true, "fast": true },
-    { "name": "keywords", "stored": true, "indexed": true, "fast": true },
-    { "name": "language", "stored": true, "indexed": true, "fast": true },
-    { "name": "source", "stored": true, "indexed": true, "fast": false },
-    { "name": "created_at", "stored": true, "indexed": true, "fast": true },
-    { "name": "updated_at", "stored": true, "indexed": true, "fast": true }
-  ],
-  "numeric_fields": [
-    { "name": "prep_time_minutes", "i64": true, "fast": true, "stored": true },
-    { "name": "cook_time_minutes", "i64": true, "fast": true, "stored": true },
-    { "name": "total_time_minutes", "i64": true, "fast": true, "stored": true },
-    { "name": "servings", "i64": true, "fast": true, "stored": true }
-  ],
-  "nested_fields": [
-    {
-      "name": "ingredients",
-      "fields": [
-        { "type": "keyword", "name": "item", "stored": true, "indexed": true, "fast": true },
-        { "type": "numeric", "name": "quantity", "i64": false, "fast": true, "stored": true },
-        { "type": "keyword", "name": "unit", "stored": true, "indexed": true, "fast": true },
-        { "type": "keyword", "name": "prep", "stored": true, "indexed": true, "fast": true }
-      ]
-    },
-    {
-      "name": "nutrition",
-      "fields": [
-        {
-          "type": "object",
-          "name": "per_serving",
-          "fields": [
-            { "type": "numeric", "name": "calories", "i64": true, "fast": true, "stored": true },
-            { "type": "numeric", "name": "protein_g", "i64": true, "fast": true, "stored": true },
-            { "type": "numeric", "name": "carbs_g", "i64": true, "fast": true, "stored": true },
-            { "type": "numeric", "name": "fat_g", "i64": true, "fast": true, "stored": true },
-            { "type": "numeric", "name": "fiber_g", "i64": true, "fast": true, "stored": true },
-            { "type": "numeric", "name": "sodium_mg", "i64": true, "fast": true, "stored": true },
-            { "type": "numeric", "name": "sugar_g", "i64": true, "fast": true, "stored": true }
-          ]
+  "$schema": "https://searchlite.dev/draft/2025/schema",
+  "type": "object",
+  "searchlite:docIdField": "doc_id",
+  "properties": {
+    "text": { "type": "string" },
+    "title": { "type": "string" },
+    "description": { "type": "string" },
+    "instructions": { "type": "string" },
+    "cuisine": { "type": "string", "searchlite:kind": "keyword" },
+    "region": { "type": "string", "searchlite:kind": "keyword" },
+    "meal_type": { "type": "string", "searchlite:kind": "keyword" },
+    "difficulty": { "type": "string", "searchlite:kind": "keyword" },
+    "dietary_tags": { "type": "string", "searchlite:kind": "keyword" },
+    "allergens": { "type": "string", "searchlite:kind": "keyword" },
+    "equipment": { "type": "string", "searchlite:kind": "keyword" },
+    "keywords": { "type": "string", "searchlite:kind": "keyword" },
+    "language": { "type": "string", "searchlite:kind": "keyword" },
+    "source": { "type": "string", "searchlite:kind": "keyword", "searchlite:fast": false },
+    "created_at": { "type": "string", "searchlite:kind": "keyword" },
+    "updated_at": { "type": "string", "searchlite:kind": "keyword" },
+    "prep_time_minutes": { "type": "integer", "searchlite:stored": true },
+    "cook_time_minutes": { "type": "integer", "searchlite:stored": true },
+    "total_time_minutes": { "type": "integer", "searchlite:stored": true },
+    "servings": { "type": "integer", "searchlite:stored": true },
+    "ingredients": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "item": { "type": "string", "searchlite:kind": "keyword" },
+          "quantity": { "type": "number", "searchlite:stored": true },
+          "unit": { "type": "string", "searchlite:kind": "keyword" },
+          "prep": { "type": "string", "searchlite:kind": "keyword" }
         }
-      ]
+      }
+    },
+    "nutrition": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "per_serving": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "calories": { "type": "integer", "searchlite:stored": true },
+                "protein_g": { "type": "integer", "searchlite:stored": true },
+                "carbs_g": { "type": "integer", "searchlite:stored": true },
+                "fat_g": { "type": "integer", "searchlite:stored": true },
+                "fiber_g": { "type": "integer", "searchlite:stored": true },
+                "sodium_mg": { "type": "integer", "searchlite:stored": true },
+                "sugar_g": { "type": "integer", "searchlite:stored": true }
+              }
+            }
+          }
+        }
+      }
     }
-  ],
-  "vector_fields": []
+  }
 }

--- a/examples/video-games/schema.json
+++ b/examples/video-games/schema.json
@@ -1,407 +1,119 @@
 {
-  "doc_id_field": "doc_id",
-  "text_fields": [
-    {
-      "name": "text",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+  "$schema": "https://searchlite.dev/draft/2025/schema",
+  "type": "object",
+  "searchlite:docIdField": "doc_id",
+  "properties": {
+    "text": { "type": "string" },
+    "title": { "type": "string" },
+    "summary": { "type": "string" },
+    "tips": { "type": "string" },
+    "notes": { "type": "string" },
+    "changes": { "type": "string" },
+    "pros": { "type": "string" },
+    "cons": { "type": "string" },
+    "settings": { "type": "string" },
+    "known_issues": { "type": "string" },
+    "installation_steps": { "type": "string" },
+    "steps": { "type": "string" },
+    "techniques": { "type": "string" },
+    "compatibility": { "type": "string" },
+    "legal_note": { "type": "string" },
+    "doc_type": { "type": "string", "searchlite:kind": "keyword" },
+    "developer": { "type": "string", "searchlite:kind": "keyword" },
+    "publisher": { "type": "string", "searchlite:kind": "keyword" },
+    "era": { "type": "string", "searchlite:kind": "keyword" },
+    "platforms": { "type": "string", "searchlite:kind": "keyword" },
+    "genres": { "type": "string", "searchlite:kind": "keyword" },
+    "rating_board": { "type": "string", "searchlite:kind": "keyword" },
+    "region": { "type": "string", "searchlite:kind": "keyword" },
+    "language": { "type": "string", "searchlite:kind": "keyword" },
+    "source": { "type": "string", "searchlite:kind": "keyword", "searchlite:fast": false },
+    "tags": { "type": "string", "searchlite:kind": "keyword" },
+    "keywords": { "type": "string", "searchlite:kind": "keyword" },
+    "entities": { "type": "string", "searchlite:kind": "keyword" },
+    "difficulty_estimate": { "type": "string", "searchlite:kind": "keyword" },
+    "category": { "type": "string", "searchlite:kind": "keyword" },
+    "version": { "type": "string", "searchlite:kind": "keyword", "searchlite:fast": false },
+    "accuracy_grade": { "type": "string", "searchlite:kind": "keyword" },
+    "recommended_core": { "type": "string", "searchlite:kind": "keyword", "searchlite:fast": false },
+    "mod_name": { "type": "string", "searchlite:kind": "keyword", "searchlite:fast": false },
+    "created_at": { "type": "string", "searchlite:kind": "keyword" },
+    "updated_at": { "type": "string", "searchlite:kind": "keyword" },
+    "release_year": { "type": "integer", "searchlite:stored": true },
+    "review_score_out_of_10": { "type": "number", "searchlite:stored": true },
+    "target_time_minutes": { "type": "integer", "searchlite:stored": true },
+    "game": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "game_id": { "type": "string", "searchlite:kind": "keyword" },
+          "name": { "type": "string", "searchlite:kind": "keyword" },
+          "franchise": { "type": ["string", "null"], "searchlite:kind": "keyword", "searchlite:indexed": false }
+        }
+      }
     },
-    {
-      "name": "title",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+    "sections": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "heading": { "type": "string" },
+          "content": { "type": "string" }
+        }
+      }
     },
-    {
-      "name": "summary",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+    "achievements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "tier": { "type": "string", "searchlite:kind": "keyword" },
+          "description": { "type": "string" }
+        }
+      }
     },
-    {
-      "name": "tips",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+    "estimated_hours": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "main": { "type": "integer", "searchlite:stored": true },
+          "completionist": { "type": "integer", "searchlite:stored": true }
+        }
+      }
     },
-    {
-      "name": "notes",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+    "tier_list": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "S": { "type": "string", "searchlite:kind": "keyword" },
+          "A": { "type": "string", "searchlite:kind": "keyword" },
+          "B": { "type": "string", "searchlite:kind": "keyword" }
+        }
+      }
     },
-    {
-      "name": "changes",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+    "codes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "input": { "type": "string" },
+          "effect": { "type": "string" }
+        }
+      }
     },
-    {
-      "name": "pros",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "cons",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "settings",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "known_issues",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "installation_steps",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "steps",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "techniques",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "compatibility",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
-    },
-    {
-      "name": "legal_note",
-      "tokenizer": "default",
-      "stored": true,
-      "indexed": true
+    "splits": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "split": { "type": "string" },
+          "target_time_min": { "type": "integer", "searchlite:stored": true }
+        }
+      }
     }
-  ],
-  "keyword_fields": [
-    {
-      "name": "doc_id",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "doc_type",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "developer",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "publisher",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "era",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "platforms",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "genres",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "rating_board",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "region",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "language",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "source",
-      "stored": true,
-      "indexed": true,
-      "fast": false
-    },
-    {
-      "name": "tags",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "keywords",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "entities",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "difficulty_estimate",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "category",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "version",
-      "stored": true,
-      "indexed": true,
-      "fast": false
-    },
-    {
-      "name": "accuracy_grade",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "recommended_core",
-      "stored": true,
-      "indexed": true,
-      "fast": false
-    },
-    {
-      "name": "mod_name",
-      "stored": true,
-      "indexed": true,
-      "fast": false
-    },
-    {
-      "name": "created_at",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    },
-    {
-      "name": "updated_at",
-      "stored": true,
-      "indexed": true,
-      "fast": true
-    }
-  ],
-  "numeric_fields": [
-    {
-      "name": "release_year",
-      "i64": true,
-      "fast": true,
-      "stored": true
-    },
-    {
-      "name": "review_score_out_of_10",
-      "i64": false,
-      "fast": true,
-      "stored": true
-    },
-    {
-      "name": "target_time_minutes",
-      "i64": true,
-      "fast": true,
-      "stored": true
-    }
-  ],
-  "nested_fields": [
-    {
-      "name": "game",
-      "fields": [
-        {
-          "type": "keyword",
-          "name": "game_id",
-          "stored": true,
-          "indexed": true,
-          "fast": true
-        },
-        {
-          "type": "keyword",
-          "name": "name",
-          "stored": true,
-          "indexed": true,
-          "fast": true
-        },
-        {
-          "type": "keyword",
-          "name": "franchise",
-          "stored": true,
-          "indexed": false,
-          "fast": true,
-          "nullable": true
-        }
-      ]
-    },
-    {
-      "name": "sections",
-      "fields": [
-        {
-          "type": "text",
-          "name": "heading",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        },
-        {
-          "type": "text",
-          "name": "content",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        }
-      ]
-    },
-    {
-      "name": "achievements",
-      "fields": [
-        {
-          "type": "text",
-          "name": "name",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        },
-        {
-          "type": "keyword",
-          "name": "tier",
-          "stored": true,
-          "indexed": true,
-          "fast": true
-        },
-        {
-          "type": "text",
-          "name": "description",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        }
-      ]
-    },
-    {
-      "name": "estimated_hours",
-      "fields": [
-        {
-          "type": "numeric",
-          "name": "main",
-          "i64": true,
-          "fast": true,
-          "stored": true
-        },
-        {
-          "type": "numeric",
-          "name": "completionist",
-          "i64": true,
-          "fast": true,
-          "stored": true
-        }
-      ]
-    },
-    {
-      "name": "tier_list",
-      "fields": [
-        {
-          "type": "keyword",
-          "name": "S",
-          "stored": true,
-          "indexed": true,
-          "fast": true
-        },
-        {
-          "type": "keyword",
-          "name": "A",
-          "stored": true,
-          "indexed": true,
-          "fast": true
-        },
-        {
-          "type": "keyword",
-          "name": "B",
-          "stored": true,
-          "indexed": true,
-          "fast": true
-        }
-      ]
-    },
-    {
-      "name": "codes",
-      "fields": [
-        {
-          "type": "text",
-          "name": "input",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        },
-        {
-          "type": "text",
-          "name": "effect",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        }
-      ]
-    },
-    {
-      "name": "splits",
-      "fields": [
-        {
-          "type": "text",
-          "name": "split",
-          "tokenizer": "default",
-          "stored": true,
-          "indexed": true
-        },
-        {
-          "type": "numeric",
-          "name": "target_time_min",
-          "i64": true,
-          "fast": true,
-          "stored": true
-        }
-      ]
-    }
-  ],
-  "vector_fields": []
+  }
 }

--- a/index-schema.json
+++ b/index-schema.json
@@ -1,56 +1,64 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/davidkelley/searchlite/index-schema.json",
-  "title": "Searchlite Index Schema",
-  "description": "Defines the structure of schema.json files used to build Searchlite indexes.",
+  "$id": "https://searchlite.dev/draft/2025/schema",
+  "title": "Searchlite Index Meta-Schema",
+  "description": "Validates user-authored JSON Schema documents that use the searchlite: vocabulary to define Searchlite indexes.",
   "type": "object",
-  "additionalProperties": false,
-  "required": ["text_fields", "keyword_fields", "numeric_fields"],
+  "required": ["type", "properties"],
   "properties": {
-    "doc_id_field": {
-      "type": "string",
-      "description": "Name of the string primary key field expected on every document.",
-      "default": "_id",
-      "minLength": 1
+    "$schema": {
+      "type": "string"
     },
-    "analyzers": {
-      "type": "array",
-      "description": "Optional custom analyzers composed of a tokenizer and token filters.",
-      "items": { "$ref": "#/$defs/analyzer" },
-      "default": []
+    "$id": {
+      "type": "string"
     },
-    "text_fields": {
-      "type": "array",
-      "description": "Top-level text fields to tokenize and index.",
-      "items": { "$ref": "#/$defs/text_field" },
-      "default": []
+    "title": {
+      "type": "string"
     },
-    "keyword_fields": {
-      "type": "array",
-      "description": "Top-level keyword fields for exact matches and filters.",
-      "items": { "$ref": "#/$defs/keyword_field" },
-      "default": []
+    "description": {
+      "type": "string"
     },
-    "numeric_fields": {
-      "type": "array",
-      "description": "Top-level numeric fields for range queries and aggregations.",
-      "items": { "$ref": "#/$defs/numeric_field" },
-      "default": []
+    "type": {
+      "const": "object"
     },
-    "nested_fields": {
-      "type": "array",
-      "description": "Nested objects whose child fields are flattened to dotted paths.",
-      "items": { "$ref": "#/$defs/nested_field" },
-      "default": []
+    "properties": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/propertySchema"
+      }
     },
-    "vector_fields": {
+    "required": {
       "type": "array",
-      "description": "Optional dense vector fields (requires the `vectors` feature).",
-      "items": { "$ref": "#/$defs/vector_field" },
-      "default": []
+      "items": {
+        "type": "string"
+      }
+    },
+    "additionalProperties": {
+      "type": "boolean"
+    },
+    "searchlite:docIdField": {
+      "$ref": "#/$defs/searchlite:docIdField"
+    },
+    "searchlite:analyzers": {
+      "$ref": "#/$defs/searchlite:analyzers"
     }
   },
+  "additionalProperties": false,
   "$defs": {
+    "searchlite:docIdField": {
+      "type": "string",
+      "default": "_id",
+      "minLength": 1,
+      "description": "Name of the string primary key field expected on every document."
+    },
+    "searchlite:analyzers": {
+      "type": "array",
+      "description": "Custom analyzers composed of a tokenizer and token filters.",
+      "items": {
+        "$ref": "#/$defs/analyzer"
+      },
+      "default": []
+    },
     "analyzer": {
       "type": "object",
       "description": "Named analyzer consisting of a tokenizer and optional filters.",
@@ -60,30 +68,35 @@
         "name": {
           "type": "string",
           "minLength": 1,
-          "description": "Unique analyzer identifier referenced by text fields."
+          "description": "Unique analyzer identifier referenced by field schemas."
         },
         "tokenizer": {
           "type": "string",
           "minLength": 1,
-          "description": "Built-in tokenizer name (`default`, `unicode`, or `whitespace`)."
+          "description": "Built-in tokenizer name (e.g. default, unicode, whitespace)."
         },
         "filters": {
           "type": "array",
-          "items": { "$ref": "#/$defs/token_filter" },
+          "items": {
+            "$ref": "#/$defs/tokenFilter"
+          },
           "default": [],
           "description": "Ordered token filters applied after tokenization."
         }
       }
     },
-    "token_filter": {
-      "description": "Token filters applied after tokenization.",
+    "tokenFilter": {
+      "description": "A single token filter applied after tokenization.",
       "oneOf": [
         {
           "type": "object",
           "required": ["lowercase"],
           "additionalProperties": false,
           "properties": {
-            "lowercase": { "type": "boolean", "description": "Lowercase tokens using Unicode rules." }
+            "lowercase": {
+              "type": "boolean",
+              "description": "Lowercase tokens using Unicode rules."
+            }
           }
         },
         {
@@ -92,8 +105,8 @@
           "additionalProperties": false,
           "properties": {
             "stopwords": {
-              "$ref": "#/$defs/stopwords_config",
-              "description": "Built-in list name (e.g., `en`) or explicit array."
+              "$ref": "#/$defs/stopwordsConfig",
+              "description": "Built-in list name (e.g. en) or explicit array of stop words."
             }
           }
         },
@@ -104,7 +117,7 @@
           "properties": {
             "stemmer": {
               "type": "string",
-              "description": "Stemmer language (e.g., `english`)."
+              "description": "Stemmer language (e.g. english)."
             }
           }
         },
@@ -115,7 +128,9 @@
           "properties": {
             "synonyms": {
               "type": "array",
-              "items": { "$ref": "#/$defs/synonym_rule" },
+              "items": {
+                "$ref": "#/$defs/synonymRule"
+              },
               "description": "Synonym expansion rules applied at the same token position."
             }
           }
@@ -125,27 +140,35 @@
           "required": ["edge_ngram"],
           "additionalProperties": false,
           "properties": {
-            "edge_ngram": { "$ref": "#/$defs/edge_ngram" }
+            "edge_ngram": {
+              "$ref": "#/$defs/edgeNgram"
+            }
           }
         }
       ]
     },
-    "stopwords_config": {
+    "stopwordsConfig": {
       "oneOf": [
         { "type": "string" },
         { "type": "array", "items": { "type": "string" } }
       ]
     },
-    "synonym_rule": {
+    "synonymRule": {
       "type": "object",
       "additionalProperties": false,
       "required": ["from", "to"],
       "properties": {
-        "from": { "type": "array", "items": { "type": "string" } },
-        "to": { "type": "array", "items": { "type": "string" } }
+        "from": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "to": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
       }
     },
-    "edge_ngram": {
+    "edgeNgram": {
       "type": "object",
       "additionalProperties": false,
       "required": ["min", "max"],
@@ -154,342 +177,62 @@
         "max": { "type": "integer", "minimum": 1 }
       }
     },
-    "search_as_you_type": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "min_gram": { "type": "integer", "minimum": 1, "default": 1 },
-        "max_gram": { "type": "integer", "minimum": 1, "default": 15 }
-      },
-      "description": "Convenience flag that adds an edge_ngram filter to the index analyzer while keeping the search analyzer unchanged."
+    "searchlite:kind": {
+      "type": "string",
+      "enum": ["keyword"],
+      "description": "The searchlite field kind."
     },
-    "text_field": {
-      "type": "object",
-      "description": "Tokenized text column stored in postings and optionally in the doc store.",
-      "additionalProperties": false,
-      "required": ["name", "stored", "indexed"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name used in documents and queries."
-        },
-        "analyzer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Analyzer identifier applied at index time."
-        },
-        "tokenizer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Deprecated alias for `analyzer`."
-        },
-        "search_analyzer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Optional analyzer to use at search time."
-        },
-        "search_tokenizer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Deprecated alias for `search_analyzer`."
-        },
-        "stored": {
-          "type": "boolean",
-          "description": "Keep raw field values for retrieval and snippets."
-        },
-        "indexed": {
-          "type": "boolean",
-          "description": "Index tokenized terms to make the field searchable."
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Permit null values in documents for this field.",
-          "default": false
-        },
-        "search_as_you_type": {
-          "$ref": "#/$defs/search_as_you_type",
-          "description": "Enable edge n-gram indexing for search-as-you-type queries."
-        }
-      },
-      "allOf": [
-        {
-          "anyOf": [
-            { "required": ["analyzer"] },
-            { "required": ["tokenizer"] },
-            { "required": ["search_as_you_type"] }
-          ]
-        },
-        { "not": { "required": ["analyzer", "tokenizer"] } },
-        { "not": { "required": ["search_analyzer", "search_tokenizer"] } }
-      ]
+    "searchlite:stored": {
+      "type": "boolean",
+      "description": "Keep raw field values for retrieval and snippets."
     },
-    "keyword_field": {
+    "searchlite:indexed": {
+      "type": "boolean",
+      "description": "Index terms to make the field searchable."
+    },
+    "searchlite:fast": {
+      "type": "boolean",
+      "description": "Expose as a fast field to enable filters and aggregations."
+    },
+    "searchlite:analyzer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Analyzer identifier applied at index time."
+    },
+    "searchlite:searchAnalyzer": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Analyzer to use at search time (defaults to the index analyzer)."
+    },
+    "searchlite:searchAsYouType": {
       "type": "object",
-      "description": "Keyword (untokenized) field for exact matches and fast filtering.",
       "additionalProperties": false,
-      "required": ["name", "stored", "indexed", "fast"],
+      "description": "Enable edge n-gram indexing for search-as-you-type queries.",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name used in documents and filters."
+        "minGram": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 1,
+          "description": "Minimum edge n-gram length."
         },
-        "stored": {
-          "type": "boolean",
-          "description": "Keep raw keyword values for retrieval."
-        },
-        "indexed": {
-          "type": "boolean",
-          "description": "Index keyword terms for matching."
-        },
-        "fast": {
-          "type": "boolean",
-          "description": "Expose as a fast field to enable filters and aggregations."
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Permit null values in documents for this field.",
-          "default": false
+        "maxGram": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 15,
+          "description": "Maximum edge n-gram length."
         }
       }
     },
-    "numeric_field": {
-      "type": "object",
-      "description": "Numeric field (i64 or f64) used for range queries and aggregations.",
-      "additionalProperties": false,
-      "required": ["name", "i64", "fast"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name used in documents and filters."
-        },
-        "i64": {
-          "type": "boolean",
-          "description": "When true store as a signed 64-bit integer; otherwise store as f64."
-        },
-        "fast": {
-          "type": "boolean",
-          "description": "Expose as a fast field to enable filters and aggregations."
-        },
-        "stored": {
-          "type": "boolean",
-          "description": "Keep numeric values in the doc store for retrieval.",
-          "default": false
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Permit null values in documents for this field.",
-          "default": false
-        }
-      }
+    "searchlite:nullable": {
+      "type": "boolean",
+      "description": "Permit null values in documents for this field."
     },
-    "nested_field": {
+    "searchlite:vector": {
       "type": "object",
-      "description": "Nested object whose child fields are validated per object and stored separately.",
       "additionalProperties": false,
-      "required": ["name"],
+      "required": ["dim", "metric"],
+      "description": "Dense vector field configuration.",
       "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Name of the nested object as it appears in documents."
-        },
-        "fields": {
-          "type": "array",
-          "description": "Fields contained within this nested object.",
-          "items": { "$ref": "#/$defs/nested_property" },
-          "default": []
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Allow the entire object to be null in documents.",
-          "default": false
-        }
-      }
-    },
-    "nested_property": {
-      "description": "Field definitions allowed inside a nested object. Each entry must declare its type.",
-      "oneOf": [
-        { "$ref": "#/$defs/nested_text_property" },
-        { "$ref": "#/$defs/nested_keyword_property" },
-        { "$ref": "#/$defs/nested_numeric_property" },
-        { "$ref": "#/$defs/nested_object_property" }
-      ]
-    },
-    "nested_text_property": {
-      "type": "object",
-      "description": "Text field within a nested object.",
-      "additionalProperties": false,
-      "required": ["type", "name", "stored", "indexed"],
-      "properties": {
-        "type": {
-          "const": "text",
-          "description": "Marks this nested field as text."
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name relative to its parent object."
-        },
-        "analyzer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Analyzer identifier applied at index time."
-        },
-        "tokenizer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Deprecated alias for `analyzer`."
-        },
-        "search_analyzer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Optional analyzer to use at search time."
-        },
-        "search_tokenizer": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Deprecated alias for `search_analyzer`."
-        },
-        "stored": {
-          "type": "boolean",
-          "description": "Keep raw field values for retrieval and snippets."
-        },
-        "indexed": {
-          "type": "boolean",
-          "description": "Index tokenized terms to make the field searchable."
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Permit null values in documents for this field.",
-          "default": false
-        },
-        "search_as_you_type": {
-          "$ref": "#/$defs/search_as_you_type",
-          "description": "Enable edge n-gram indexing for search-as-you-type queries."
-        }
-      },
-      "allOf": [
-        {
-          "anyOf": [
-            { "required": ["analyzer"] },
-            { "required": ["tokenizer"] }
-          ]
-        },
-        { "not": { "required": ["analyzer", "tokenizer"] } },
-        { "not": { "required": ["search_analyzer", "search_tokenizer"] } }
-      ]
-    },
-    "nested_keyword_property": {
-      "type": "object",
-      "description": "Keyword field within a nested object.",
-      "additionalProperties": false,
-      "required": ["type", "name", "stored", "indexed", "fast"],
-      "properties": {
-        "type": {
-          "const": "keyword",
-          "description": "Marks this nested field as keyword."
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name relative to its parent object."
-        },
-        "stored": {
-          "type": "boolean",
-          "description": "Keep raw keyword values for retrieval."
-        },
-        "indexed": {
-          "type": "boolean",
-          "description": "Index keyword terms for matching."
-        },
-        "fast": {
-          "type": "boolean",
-          "description": "Expose as a fast field to enable filters and aggregations."
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Permit null values in documents for this field.",
-          "default": false
-        }
-      }
-    },
-    "nested_numeric_property": {
-      "type": "object",
-      "description": "Numeric field within a nested object.",
-      "additionalProperties": false,
-      "required": ["type", "name", "i64", "fast"],
-      "properties": {
-        "type": {
-          "const": "numeric",
-          "description": "Marks this nested field as numeric."
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name relative to its parent object."
-        },
-        "i64": {
-          "type": "boolean",
-          "description": "When true store as a signed 64-bit integer; otherwise store as f64."
-        },
-        "fast": {
-          "type": "boolean",
-          "description": "Expose as a fast field to enable filters and aggregations."
-        },
-        "stored": {
-          "type": "boolean",
-          "description": "Keep numeric values in the doc store for retrieval.",
-          "default": false
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Permit null values in documents for this field.",
-          "default": false
-        }
-      }
-    },
-    "nested_object_property": {
-      "type": "object",
-      "description": "Nested object contained within another nested object.",
-      "additionalProperties": false,
-      "required": ["type", "name"],
-      "properties": {
-        "type": {
-          "const": "object",
-          "description": "Marks this nested entry as another nested object."
-        },
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Name of the nested object relative to its parent."
-        },
-        "fields": {
-          "type": "array",
-          "description": "Child fields contained in this nested object.",
-          "items": { "$ref": "#/$defs/nested_property" },
-          "default": []
-        },
-        "nullable": {
-          "type": "boolean",
-          "description": "Allow the entire nested object to be null in documents.",
-          "default": false
-        }
-      }
-    },
-    "vector_field": {
-      "type": "object",
-      "description": "Dense vector field configuration (requires the `vectors` feature).",
-      "additionalProperties": false,
-      "required": ["name", "dim", "metric"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1,
-          "description": "Field name for vector embeddings."
-        },
         "dim": {
           "type": "integer",
           "minimum": 1,
@@ -499,6 +242,166 @@
           "type": "string",
           "enum": ["Cosine", "L2"],
           "description": "Similarity metric used for vector search."
+        },
+        "hnsw": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "HNSW index parameters.",
+          "properties": {
+            "m": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Number of bi-directional links per node."
+            },
+            "ef_construction": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Size of the dynamic candidate list during construction."
+            }
+          }
+        }
+      }
+    },
+    "propertySchema": {
+      "description": "A JSON Schema for a single property, extended with optional searchlite: keywords.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "default": true,
+        "enum": {
+          "type": "array"
+        },
+        "const": true,
+        "format": {
+          "type": "string"
+        },
+        "minLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxLength": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "pattern": {
+          "type": "string"
+        },
+        "minimum": {
+          "type": "number"
+        },
+        "maximum": {
+          "type": "number"
+        },
+        "exclusiveMinimum": {
+          "type": "number"
+        },
+        "exclusiveMaximum": {
+          "type": "number"
+        },
+        "multipleOf": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "items": true,
+        "minItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "maxItems": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "uniqueItems": {
+          "type": "boolean"
+        },
+        "properties": {
+          "type": "object"
+        },
+        "required": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "additionalProperties": true,
+        "oneOf": {
+          "type": "array"
+        },
+        "anyOf": {
+          "type": "array"
+        },
+        "allOf": {
+          "type": "array"
+        },
+        "not": true,
+        "if": true,
+        "then": true,
+        "else": true,
+        "$ref": {
+          "type": "string"
+        },
+        "$defs": {
+          "type": "object"
+        },
+        "examples": {
+          "type": "array"
+        },
+        "deprecated": {
+          "type": "boolean"
+        },
+        "readOnly": {
+          "type": "boolean"
+        },
+        "writeOnly": {
+          "type": "boolean"
+        },
+        "title": {
+          "type": "string"
+        },
+        "searchlite:kind": {
+          "$ref": "#/$defs/searchlite:kind"
+        },
+        "searchlite:stored": {
+          "$ref": "#/$defs/searchlite:stored"
+        },
+        "searchlite:indexed": {
+          "$ref": "#/$defs/searchlite:indexed"
+        },
+        "searchlite:fast": {
+          "$ref": "#/$defs/searchlite:fast"
+        },
+        "searchlite:analyzer": {
+          "$ref": "#/$defs/searchlite:analyzer"
+        },
+        "searchlite:searchAnalyzer": {
+          "$ref": "#/$defs/searchlite:searchAnalyzer"
+        },
+        "searchlite:searchAsYouType": {
+          "$ref": "#/$defs/searchlite:searchAsYouType"
+        },
+        "searchlite:nullable": {
+          "$ref": "#/$defs/searchlite:nullable"
+        },
+        "searchlite:vector": {
+          "$ref": "#/$defs/searchlite:vector"
+        }
+      },
+      "patternProperties": {
+        "^searchlite:": {
+          "oneOf": [
+            { "$ref": "#/$defs/searchlite:kind" },
+            { "$ref": "#/$defs/searchlite:stored" },
+            { "$ref": "#/$defs/searchlite:indexed" },
+            { "$ref": "#/$defs/searchlite:fast" },
+            { "$ref": "#/$defs/searchlite:analyzer" },
+            { "$ref": "#/$defs/searchlite:searchAnalyzer" },
+            { "$ref": "#/$defs/searchlite:searchAsYouType" },
+            { "$ref": "#/$defs/searchlite:nullable" },
+            { "$ref": "#/$defs/searchlite:vector" }
+          ]
         }
       }
     }

--- a/index-schema.json
+++ b/index-schema.json
@@ -267,7 +267,10 @@
       "type": "object",
       "properties": {
         "type": {
-          "type": "string"
+          "oneOf": [
+            { "type": "string" },
+            { "type": "array", "items": { "type": "string" } }
+          ]
         },
         "description": {
           "type": "string"

--- a/integration/tests/adversarial_matrix.rs
+++ b/integration/tests/adversarial_matrix.rs
@@ -11,19 +11,20 @@ use integration::surfaces::SurfaceHarness;
 
 fn valid_schema() -> serde_json::Value {
   json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": []
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" }
+    }
   })
 }
 
 fn invalid_schema() -> serde_json::Value {
-  json!({ "doc_id_field": 7 })
+  json!({
+    "type": "object",
+    "properties": {
+      "x": { "type": "string", "searchlite:bogus": true }
+    }
+  })
 }
 
 fn docs_ndjson() -> &'static str {

--- a/integration/tests/contracts_cli.rs
+++ b/integration/tests/contracts_cli.rs
@@ -27,14 +27,10 @@ fn cli_contract_search_emits_json() -> Result<()> {
   fs::write(
     &schema_path,
     serde_json::to_vec_pretty(&json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [],
-      "numeric_fields": [],
-      "nested_fields": [],
-      "vector_fields": []
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" }
+      }
     }))?,
   )?;
   let docs_path = dir.path().join("docs.jsonl");
@@ -99,14 +95,10 @@ fn cli_contract_inspect_emits_manifest_json() -> Result<()> {
   fs::write(
     &schema_path,
     serde_json::to_vec_pretty(&json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [],
-      "numeric_fields": [],
-      "nested_fields": [],
-      "vector_fields": []
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" }
+      }
     }))?,
   )?;
 

--- a/integration/tests/contracts_core.rs
+++ b/integration/tests/contracts_core.rs
@@ -7,16 +7,11 @@ use integration::surfaces::SurfaceHarness;
 
 fn schema_json() -> serde_json::Value {
   json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [
-      { "name": "lang", "stored": true, "indexed": true, "fast": true, "nullable": false }
-    ],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": []
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "lang": { "type": "string", "searchlite:kind": "keyword" }
+    }
   })
 }
 

--- a/integration/tests/contracts_http.rs
+++ b/integration/tests/contracts_http.rs
@@ -10,14 +10,10 @@ use integration::surfaces::SurfaceHarness;
 
 fn valid_schema() -> serde_json::Value {
   json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": []
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" }
+    }
   })
 }
 

--- a/integration/tests/surface_smoke.rs
+++ b/integration/tests/surface_smoke.rs
@@ -11,14 +11,10 @@ use integration::surfaces::SurfaceHarness;
 
 fn schema_json() -> serde_json::Value {
   json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": []
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" }
+    }
   })
 }
 

--- a/searchlite-core/src/index/json_schema.rs
+++ b/searchlite-core/src/index/json_schema.rs
@@ -44,11 +44,11 @@ pub fn parse_json_schema(root: &Value) -> Result<Schema> {
     );
   }
 
-  let doc_id_field = obj
-    .get("searchlite:docIdField")
-    .and_then(|v| v.as_str())
-    .map(String::from)
-    .unwrap_or_else(default_doc_id_field);
+  let doc_id_field = match obj.get("searchlite:docIdField") {
+    Some(Value::String(s)) => s.clone(),
+    Some(_) => bail!("searchlite:docIdField must be a string"),
+    None => default_doc_id_field(),
+  };
 
   let analyzers: Vec<AnalyzerDef> = match obj.get("searchlite:analyzers") {
     Some(v) => serde_json::from_value(v.clone()).context("parsing searchlite:analyzers")?,
@@ -94,7 +94,10 @@ pub fn parse_json_schema(root: &Value) -> Result<Schema> {
         if kind.as_deref() == Some("keyword") {
           keyword_fields.push(parse_keyword_field(name, prop, nullable)?);
         } else if kind.is_some() {
-          bail!("property `{name}`: unknown searchlite:kind value `{}`", kind.unwrap());
+          bail!(
+            "property `{name}`: unknown searchlite:kind value `{}`",
+            kind.unwrap()
+          );
         } else {
           text_fields.push(parse_text_field(name, prop, nullable)?);
         }
@@ -116,6 +119,12 @@ pub fn parse_json_schema(root: &Value) -> Result<Schema> {
 
         #[cfg(feature = "vectors")]
         if prop.contains_key("searchlite:vector") {
+          let items_type = items.get("type").and_then(|v| v.as_str()).unwrap_or("");
+          if items_type != "number" {
+            bail!(
+              "property `{name}`: vector fields require items.type to be \"number\", got \"{items_type}\""
+            );
+          }
           vector_fields.push(parse_vector_field(name, prop, items)?);
           continue;
         }
@@ -299,7 +308,9 @@ fn parse_nested_properties(props: &Map<String, Value>) -> Result<Vec<NestedPrope
             kind.unwrap()
           );
         } else {
-          out.push(NestedProperty::Text(parse_text_field(name, prop, nullable)?));
+          out.push(NestedProperty::Text(parse_text_field(
+            name, prop, nullable,
+          )?));
         }
       }
       "integer" => {
@@ -330,9 +341,7 @@ fn parse_nested_properties(props: &Map<String, Value>) -> Result<Vec<NestedPrope
             name, items, nullable,
           )?));
         } else {
-          bail!(
-            "nested property `{name}`: unsupported array items type `{items_type}`"
-          );
+          bail!("nested property `{name}`: unsupported array items type `{items_type}`");
         }
       }
       other => {
@@ -387,7 +396,9 @@ fn parse_vector_field(
     .get("dim")
     .and_then(|v| v.as_u64())
     .map(|v| v as usize)
-    .ok_or_else(|| anyhow!("property `{name}`: searchlite:vector.dim is required and must be a positive integer"))?;
+    .ok_or_else(|| {
+      anyhow!("property `{name}`: searchlite:vector.dim is required and must be a positive integer")
+    })?;
 
   let metric_str = vec_obj
     .get("metric")
@@ -543,7 +554,10 @@ fn vector_field_to_json(f: &VectorField) -> Value {
     }),
   );
   if let Some(hnsw) = &f.hnsw {
-    vec_config.insert("hnsw".into(), serde_json::to_value(hnsw).unwrap_or(json!({})));
+    vec_config.insert(
+      "hnsw".into(),
+      serde_json::to_value(hnsw).unwrap_or(json!({})),
+    );
   }
 
   let mut prop = Map::new();
@@ -750,8 +764,14 @@ mod tests {
     assert_eq!(n.name, "author");
     assert_eq!(n.fields.len(), 2);
     // BTreeMap ordering: "age" < "name"
-    assert!(n.fields.iter().any(|f| matches!(f, NestedProperty::Keyword(kf) if kf.name == "name")));
-    assert!(n.fields.iter().any(|f| matches!(f, NestedProperty::Numeric(nf) if nf.name == "age")));
+    assert!(n
+      .fields
+      .iter()
+      .any(|f| matches!(f, NestedProperty::Keyword(kf) if kf.name == "name")));
+    assert!(n
+      .fields
+      .iter()
+      .any(|f| matches!(f, NestedProperty::Numeric(nf) if nf.name == "age")));
   }
 
   #[test]
@@ -877,6 +897,40 @@ mod tests {
   }
 
   #[test]
+  fn error_on_non_string_doc_id_field() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "searchlite:docIdField": 123,
+      "properties": {}
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("must be a string"),
+      "expected doc_id_field type error, got: {err}"
+    );
+  }
+
+  #[cfg(feature = "vectors")]
+  #[test]
+  fn error_on_vector_with_wrong_items_type() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "embedding": {
+          "type": "array",
+          "items": { "type": "string" },
+          "searchlite:vector": { "dim": 384, "metric": "Cosine" }
+        }
+      }
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("items.type") && err.to_string().contains("number"),
+      "expected vector items.type error, got: {err}"
+    );
+  }
+
+  #[test]
   fn error_on_old_format() {
     let err = parse_json_schema(&json!({
       "text_fields": [],
@@ -966,7 +1020,10 @@ mod tests {
     let rt = round_trip(&original);
     assert_eq!(rt.doc_id_field, "pk");
     assert_eq!(rt.text_fields[0].analyzer, "english");
-    assert_eq!(rt.text_fields[0].search_analyzer.as_deref(), Some("standard"));
+    assert_eq!(
+      rt.text_fields[0].search_analyzer.as_deref(),
+      Some("standard")
+    );
     assert!(rt.keyword_fields[0].nullable);
     assert!(!rt.keyword_fields[0].fast);
     assert!(!rt.numeric_fields[0].i64);

--- a/searchlite-core/src/index/json_schema.rs
+++ b/searchlite-core/src/index/json_schema.rs
@@ -90,7 +90,7 @@ pub fn parse_json_schema(root: &Value) -> Result<Schema> {
 
     match base_type.as_str() {
       "string" => {
-        let kind = sl_str(prop, "kind");
+        let kind = sl_str(prop, "kind")?;
         if kind.as_deref() == Some("keyword") {
           keyword_fields.push(parse_keyword_field(name, prop, nullable)?);
         } else if kind.is_some() {
@@ -209,13 +209,23 @@ pub fn schema_to_json_schema(schema: &Schema) -> Value {
 // ── Field parsers ────────────────────────────────────────────────────────────
 
 fn parse_text_field(name: &str, prop: &Map<String, Value>, nullable: bool) -> Result<TextField> {
-  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  let nullable = sl_bool(prop, "nullable")?.unwrap_or(nullable);
+  let analyzer = sl_str(prop, "analyzer")?.unwrap_or_else(|| "default".to_string());
+  if analyzer.is_empty() {
+    bail!("property `{name}`: searchlite:analyzer must not be empty");
+  }
+  let search_analyzer = sl_str(prop, "searchAnalyzer")?;
+  if let Some(ref sa) = search_analyzer {
+    if sa.is_empty() {
+      bail!("property `{name}`: searchlite:searchAnalyzer must not be empty");
+    }
+  }
   Ok(TextField {
     name: name.to_string(),
-    analyzer: sl_str(prop, "analyzer").unwrap_or_else(|| "default".to_string()),
-    search_analyzer: sl_str(prop, "searchAnalyzer"),
-    stored: sl_bool(prop, "stored").unwrap_or(true),
-    indexed: sl_bool(prop, "indexed").unwrap_or(true),
+    analyzer,
+    search_analyzer,
+    stored: sl_bool(prop, "stored")?.unwrap_or(true),
+    indexed: sl_bool(prop, "indexed")?.unwrap_or(true),
     nullable,
     search_as_you_type: parse_search_as_you_type(prop)?,
   })
@@ -226,12 +236,12 @@ fn parse_keyword_field(
   prop: &Map<String, Value>,
   nullable: bool,
 ) -> Result<KeywordField> {
-  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  let nullable = sl_bool(prop, "nullable")?.unwrap_or(nullable);
   Ok(KeywordField {
     name: name.to_string(),
-    stored: sl_bool(prop, "stored").unwrap_or(true),
-    indexed: sl_bool(prop, "indexed").unwrap_or(true),
-    fast: sl_bool(prop, "fast").unwrap_or(true),
+    stored: sl_bool(prop, "stored")?.unwrap_or(true),
+    indexed: sl_bool(prop, "indexed")?.unwrap_or(true),
+    fast: sl_bool(prop, "fast")?.unwrap_or(true),
     nullable,
   })
 }
@@ -242,12 +252,12 @@ fn parse_numeric_field(
   nullable: bool,
   is_i64: bool,
 ) -> Result<NumericField> {
-  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  let nullable = sl_bool(prop, "nullable")?.unwrap_or(nullable);
   Ok(NumericField {
     name: name.to_string(),
     i64: is_i64,
-    fast: sl_bool(prop, "fast").unwrap_or(true),
-    stored: sl_bool(prop, "stored").unwrap_or(false),
+    fast: sl_bool(prop, "fast")?.unwrap_or(true),
+    stored: sl_bool(prop, "stored")?.unwrap_or(false),
     nullable,
   })
 }
@@ -257,7 +267,7 @@ fn parse_nested_field(
   prop: &Map<String, Value>,
   nullable: bool,
 ) -> Result<NestedField> {
-  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  let nullable = sl_bool(prop, "nullable")?.unwrap_or(nullable);
   let fields = match prop.get("properties") {
     Some(Value::Object(m)) => parse_nested_properties(m)?,
     _ => Vec::new(),
@@ -297,7 +307,7 @@ fn parse_nested_properties(props: &Map<String, Value>) -> Result<Vec<NestedPrope
 
     match base_type.as_str() {
       "string" => {
-        let kind = sl_str(prop, "kind");
+        let kind = sl_str(prop, "kind")?;
         if kind.as_deref() == Some("keyword") {
           out.push(NestedProperty::Keyword(parse_keyword_field(
             name, prop, nullable,
@@ -594,19 +604,24 @@ fn resolve_type(name: &str, prop: &Map<String, Value>) -> Result<(String, bool)>
   }
 }
 
-/// Read a `searchlite:` boolean keyword.
-fn sl_bool(prop: &Map<String, Value>, key: &str) -> Option<bool> {
-  prop
-    .get(&format!("{PREFIX}{key}"))
-    .and_then(|v| v.as_bool())
+/// Read a `searchlite:` boolean keyword, rejecting wrong types.
+fn sl_bool(prop: &Map<String, Value>, key: &str) -> Result<Option<bool>> {
+  let full_key = format!("{PREFIX}{key}");
+  match prop.get(&full_key) {
+    Some(Value::Bool(b)) => Ok(Some(*b)),
+    Some(_) => bail!("`{full_key}` must be a boolean"),
+    None => Ok(None),
+  }
 }
 
-/// Read a `searchlite:` string keyword.
-fn sl_str(prop: &Map<String, Value>, key: &str) -> Option<String> {
-  prop
-    .get(&format!("{PREFIX}{key}"))
-    .and_then(|v| v.as_str())
-    .map(String::from)
+/// Read a `searchlite:` string keyword, rejecting wrong types.
+fn sl_str(prop: &Map<String, Value>, key: &str) -> Result<Option<String>> {
+  let full_key = format!("{PREFIX}{key}");
+  match prop.get(&full_key) {
+    Some(Value::String(s)) => Ok(Some(s.clone())),
+    Some(_) => bail!("`{full_key}` must be a string"),
+    None => Ok(None),
+  }
 }
 
 /// Known `searchlite:` keywords that may appear on individual properties.
@@ -927,6 +942,51 @@ mod tests {
     assert!(
       err.to_string().contains("items.type") && err.to_string().contains("number"),
       "expected vector items.type error, got: {err}"
+    );
+  }
+
+  #[test]
+  fn error_on_wrong_type_for_stored() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "x": { "type": "string", "searchlite:stored": "yes" }
+      }
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("must be a boolean"),
+      "expected type error for stored, got: {err}"
+    );
+  }
+
+  #[test]
+  fn error_on_wrong_type_for_kind() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "x": { "type": "string", "searchlite:kind": true }
+      }
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("must be a string"),
+      "expected type error for kind, got: {err}"
+    );
+  }
+
+  #[test]
+  fn error_on_empty_analyzer() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "x": { "type": "string", "searchlite:analyzer": "" }
+      }
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("must not be empty"),
+      "expected empty analyzer error, got: {err}"
     );
   }
 

--- a/searchlite-core/src/index/json_schema.rs
+++ b/searchlite-core/src/index/json_schema.rs
@@ -44,8 +44,21 @@ pub fn parse_json_schema(root: &Value) -> Result<Schema> {
     );
   }
 
+  // Enforce root `type: "object"` when present (the meta-schema requires it,
+  // so the parser should not silently accept other values).
+  match obj.get("type") {
+    Some(Value::String(s)) if s == "object" => {}
+    Some(_) => bail!("root `type` must be \"object\""),
+    None => {}
+  }
+
+  // Reject unknown root-level `searchlite:` keywords so malformed schemas
+  // surface a clear error instead of being silently ignored.
+  validate_root_searchlite_keys(obj)?;
+
   let doc_id_field = match obj.get("searchlite:docIdField") {
-    Some(Value::String(s)) => s.clone(),
+    Some(Value::String(s)) if !s.is_empty() => s.clone(),
+    Some(Value::String(_)) => bail!("searchlite:docIdField must be a non-empty string"),
     Some(_) => bail!("searchlite:docIdField must be a string"),
     None => default_doc_id_field(),
   };
@@ -637,11 +650,24 @@ const KNOWN_PROPERTY_KEYS: &[&str] = &[
   "searchlite:vector",
 ];
 
+/// Known `searchlite:` keywords that may appear at the root of a schema.
+const KNOWN_ROOT_KEYS: &[&str] = &["searchlite:docIdField", "searchlite:analyzers"];
+
 /// Validate that all `searchlite:` keys on a property are known.
 fn validate_searchlite_keys(name: &str, prop: &Map<String, Value>) -> Result<()> {
   for key in prop.keys() {
     if key.starts_with(PREFIX) && !KNOWN_PROPERTY_KEYS.contains(&key.as_str()) {
       bail!("property `{name}`: unknown keyword `{key}`");
+    }
+  }
+  Ok(())
+}
+
+/// Validate that all `searchlite:` keys at the root of the schema are known.
+fn validate_root_searchlite_keys(obj: &Map<String, Value>) -> Result<()> {
+  for key in obj.keys() {
+    if key.starts_with(PREFIX) && !KNOWN_ROOT_KEYS.contains(&key.as_str()) {
+      bail!("unknown root-level keyword `{key}`");
     }
   }
   Ok(())
@@ -1011,6 +1037,47 @@ mod tests {
     }))
     .unwrap_err();
     assert!(err.to_string().contains("unknown keyword"));
+  }
+
+  #[test]
+  fn error_on_unknown_root_searchlite_key() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "searchlite:bogus": true,
+      "properties": {}
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("unknown root-level keyword"),
+      "expected unknown root-level keyword error, got: {err}"
+    );
+  }
+
+  #[test]
+  fn error_on_wrong_root_type() {
+    let err = parse_json_schema(&json!({
+      "type": "array",
+      "properties": {}
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("root `type` must be \"object\""),
+      "expected root type error, got: {err}"
+    );
+  }
+
+  #[test]
+  fn error_on_empty_doc_id_field() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "searchlite:docIdField": "",
+      "properties": {}
+    }))
+    .unwrap_err();
+    assert!(
+      err.to_string().contains("non-empty string"),
+      "expected empty doc_id_field error, got: {err}"
+    );
   }
 
   #[test]

--- a/searchlite-core/src/index/json_schema.rs
+++ b/searchlite-core/src/index/json_schema.rs
@@ -1,0 +1,1079 @@
+//! Conversion between JSON Schema (with `searchlite:` vocabulary) and the
+//! internal [`Schema`] representation.
+//!
+//! The user-facing schema format is standard JSON Schema 2020-12 annotated with
+//! `searchlite:` prefixed keywords that configure search-engine behaviour.  The
+//! internal representation keeps flat, type-specific arrays for engine
+//! efficiency.
+
+use anyhow::{anyhow, bail, Context, Result};
+use serde_json::{json, Map, Value};
+
+use super::manifest::{
+  default_doc_id_field, KeywordField, NestedField, NestedProperty, NumericField, Schema,
+  SearchAsYouType, TextField,
+};
+use crate::analysis::analyzer::AnalyzerDef;
+
+#[cfg(feature = "vectors")]
+use super::manifest::{VectorField, VectorMetric};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const META_SCHEMA: &str = "https://searchlite.dev/draft/2025/schema";
+const PREFIX: &str = "searchlite:";
+
+// ── Parsing (JSON Schema → internal Schema) ──────────────────────────────────
+
+/// Parse a JSON Schema document with `searchlite:` vocabulary into an internal
+/// [`Schema`].
+pub fn parse_json_schema(root: &Value) -> Result<Schema> {
+  let obj = root
+    .as_object()
+    .ok_or_else(|| anyhow!("schema must be a JSON object"))?;
+
+  // Reject old-format schemas with a helpful message.
+  if obj.contains_key("text_fields")
+    || obj.contains_key("keyword_fields")
+    || obj.contains_key("numeric_fields")
+  {
+    bail!(
+      "this appears to be a legacy field-array schema (text_fields/keyword_fields/numeric_fields). \
+       Searchlite now uses JSON Schema with `searchlite:` vocabulary keywords. \
+       See https://searchlite.dev/docs/schema for the new format."
+    );
+  }
+
+  let doc_id_field = obj
+    .get("searchlite:docIdField")
+    .and_then(|v| v.as_str())
+    .map(String::from)
+    .unwrap_or_else(default_doc_id_field);
+
+  let analyzers: Vec<AnalyzerDef> = match obj.get("searchlite:analyzers") {
+    Some(v) => serde_json::from_value(v.clone()).context("parsing searchlite:analyzers")?,
+    None => Vec::new(),
+  };
+
+  let props = match obj.get("properties") {
+    Some(Value::Object(m)) => m,
+    Some(_) => bail!("`properties` must be a JSON object"),
+    None => {
+      return Ok(Schema {
+        doc_id_field,
+        analyzers,
+        text_fields: Vec::new(),
+        keyword_fields: Vec::new(),
+        numeric_fields: Vec::new(),
+        nested_fields: Vec::new(),
+        #[cfg(feature = "vectors")]
+        vector_fields: Vec::new(),
+      });
+    }
+  };
+
+  let mut text_fields = Vec::new();
+  let mut keyword_fields = Vec::new();
+  let mut numeric_fields = Vec::new();
+  let mut nested_fields = Vec::new();
+  #[cfg(feature = "vectors")]
+  let mut vector_fields = Vec::new();
+
+  for (name, prop_val) in props {
+    let prop = prop_val
+      .as_object()
+      .ok_or_else(|| anyhow!("property `{name}` must be a JSON object"))?;
+
+    validate_searchlite_keys(name, prop)?;
+
+    let (base_type, nullable) = resolve_type(name, prop)?;
+
+    match base_type.as_str() {
+      "string" => {
+        let kind = sl_str(prop, "kind");
+        if kind.as_deref() == Some("keyword") {
+          keyword_fields.push(parse_keyword_field(name, prop, nullable)?);
+        } else if kind.is_some() {
+          bail!("property `{name}`: unknown searchlite:kind value `{}`", kind.unwrap());
+        } else {
+          text_fields.push(parse_text_field(name, prop, nullable)?);
+        }
+      }
+      "integer" => {
+        numeric_fields.push(parse_numeric_field(name, prop, nullable, true)?);
+      }
+      "number" => {
+        numeric_fields.push(parse_numeric_field(name, prop, nullable, false)?);
+      }
+      "object" => {
+        nested_fields.push(parse_nested_field(name, prop, nullable)?);
+      }
+      "array" => {
+        let items = prop
+          .get("items")
+          .and_then(|v| v.as_object())
+          .ok_or_else(|| anyhow!("property `{name}`: array type requires an `items` object"))?;
+
+        #[cfg(feature = "vectors")]
+        if prop.contains_key("searchlite:vector") {
+          vector_fields.push(parse_vector_field(name, prop, items)?);
+          continue;
+        }
+        #[cfg(not(feature = "vectors"))]
+        if prop.contains_key("searchlite:vector") {
+          bail!("property `{name}`: vector fields require the `vectors` feature flag");
+        }
+
+        let items_type = items.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if items_type == "object" {
+          nested_fields.push(parse_nested_from_array(name, items, nullable)?);
+        } else {
+          bail!(
+            "property `{name}`: unsupported array items type `{items_type}`. \
+             Arrays must contain objects (nested fields) or numbers with searchlite:vector."
+          );
+        }
+      }
+      other => {
+        bail!("property `{name}`: unsupported JSON Schema type `{other}`");
+      }
+    }
+  }
+
+  Ok(Schema {
+    doc_id_field,
+    analyzers,
+    text_fields,
+    keyword_fields,
+    numeric_fields,
+    nested_fields,
+    #[cfg(feature = "vectors")]
+    vector_fields,
+  })
+}
+
+// ── Serialization (internal Schema → JSON Schema) ────────────────────────────
+
+/// Serialize an internal [`Schema`] to JSON Schema with `searchlite:` vocabulary.
+pub fn schema_to_json_schema(schema: &Schema) -> Value {
+  let mut root = Map::new();
+  root.insert("$schema".into(), json!(META_SCHEMA));
+  root.insert("type".into(), json!("object"));
+
+  if schema.doc_id_field != "_id" {
+    root.insert("searchlite:docIdField".into(), json!(schema.doc_id_field));
+  }
+
+  if !schema.analyzers.is_empty() {
+    root.insert(
+      "searchlite:analyzers".into(),
+      serde_json::to_value(&schema.analyzers).unwrap_or(json!([])),
+    );
+  }
+
+  let mut properties = Map::new();
+
+  for f in &schema.text_fields {
+    properties.insert(f.name.clone(), text_field_to_json(f));
+  }
+  for f in &schema.keyword_fields {
+    properties.insert(f.name.clone(), keyword_field_to_json(f));
+  }
+  for f in &schema.numeric_fields {
+    properties.insert(f.name.clone(), numeric_field_to_json(f));
+  }
+  for f in &schema.nested_fields {
+    properties.insert(f.name.clone(), nested_field_to_json(f));
+  }
+  #[cfg(feature = "vectors")]
+  for f in &schema.vector_fields {
+    properties.insert(f.name.clone(), vector_field_to_json(f));
+  }
+
+  if !properties.is_empty() {
+    root.insert("properties".into(), Value::Object(properties));
+  }
+
+  Value::Object(root)
+}
+
+// ── Field parsers ────────────────────────────────────────────────────────────
+
+fn parse_text_field(name: &str, prop: &Map<String, Value>, nullable: bool) -> Result<TextField> {
+  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  Ok(TextField {
+    name: name.to_string(),
+    analyzer: sl_str(prop, "analyzer").unwrap_or_else(|| "default".to_string()),
+    search_analyzer: sl_str(prop, "searchAnalyzer"),
+    stored: sl_bool(prop, "stored").unwrap_or(true),
+    indexed: sl_bool(prop, "indexed").unwrap_or(true),
+    nullable,
+    search_as_you_type: parse_search_as_you_type(prop)?,
+  })
+}
+
+fn parse_keyword_field(
+  name: &str,
+  prop: &Map<String, Value>,
+  nullable: bool,
+) -> Result<KeywordField> {
+  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  Ok(KeywordField {
+    name: name.to_string(),
+    stored: sl_bool(prop, "stored").unwrap_or(true),
+    indexed: sl_bool(prop, "indexed").unwrap_or(true),
+    fast: sl_bool(prop, "fast").unwrap_or(true),
+    nullable,
+  })
+}
+
+fn parse_numeric_field(
+  name: &str,
+  prop: &Map<String, Value>,
+  nullable: bool,
+  is_i64: bool,
+) -> Result<NumericField> {
+  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  Ok(NumericField {
+    name: name.to_string(),
+    i64: is_i64,
+    fast: sl_bool(prop, "fast").unwrap_or(true),
+    stored: sl_bool(prop, "stored").unwrap_or(false),
+    nullable,
+  })
+}
+
+fn parse_nested_field(
+  name: &str,
+  prop: &Map<String, Value>,
+  nullable: bool,
+) -> Result<NestedField> {
+  let nullable = sl_bool(prop, "nullable").unwrap_or(nullable);
+  let fields = match prop.get("properties") {
+    Some(Value::Object(m)) => parse_nested_properties(m)?,
+    _ => Vec::new(),
+  };
+  Ok(NestedField {
+    name: name.to_string(),
+    fields,
+    nullable,
+  })
+}
+
+fn parse_nested_from_array(
+  name: &str,
+  items: &Map<String, Value>,
+  nullable: bool,
+) -> Result<NestedField> {
+  let fields = match items.get("properties") {
+    Some(Value::Object(m)) => parse_nested_properties(m)?,
+    _ => Vec::new(),
+  };
+  Ok(NestedField {
+    name: name.to_string(),
+    fields,
+    nullable,
+  })
+}
+
+fn parse_nested_properties(props: &Map<String, Value>) -> Result<Vec<NestedProperty>> {
+  let mut out = Vec::new();
+  for (name, val) in props {
+    let prop = val
+      .as_object()
+      .ok_or_else(|| anyhow!("nested property `{name}` must be a JSON object"))?;
+
+    validate_searchlite_keys(name, prop)?;
+    let (base_type, nullable) = resolve_type(name, prop)?;
+
+    match base_type.as_str() {
+      "string" => {
+        let kind = sl_str(prop, "kind");
+        if kind.as_deref() == Some("keyword") {
+          out.push(NestedProperty::Keyword(parse_keyword_field(
+            name, prop, nullable,
+          )?));
+        } else if kind.is_some() {
+          bail!(
+            "nested property `{name}`: unknown searchlite:kind value `{}`",
+            kind.unwrap()
+          );
+        } else {
+          out.push(NestedProperty::Text(parse_text_field(name, prop, nullable)?));
+        }
+      }
+      "integer" => {
+        out.push(NestedProperty::Numeric(parse_numeric_field(
+          name, prop, nullable, true,
+        )?));
+      }
+      "number" => {
+        out.push(NestedProperty::Numeric(parse_numeric_field(
+          name, prop, nullable, false,
+        )?));
+      }
+      "object" => {
+        out.push(NestedProperty::Object(parse_nested_field(
+          name, prop, nullable,
+        )?));
+      }
+      "array" => {
+        let items = prop
+          .get("items")
+          .and_then(|v| v.as_object())
+          .ok_or_else(|| {
+            anyhow!("nested property `{name}`: array type requires an `items` object")
+          })?;
+        let items_type = items.get("type").and_then(|v| v.as_str()).unwrap_or("");
+        if items_type == "object" {
+          out.push(NestedProperty::Object(parse_nested_from_array(
+            name, items, nullable,
+          )?));
+        } else {
+          bail!(
+            "nested property `{name}`: unsupported array items type `{items_type}`"
+          );
+        }
+      }
+      other => {
+        bail!("nested property `{name}`: unsupported type `{other}`");
+      }
+    }
+  }
+  Ok(out)
+}
+
+fn parse_search_as_you_type(prop: &Map<String, Value>) -> Result<Option<SearchAsYouType>> {
+  let val = match prop.get("searchlite:searchAsYouType") {
+    Some(v) => v,
+    None => return Ok(None),
+  };
+  let obj = val
+    .as_object()
+    .ok_or_else(|| anyhow!("searchlite:searchAsYouType must be an object"))?;
+  let min_gram = obj
+    .get("minGram")
+    .and_then(|v| v.as_u64())
+    .map(|v| v as usize)
+    .unwrap_or(1);
+  let max_gram = obj
+    .get("maxGram")
+    .and_then(|v| v.as_u64())
+    .map(|v| v as usize)
+    .unwrap_or(15);
+  if min_gram == 0 || max_gram == 0 {
+    bail!("searchlite:searchAsYouType: minGram and maxGram must be > 0");
+  }
+  if min_gram > max_gram {
+    bail!("searchlite:searchAsYouType: minGram must be <= maxGram");
+  }
+  Ok(Some(SearchAsYouType { min_gram, max_gram }))
+}
+
+#[cfg(feature = "vectors")]
+fn parse_vector_field(
+  name: &str,
+  prop: &Map<String, Value>,
+  _items: &Map<String, Value>,
+) -> Result<VectorField> {
+  let vec_val = prop
+    .get("searchlite:vector")
+    .ok_or_else(|| anyhow!("property `{name}`: missing searchlite:vector"))?;
+  let vec_obj = vec_val
+    .as_object()
+    .ok_or_else(|| anyhow!("property `{name}`: searchlite:vector must be an object"))?;
+
+  let dim = vec_obj
+    .get("dim")
+    .and_then(|v| v.as_u64())
+    .map(|v| v as usize)
+    .ok_or_else(|| anyhow!("property `{name}`: searchlite:vector.dim is required and must be a positive integer"))?;
+
+  let metric_str = vec_obj
+    .get("metric")
+    .and_then(|v| v.as_str())
+    .ok_or_else(|| anyhow!("property `{name}`: searchlite:vector.metric is required"))?;
+  let metric = match metric_str {
+    "Cosine" => VectorMetric::Cosine,
+    "L2" => VectorMetric::L2,
+    other => bail!("property `{name}`: unknown vector metric `{other}` (expected Cosine or L2)"),
+  };
+
+  let hnsw = match vec_obj.get("hnsw") {
+    Some(v) => Some(
+      serde_json::from_value(v.clone())
+        .context(format!("property `{name}`: parsing searchlite:vector.hnsw"))?,
+    ),
+    None => None,
+  };
+
+  Ok(VectorField {
+    name: name.to_string(),
+    dim,
+    metric,
+    hnsw,
+  })
+}
+
+// ── Field serializers ────────────────────────────────────────────────────────
+
+fn text_field_to_json(f: &TextField) -> Value {
+  let mut prop = Map::new();
+  let type_val = if f.nullable {
+    json!(["string", "null"])
+  } else {
+    json!("string")
+  };
+  prop.insert("type".into(), type_val);
+
+  if f.analyzer != "default" {
+    prop.insert("searchlite:analyzer".into(), json!(f.analyzer));
+  }
+  if let Some(sa) = &f.search_analyzer {
+    prop.insert("searchlite:searchAnalyzer".into(), json!(sa));
+  }
+  // Omit stored/indexed when they match text defaults (true/true).
+  if !f.stored {
+    prop.insert("searchlite:stored".into(), json!(false));
+  }
+  if !f.indexed {
+    prop.insert("searchlite:indexed".into(), json!(false));
+  }
+  if let Some(saty) = &f.search_as_you_type {
+    let mut saty_obj = Map::new();
+    if saty.min_gram != 1 {
+      saty_obj.insert("minGram".into(), json!(saty.min_gram));
+    }
+    if saty.max_gram != 15 {
+      saty_obj.insert("maxGram".into(), json!(saty.max_gram));
+    }
+    prop.insert("searchlite:searchAsYouType".into(), Value::Object(saty_obj));
+  }
+  Value::Object(prop)
+}
+
+fn keyword_field_to_json(f: &KeywordField) -> Value {
+  let mut prop = Map::new();
+  let type_val = if f.nullable {
+    json!(["string", "null"])
+  } else {
+    json!("string")
+  };
+  prop.insert("type".into(), type_val);
+  prop.insert("searchlite:kind".into(), json!("keyword"));
+
+  // Omit when matching keyword defaults (true/true/true).
+  if !f.stored {
+    prop.insert("searchlite:stored".into(), json!(false));
+  }
+  if !f.indexed {
+    prop.insert("searchlite:indexed".into(), json!(false));
+  }
+  if !f.fast {
+    prop.insert("searchlite:fast".into(), json!(false));
+  }
+  Value::Object(prop)
+}
+
+fn numeric_field_to_json(f: &NumericField) -> Value {
+  let mut prop = Map::new();
+  let base_type = if f.i64 { "integer" } else { "number" };
+  let type_val = if f.nullable {
+    json!([base_type, "null"])
+  } else {
+    json!(base_type)
+  };
+  prop.insert("type".into(), type_val);
+
+  // Omit when matching numeric defaults (fast: true, stored: false).
+  if !f.fast {
+    prop.insert("searchlite:fast".into(), json!(false));
+  }
+  if f.stored {
+    prop.insert("searchlite:stored".into(), json!(true));
+  }
+  Value::Object(prop)
+}
+
+fn nested_field_to_json(f: &NestedField) -> Value {
+  let mut items = Map::new();
+  items.insert("type".into(), json!("object"));
+
+  if !f.fields.is_empty() {
+    let mut properties = Map::new();
+    for child in &f.fields {
+      match child {
+        NestedProperty::Text(tf) => {
+          properties.insert(tf.name.clone(), text_field_to_json(tf));
+        }
+        NestedProperty::Keyword(kf) => {
+          properties.insert(kf.name.clone(), keyword_field_to_json(kf));
+        }
+        NestedProperty::Numeric(nf) => {
+          properties.insert(nf.name.clone(), numeric_field_to_json(nf));
+        }
+        NestedProperty::Object(nested) => {
+          properties.insert(nested.name.clone(), nested_field_to_json(nested));
+        }
+      }
+    }
+    items.insert("properties".into(), Value::Object(properties));
+  }
+
+  let mut prop = Map::new();
+  let type_val = if f.nullable {
+    json!(["array", "null"])
+  } else {
+    json!("array")
+  };
+  prop.insert("type".into(), type_val);
+  prop.insert("items".into(), Value::Object(items));
+  Value::Object(prop)
+}
+
+#[cfg(feature = "vectors")]
+fn vector_field_to_json(f: &VectorField) -> Value {
+  let mut vec_config = Map::new();
+  vec_config.insert("dim".into(), json!(f.dim));
+  vec_config.insert(
+    "metric".into(),
+    json!(match f.metric {
+      VectorMetric::Cosine => "Cosine",
+      VectorMetric::L2 => "L2",
+    }),
+  );
+  if let Some(hnsw) = &f.hnsw {
+    vec_config.insert("hnsw".into(), serde_json::to_value(hnsw).unwrap_or(json!({})));
+  }
+
+  let mut prop = Map::new();
+  prop.insert("type".into(), json!("array"));
+  prop.insert("items".into(), json!({"type": "number"}));
+  prop.insert("searchlite:vector".into(), Value::Object(vec_config));
+  Value::Object(prop)
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Extract the base type and nullable flag from a property's `type` field.
+///
+/// Supports `"type": "string"` and `"type": ["string", "null"]`.
+fn resolve_type(name: &str, prop: &Map<String, Value>) -> Result<(String, bool)> {
+  let type_val = prop
+    .get("type")
+    .ok_or_else(|| anyhow!("property `{name}` is missing a `type` field"))?;
+
+  match type_val {
+    Value::String(s) => Ok((s.clone(), false)),
+    Value::Array(arr) => {
+      let types: Vec<&str> = arr.iter().filter_map(|v| v.as_str()).collect();
+      let nullable = types.contains(&"null");
+      let base: Vec<&&str> = types.iter().filter(|t| **t != "null").collect();
+      if base.len() != 1 {
+        bail!(
+          "property `{name}`: `type` array must contain exactly one base type plus optional \"null\""
+        );
+      }
+      Ok((base[0].to_string(), nullable))
+    }
+    _ => bail!("property `{name}`: `type` must be a string or array"),
+  }
+}
+
+/// Read a `searchlite:` boolean keyword.
+fn sl_bool(prop: &Map<String, Value>, key: &str) -> Option<bool> {
+  prop
+    .get(&format!("{PREFIX}{key}"))
+    .and_then(|v| v.as_bool())
+}
+
+/// Read a `searchlite:` string keyword.
+fn sl_str(prop: &Map<String, Value>, key: &str) -> Option<String> {
+  prop
+    .get(&format!("{PREFIX}{key}"))
+    .and_then(|v| v.as_str())
+    .map(String::from)
+}
+
+/// Known `searchlite:` keywords that may appear on individual properties.
+const KNOWN_PROPERTY_KEYS: &[&str] = &[
+  "searchlite:kind",
+  "searchlite:stored",
+  "searchlite:indexed",
+  "searchlite:fast",
+  "searchlite:analyzer",
+  "searchlite:searchAnalyzer",
+  "searchlite:searchAsYouType",
+  "searchlite:nullable",
+  "searchlite:vector",
+];
+
+/// Validate that all `searchlite:` keys on a property are known.
+fn validate_searchlite_keys(name: &str, prop: &Map<String, Value>) -> Result<()> {
+  for key in prop.keys() {
+    if key.starts_with(PREFIX) && !KNOWN_PROPERTY_KEYS.contains(&key.as_str()) {
+      bail!("property `{name}`: unknown keyword `{key}`");
+    }
+  }
+  Ok(())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use serde_json::json;
+
+  fn round_trip(schema: &Schema) -> Schema {
+    let json_val = schema_to_json_schema(schema);
+    parse_json_schema(&json_val).expect("round-trip parse failed")
+  }
+
+  #[test]
+  fn text_field_defaults() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "title": { "type": "string" }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.text_fields.len(), 1);
+    let f = &schema.text_fields[0];
+    assert_eq!(f.name, "title");
+    assert_eq!(f.analyzer, "default");
+    assert!(f.stored);
+    assert!(f.indexed);
+    assert!(!f.nullable);
+    assert!(f.search_analyzer.is_none());
+    assert!(f.search_as_you_type.is_none());
+  }
+
+  #[test]
+  fn keyword_inference() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "tag": { "type": "string", "searchlite:kind": "keyword" }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.keyword_fields.len(), 1);
+    let f = &schema.keyword_fields[0];
+    assert_eq!(f.name, "tag");
+    assert!(f.stored);
+    assert!(f.indexed);
+    assert!(f.fast);
+    assert!(!f.nullable);
+  }
+
+  #[test]
+  fn integer_type() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "count": { "type": "integer" }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.numeric_fields.len(), 1);
+    let f = &schema.numeric_fields[0];
+    assert_eq!(f.name, "count");
+    assert!(f.i64);
+    assert!(f.fast);
+    assert!(!f.stored);
+    assert!(!f.nullable);
+  }
+
+  #[test]
+  fn number_type() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "price": { "type": "number" }
+      }
+    }))
+    .unwrap();
+
+    let f = &schema.numeric_fields[0];
+    assert!(!f.i64);
+  }
+
+  #[test]
+  fn nullable_via_type_array() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "bio": { "type": ["string", "null"] }
+      }
+    }))
+    .unwrap();
+
+    assert!(schema.text_fields[0].nullable);
+  }
+
+  #[test]
+  fn nullable_via_keyword() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "bio": { "type": "string", "searchlite:nullable": true }
+      }
+    }))
+    .unwrap();
+
+    assert!(schema.text_fields[0].nullable);
+  }
+
+  #[test]
+  fn nested_from_object_properties() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "author": {
+          "type": "object",
+          "properties": {
+            "name": { "type": "string", "searchlite:kind": "keyword" },
+            "age": { "type": "integer" }
+          }
+        }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.nested_fields.len(), 1);
+    let n = &schema.nested_fields[0];
+    assert_eq!(n.name, "author");
+    assert_eq!(n.fields.len(), 2);
+    // BTreeMap ordering: "age" < "name"
+    assert!(n.fields.iter().any(|f| matches!(f, NestedProperty::Keyword(kf) if kf.name == "name")));
+    assert!(n.fields.iter().any(|f| matches!(f, NestedProperty::Numeric(nf) if nf.name == "age")));
+  }
+
+  #[test]
+  fn nested_from_array_of_objects() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": { "type": "string", "searchlite:kind": "keyword" }
+            }
+          }
+        }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.nested_fields.len(), 1);
+    assert_eq!(schema.nested_fields[0].name, "tags");
+    assert_eq!(schema.nested_fields[0].fields.len(), 1);
+  }
+
+  #[test]
+  fn custom_text_field_overrides() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "body": {
+          "type": "string",
+          "searchlite:analyzer": "english",
+          "searchlite:searchAnalyzer": "standard",
+          "searchlite:stored": false,
+          "searchlite:indexed": true
+        }
+      }
+    }))
+    .unwrap();
+
+    let f = &schema.text_fields[0];
+    assert_eq!(f.analyzer, "english");
+    assert_eq!(f.search_analyzer.as_deref(), Some("standard"));
+    assert!(!f.stored);
+    assert!(f.indexed);
+  }
+
+  #[test]
+  fn custom_keyword_overrides() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "status": {
+          "type": "string",
+          "searchlite:kind": "keyword",
+          "searchlite:fast": false,
+          "searchlite:stored": false
+        }
+      }
+    }))
+    .unwrap();
+
+    let f = &schema.keyword_fields[0];
+    assert!(!f.fast);
+    assert!(!f.stored);
+  }
+
+  #[test]
+  fn search_as_you_type() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string",
+          "searchlite:searchAsYouType": { "minGram": 2, "maxGram": 10 }
+        }
+      }
+    }))
+    .unwrap();
+
+    let saty = schema.text_fields[0].search_as_you_type.as_ref().unwrap();
+    assert_eq!(saty.min_gram, 2);
+    assert_eq!(saty.max_gram, 10);
+  }
+
+  #[test]
+  fn doc_id_field_default() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {}
+    }))
+    .unwrap();
+    assert_eq!(schema.doc_id_field, "_id");
+  }
+
+  #[test]
+  fn doc_id_field_custom() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "searchlite:docIdField": "pk",
+      "properties": {}
+    }))
+    .unwrap();
+    assert_eq!(schema.doc_id_field, "pk");
+  }
+
+  #[test]
+  fn analyzers_pass_through() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "searchlite:analyzers": [
+        { "name": "english", "tokenizer": "default", "filters": [{"stemmer": "english"}] }
+      ],
+      "properties": {
+        "body": { "type": "string", "searchlite:analyzer": "english" }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.analyzers.len(), 1);
+    assert_eq!(schema.analyzers[0].name, "english");
+  }
+
+  #[test]
+  fn error_on_old_format() {
+    let err = parse_json_schema(&json!({
+      "text_fields": [],
+      "keyword_fields": [],
+      "numeric_fields": []
+    }))
+    .unwrap_err();
+    assert!(err.to_string().contains("legacy field-array schema"));
+  }
+
+  #[test]
+  fn error_on_unknown_searchlite_key() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "x": { "type": "string", "searchlite:bogus": true }
+      }
+    }))
+    .unwrap_err();
+    assert!(err.to_string().contains("unknown keyword"));
+  }
+
+  #[test]
+  fn round_trip_text_body() {
+    let original = Schema::default_text_body();
+    let rt = round_trip(&original);
+    assert_eq!(rt.doc_id_field, original.doc_id_field);
+    assert_eq!(rt.text_fields.len(), original.text_fields.len());
+    assert_eq!(rt.text_fields[0].name, "body");
+    assert_eq!(rt.text_fields[0].analyzer, "default");
+    assert_eq!(rt.text_fields[0].stored, original.text_fields[0].stored);
+    assert_eq!(rt.text_fields[0].indexed, original.text_fields[0].indexed);
+  }
+
+  #[test]
+  fn round_trip_mixed_fields() {
+    let original = Schema {
+      doc_id_field: "pk".to_string(),
+      analyzers: Vec::new(),
+      text_fields: vec![TextField {
+        name: "body".into(),
+        analyzer: "english".into(),
+        search_analyzer: Some("standard".into()),
+        stored: true,
+        indexed: true,
+        nullable: false,
+        search_as_you_type: None,
+      }],
+      keyword_fields: vec![KeywordField {
+        name: "tag".into(),
+        stored: true,
+        indexed: true,
+        fast: false,
+        nullable: true,
+      }],
+      numeric_fields: vec![NumericField {
+        name: "score".into(),
+        i64: false,
+        fast: true,
+        stored: true,
+        nullable: false,
+      }],
+      nested_fields: vec![NestedField {
+        name: "comments".into(),
+        fields: vec![
+          NestedProperty::Keyword(KeywordField {
+            name: "author".into(),
+            stored: true,
+            indexed: true,
+            fast: true,
+            nullable: false,
+          }),
+          NestedProperty::Numeric(NumericField {
+            name: "rating".into(),
+            i64: true,
+            fast: true,
+            stored: true,
+            nullable: false,
+          }),
+        ],
+        nullable: false,
+      }],
+      #[cfg(feature = "vectors")]
+      vector_fields: Vec::new(),
+    };
+
+    let rt = round_trip(&original);
+    assert_eq!(rt.doc_id_field, "pk");
+    assert_eq!(rt.text_fields[0].analyzer, "english");
+    assert_eq!(rt.text_fields[0].search_analyzer.as_deref(), Some("standard"));
+    assert!(rt.keyword_fields[0].nullable);
+    assert!(!rt.keyword_fields[0].fast);
+    assert!(!rt.numeric_fields[0].i64);
+    assert!(rt.numeric_fields[0].stored);
+    assert_eq!(rt.nested_fields[0].fields.len(), 2);
+  }
+
+  #[test]
+  fn serialization_omits_defaults() {
+    let schema = Schema {
+      doc_id_field: "_id".to_string(),
+      analyzers: Vec::new(),
+      text_fields: vec![TextField {
+        name: "body".into(),
+        analyzer: "default".into(),
+        search_analyzer: None,
+        stored: true,
+        indexed: true,
+        nullable: false,
+        search_as_you_type: None,
+      }],
+      keyword_fields: Vec::new(),
+      numeric_fields: Vec::new(),
+      nested_fields: Vec::new(),
+      #[cfg(feature = "vectors")]
+      vector_fields: Vec::new(),
+    };
+
+    let val = schema_to_json_schema(&schema);
+    let root = val.as_object().unwrap();
+    // doc_id_field is default, so omitted
+    assert!(!root.contains_key("searchlite:docIdField"));
+    // analyzers is empty, so omitted
+    assert!(!root.contains_key("searchlite:analyzers"));
+
+    let body = root["properties"]["body"].as_object().unwrap();
+    // analyzer is default, so omitted
+    assert!(!body.contains_key("searchlite:analyzer"));
+    // stored=true is default for text, so omitted
+    assert!(!body.contains_key("searchlite:stored"));
+    // indexed=true is default for text, so omitted
+    assert!(!body.contains_key("searchlite:indexed"));
+  }
+
+  #[cfg(feature = "vectors")]
+  #[test]
+  fn vector_field_round_trip() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "embedding": {
+          "type": "array",
+          "items": { "type": "number" },
+          "searchlite:vector": {
+            "dim": 384,
+            "metric": "Cosine"
+          }
+        }
+      }
+    }))
+    .unwrap();
+
+    assert_eq!(schema.vector_fields.len(), 1);
+    let vf = &schema.vector_fields[0];
+    assert_eq!(vf.name, "embedding");
+    assert_eq!(vf.dim, 384);
+    assert!(matches!(vf.metric, VectorMetric::Cosine));
+
+    let rt = round_trip(&schema);
+    assert_eq!(rt.vector_fields.len(), 1);
+    assert_eq!(rt.vector_fields[0].dim, 384);
+  }
+
+  #[cfg(feature = "vectors")]
+  #[test]
+  fn vector_field_missing_dim() {
+    let err = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {
+        "embedding": {
+          "type": "array",
+          "items": { "type": "number" },
+          "searchlite:vector": { "metric": "Cosine" }
+        }
+      }
+    }))
+    .unwrap_err();
+    assert!(err.to_string().contains("dim"));
+  }
+
+  #[test]
+  fn empty_properties_is_valid() {
+    let schema = parse_json_schema(&json!({
+      "type": "object",
+      "properties": {}
+    }))
+    .unwrap();
+    assert!(schema.text_fields.is_empty());
+    assert!(schema.keyword_fields.is_empty());
+  }
+
+  #[test]
+  fn no_properties_key_is_valid() {
+    let schema = parse_json_schema(&json!({
+      "type": "object"
+    }))
+    .unwrap();
+    assert!(schema.text_fields.is_empty());
+  }
+}

--- a/searchlite-core/src/index/manifest.rs
+++ b/searchlite-core/src/index/manifest.rs
@@ -85,19 +85,36 @@ impl Manifest {
   }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct Schema {
-  #[serde(default = "default_doc_id_field")]
   pub doc_id_field: String,
-  #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub analyzers: Vec<AnalyzerDef>,
   pub text_fields: Vec<TextField>,
   pub keyword_fields: Vec<KeywordField>,
   pub numeric_fields: Vec<NumericField>,
-  #[serde(default)]
   pub nested_fields: Vec<NestedField>,
   #[cfg(feature = "vectors")]
   pub vector_fields: Vec<VectorField>,
+}
+
+impl Serialize for Schema {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    let json_value = super::json_schema::schema_to_json_schema(self);
+    json_value.serialize(serializer)
+  }
+}
+
+impl<'de> Deserialize<'de> for Schema {
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: serde::Deserializer<'de>,
+  {
+    let value = serde_json::Value::deserialize(deserializer)?;
+    super::json_schema::parse_json_schema(&value).map_err(serde::de::Error::custom)
+  }
 }
 
 pub fn default_doc_id_field() -> String {
@@ -818,115 +835,6 @@ pub struct TextField {
   pub search_as_you_type: Option<SearchAsYouType>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
-struct TextFieldSerde {
-  pub name: String,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub tokenizer: Option<String>,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub analyzer: Option<String>,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub search_analyzer: Option<String>,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub search_tokenizer: Option<String>,
-  pub stored: bool,
-  pub indexed: bool,
-  #[serde(default)]
-  pub nullable: bool,
-  #[serde(default, skip_serializing_if = "Option::is_none")]
-  pub search_as_you_type: Option<SearchAsYouType>,
-}
-
-impl From<TextField> for TextFieldSerde {
-  fn from(value: TextField) -> Self {
-    Self {
-      name: value.name,
-      tokenizer: Some(value.analyzer),
-      analyzer: None,
-      search_analyzer: value.search_analyzer,
-      search_tokenizer: None,
-      stored: value.stored,
-      indexed: value.indexed,
-      nullable: value.nullable,
-      search_as_you_type: value.search_as_you_type,
-    }
-  }
-}
-
-impl TryFrom<TextFieldSerde> for TextField {
-  type Error = serde::de::value::Error;
-
-  fn try_from(value: TextFieldSerde) -> Result<Self, Self::Error> {
-    let primary = match (value.analyzer, value.tokenizer) {
-      (Some(a), None) => a,
-      (None, Some(t)) => t,
-      (Some(_), Some(_)) => {
-        return Err(serde::de::Error::custom(
-          "text field cannot set both `tokenizer` and `analyzer`",
-        ));
-      }
-      (None, None) => {
-        if value.search_as_you_type.is_some() {
-          "default".to_string()
-        } else {
-          return Err(serde::de::Error::custom(
-            "text field must set `analyzer` (or `tokenizer` as an alias)",
-          ));
-        }
-      }
-    };
-    let search_analyzer = match (value.search_analyzer, value.search_tokenizer) {
-      (Some(a), None) => Some(a),
-      (None, Some(t)) => Some(t),
-      (Some(_), Some(_)) => {
-        return Err(serde::de::Error::custom(
-          "text field cannot set both `search_analyzer` and `search_tokenizer`",
-        ));
-      }
-      (None, None) => None,
-    };
-    Ok(TextField {
-      name: value.name,
-      analyzer: primary,
-      search_analyzer,
-      stored: value.stored,
-      indexed: value.indexed,
-      nullable: value.nullable,
-      search_as_you_type: value.search_as_you_type,
-    })
-  }
-}
-
-impl Serialize for TextField {
-  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-  where
-    S: serde::Serializer,
-  {
-    let helper = TextFieldSerde {
-      name: self.name.clone(),
-      tokenizer: Some(self.analyzer.clone()),
-      analyzer: None,
-      search_analyzer: self.search_analyzer.clone(),
-      search_tokenizer: None,
-      stored: self.stored,
-      indexed: self.indexed,
-      nullable: self.nullable,
-      search_as_you_type: self.search_as_you_type.clone(),
-    };
-    helper.serialize(serializer)
-  }
-}
-
-impl<'de> Deserialize<'de> for TextField {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: serde::Deserializer<'de>,
-  {
-    let helper = TextFieldSerde::deserialize(deserializer)?;
-    TextField::try_from(helper).map_err(serde::de::Error::custom)
-  }
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct KeywordField {
   pub name: String,
@@ -948,12 +856,10 @@ pub struct NumericField {
   pub nullable: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct NestedField {
   pub name: String,
-  #[serde(default)]
   pub fields: Vec<NestedProperty>,
-  #[serde(default)]
   pub nullable: bool,
 }
 
@@ -1014,8 +920,7 @@ impl NestedField {
   }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[derive(Debug, Clone)]
 pub enum NestedProperty {
   Text(TextField),
   Keyword(KeywordField),

--- a/searchlite-core/src/index/mod.rs
+++ b/searchlite-core/src/index/mod.rs
@@ -21,6 +21,7 @@ pub mod directory;
 pub mod docstore;
 pub mod fastfields;
 pub mod highlight;
+pub mod json_schema;
 pub mod manifest;
 pub mod merge;
 pub mod postings;

--- a/searchlite-core/tests/partial_update.rs
+++ b/searchlite-core/tests/partial_update.rs
@@ -22,16 +22,11 @@ fn opts(path: &std::path::Path) -> IndexOptions {
 fn update_set_unset_top_level_fields() {
   let dir = tempdir().unwrap();
   let schema: Schema = serde_json::from_value(serde_json::json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [
-      { "name": "count", "i64": true, "fast": false, "stored": true, "nullable": false }
-    ],
-    "nested_fields": [],
-    "vector_fields": []
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "count": { "type": "integer", "searchlite:stored": true, "searchlite:fast": false }
+    }
   }))
   .unwrap();
   let idx = Index::create(dir.path(), schema, opts(dir.path())).unwrap();
@@ -69,17 +64,19 @@ fn update_set_unset_top_level_fields() {
 fn update_supports_nested_paths() {
   let dir = tempdir().unwrap();
   let schema: Schema = serde_json::from_value(serde_json::json!({
-    "doc_id_field": "_id",
-    "text_fields": [{ "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [
-      { "name": "metadata", "nullable": true, "fields": [
-          { "type": "keyword", "name": "alt", "stored": true, "indexed": true, "fast": false, "nullable": true }
-        ]
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "metadata": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "alt": { "type": ["string", "null"], "searchlite:kind": "keyword", "searchlite:fast": false }
+          }
+        }
       }
-    ],
-    "vector_fields": []
+    }
   }))
   .unwrap();
   let idx = Index::create(dir.path(), schema, opts(dir.path())).unwrap();
@@ -220,14 +217,10 @@ fn update_rejects_doc_id_mutation() {
 fn update_rejects_nonstored_indexed_fields() {
   let dir = tempdir().unwrap();
   let schema: Schema = serde_json::from_value(serde_json::json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": false, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": []
+    "type": "object",
+    "properties": {
+      "body": { "type": "string", "searchlite:stored": false }
+    }
   }))
   .unwrap();
   let idx = Index::create(dir.path(), schema, opts(dir.path())).unwrap();
@@ -257,16 +250,11 @@ fn update_rejects_nonstored_indexed_fields() {
 fn update_rejects_vector_fields() {
   let dir = tempdir().unwrap();
   let schema: Schema = serde_json::from_value(serde_json::json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": [
-      { "name": "embedding", "dim": 2, "metric": "Cosine" }
-    ]
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "embedding": { "type": "array", "items": { "type": "number" }, "searchlite:vector": { "dim": 2, "metric": "Cosine" } }
+    }
   }))
   .unwrap();
   let idx = Index::create(dir.path(), schema, opts(dir.path())).unwrap();

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -27,35 +27,24 @@ fn opts(path: &Path) -> IndexOptions {
 
 fn schema() -> Schema {
   serde_json::from_value(json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [
-      { "name": "tag", "stored": true, "indexed": true, "fast": true, "nullable": true }
-    ],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": [
-      { "name": "embedding", "dim": 2, "metric": "Cosine" }
-    ]
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "tag": { "type": ["string", "null"], "searchlite:kind": "keyword" },
+      "embedding": { "type": "array", "items": { "type": "number" }, "searchlite:vector": { "dim": 2, "metric": "Cosine" } }
+    }
   }))
   .expect("schema")
 }
 
 fn multi_vector_schema() -> Schema {
   serde_json::from_value(json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": [
-      { "name": "vec_a", "dim": 2, "metric": "Cosine" },
-      { "name": "vec_b", "dim": 2, "metric": "Cosine" }
-    ]
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "vec_a": { "type": "array", "items": { "type": "number" }, "searchlite:vector": { "dim": 2, "metric": "Cosine" } },
+      "vec_b": { "type": "array", "items": { "type": "number" }, "searchlite:vector": { "dim": 2, "metric": "Cosine" } }
+    }
   }))
   .expect("schema")
 }
@@ -322,16 +311,11 @@ fn hybrid_blends_text_and_vector() {
 
 fn schema_l2() -> Schema {
   serde_json::from_value(json!({
-    "doc_id_field": "_id",
-    "text_fields": [
-      { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-    ],
-    "keyword_fields": [],
-    "numeric_fields": [],
-    "nested_fields": [],
-    "vector_fields": [
-      { "name": "embedding", "dim": 2, "metric": "L2" }
-    ]
+    "type": "object",
+    "properties": {
+      "body": { "type": "string" },
+      "embedding": { "type": "array", "items": { "type": "number" }, "searchlite:vector": { "dim": 2, "metric": "L2" } }
+    }
   }))
   .expect("schema")
 }

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -2737,16 +2737,11 @@ mod tests {
     let (client, _base, index_base, handle, _state, _args) = setup_server(index_path).await;
 
     let schema: Schema = serde_json::from_value(json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [
-        { "name": "lang", "stored": true, "indexed": true, "fast": true, "nullable": false }
-      ],
-      "numeric_fields": [],
-      "nested_fields": [],
-      "vector_fields": []
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" },
+        "lang": { "type": "string", "searchlite:kind": "keyword" }
+      }
     }))
     .unwrap();
     client
@@ -2874,22 +2869,19 @@ mod tests {
     let (client, _base, index_base, handle, _state, _args) = setup_server(index_path).await;
 
     let schema: Schema = serde_json::from_value(json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [],
-      "numeric_fields": [],
-      "nested_fields": [
-        {
-          "name": "images",
-          "nullable": false,
-          "fields": [
-            { "type": "keyword", "name": "illustrator", "stored": true, "indexed": true, "fast": true, "nullable": false }
-          ]
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" },
+        "images": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "illustrator": { "type": "string", "searchlite:kind": "keyword" }
+            }
+          }
         }
-      ],
-      "vector_fields": []
+      }
     }))
     .unwrap();
     client
@@ -2996,16 +2988,15 @@ mod tests {
     let (client, _base, index_base, handle, _state, _args) = setup_server(index_path).await;
 
     let schema: Schema = serde_json::from_value(json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [],
-      "numeric_fields": [],
-      "nested_fields": [],
-      "vector_fields": [
-        { "name": "embedding", "dim": 2, "metric": "Cosine" }
-      ]
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" },
+        "embedding": {
+          "type": "array",
+          "items": { "type": "number" },
+          "searchlite:vector": { "dim": 2, "metric": "Cosine" }
+        }
+      }
     }))
     .unwrap();
     client
@@ -3104,16 +3095,15 @@ mod tests {
     let index_base = format!("{base}/indexes/{INDEX_NAME}");
 
     let schema: Schema = serde_json::from_value(json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [],
-      "numeric_fields": [],
-      "nested_fields": [],
-      "vector_fields": [
-        { "name": "embedding", "dim": 2, "metric": "Cosine" }
-      ]
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" },
+        "embedding": {
+          "type": "array",
+          "items": { "type": "number" },
+          "searchlite:vector": { "dim": 2, "metric": "Cosine" }
+        }
+      }
     }))
     .unwrap();
     client
@@ -3488,16 +3478,11 @@ mod tests {
     let (client, _base, index_base, handle, _state, _args) = setup_server(index_path).await;
 
     let schema: Schema = serde_json::from_value(serde_json::json!({
-      "doc_id_field": "_id",
-      "text_fields": [
-        { "name": "body", "analyzer": "default", "stored": true, "indexed": true, "nullable": false }
-      ],
-      "keyword_fields": [],
-      "numeric_fields": [
-        { "name": "rank", "stored": true, "fast": true, "nullable": false, "i64": true }
-      ],
-      "nested_fields": [],
-      "vector_fields": []
+      "type": "object",
+      "properties": {
+        "body": { "type": "string" },
+        "rank": { "type": "integer", "searchlite:stored": true }
+      }
     }))
     .unwrap();
     client
@@ -3764,12 +3749,9 @@ mod tests {
     let (_client, _base, index_base, handle, _state, _args) =
       setup_server(dir.path().join("idx-invalid")).await;
     let bad_schema: Schema = serde_json::from_value(json!({
-      "doc_id_field": "a.b",
-      "text_fields": [],
-      "keyword_fields": [],
-      "numeric_fields": [],
-      "nested_fields": [],
-      "vector_fields": []
+      "type": "object",
+      "properties": {},
+      "searchlite:docIdField": "a.b"
     }))
     .unwrap();
     let res = _client

--- a/searchlite-node/README.md
+++ b/searchlite-node/README.md
@@ -65,17 +65,25 @@ const index = new EmbeddedIndex('./products', {
 });
 ```
 
-Or use detailed definitions when you need more control:
+Or pass a full JSON Schema with `searchlite:` vocabulary keywords for complete control:
 
 ```javascript
 const index = new EmbeddedIndex('./products', {
   schema: {
-    name: { type: 'text', stored: true, indexed: true, analyzer: 'default' },
-    brand: { type: 'keyword', stored: true, fast: true },
-    price: { type: 'float', stored: true, fast: true },
+    type: 'object',
+    properties: {
+      name: { type: 'string' },
+      brand: { type: 'string', 'searchlite:kind': 'keyword' },
+      price: { type: 'number', 'searchlite:stored': true },
+    },
   },
 });
 ```
+
+> **Note:** Both shorthand (`{ name: 'text' }`) and full JSON Schema formats are accepted.
+> The shorthand is a Node.js convenience -- `expandSchema()` converts it to JSON Schema
+> internally. The JSON Schema format is the canonical representation shared across all
+> searchlite clients.
 
 ### 2. Add Documents
 
@@ -264,53 +272,77 @@ Internally, methods map to [searchlite-http](../searchlite-http) endpoints:
 
 ## Schema
 
-### Field Types
+Schemas define the fields in your documents. You can use either the shorthand format
+(Node.js only) or the full JSON Schema format with `searchlite:` vocabulary keywords.
 
-| Type | Description | Defaults |
-|------|-------------|----------|
-| `'text'` | Full-text searchable with BM25 scoring | `stored: true, indexed: true, analyzer: 'default'` |
-| `'keyword'` | Exact-match filtering and aggregations | `stored: true, indexed: true, fast: true` |
-| `'integer'` | 64-bit integer, range filters | `fast: true, stored: false` |
-| `'float'` | 64-bit float, range filters | `fast: true, stored: false` |
+### Shorthand Format (Node.js only)
 
-### Detailed Field Options
+The shorthand maps field names to type strings. `expandSchema()` converts this to
+JSON Schema internally.
 
-Override any default with the detailed syntax:
+| Shorthand | JSON Schema Output | Description |
+|-----------|-------------------|-------------|
+| `'text'` | `{ type: "string" }` | Full-text searchable with BM25 scoring |
+| `'keyword'` | `{ type: "string", "searchlite:kind": "keyword" }` | Exact-match filtering and aggregations |
+| `'integer'` | `{ type: "integer" }` | 64-bit integer, range filters |
+| `'float'` | `{ type: "number" }` | 64-bit float, range filters |
+
+### JSON Schema Format
+
+The canonical format uses standard JSON Schema types with `searchlite:` vocabulary
+keywords for search-engine-specific behavior. This format is shared across all
+searchlite clients.
 
 ```javascript
 {
-  title: { type: 'text', stored: true, indexed: true, analyzer: 'default' },
-  body: { type: 'text', stored: false, indexed: true },  // indexed but not stored
-  status: { type: 'keyword', fast: true, stored: false }, // filterable but not returned
-  count: { type: 'integer', stored: true, fast: true },   // stored and fast
+  type: 'object',
+  properties: {
+    title: { type: 'string' },                                          // text (default)
+    body: { type: 'string', 'searchlite:stored': false },               // text, not stored
+    status: { type: 'string', 'searchlite:kind': 'keyword' },           // keyword
+    count: { type: 'integer', 'searchlite:stored': true },              // integer, stored
+    price: { type: 'number' },                                          // float
+    notes: { type: ['string', 'null'] },                                // nullable text
+  },
 }
 ```
 
-**Text field options:**
+### `searchlite:` Vocabulary Keywords
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `stored` | boolean | `true` | Include in stored fields for retrieval |
-| `indexed` | boolean | `true` | Include in full-text index |
-| `analyzer` | string | `'default'` | Text analysis pipeline |
-| `nullable` | boolean | `false` | Allow null values |
+These keywords extend standard JSON Schema to control search-engine behavior.
 
-**Keyword field options:**
+**For text fields** (`{ type: "string" }` without `searchlite:kind`):
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `stored` | boolean | `true` | Include in stored fields |
-| `indexed` | boolean | `true` | Include in term index |
-| `fast` | boolean | `true` | Enable fast-field for filtering and aggregations |
-| `nullable` | boolean | `false` | Allow null values |
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `searchlite:stored` | boolean | `true` | Include in stored fields for retrieval |
+| `searchlite:indexed` | boolean | `true` | Include in full-text index |
+| `searchlite:analyzer` | string | `"default"` | Text analysis pipeline |
 
-**Numeric field options (`integer` / `float`):**
+**For keyword fields** (`{ type: "string", "searchlite:kind": "keyword" }`):
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
-| `stored` | boolean | `false` | Include in stored fields |
-| `fast` | boolean | `true` | Enable fast-field for range filters |
-| `nullable` | boolean | `false` | Allow null values |
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `searchlite:stored` | boolean | `true` | Include in stored fields |
+| `searchlite:indexed` | boolean | `true` | Include in term index |
+| `searchlite:fast` | boolean | `true` | Enable fast-field for filtering and aggregations |
+
+**For numeric fields** (`{ type: "integer" }` or `{ type: "number" }`):
+
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `searchlite:stored` | boolean | `false` | Include in stored fields |
+| `searchlite:fast` | boolean | `true` | Enable fast-field for range filters |
+
+**Nullable fields:** Use a JSON Schema type array to allow null values, e.g.
+`{ type: ["string", "null"] }` or `{ type: ["integer", "null"] }`.
+
+**Index-level keywords** (on the root schema object):
+
+| Keyword | Type | Default | Description |
+|---------|------|---------|-------------|
+| `searchlite:docIdField` | string | `"_id"` | Name of the document ID field |
+| `searchlite:analyzers` | array | -- | Custom analyzer definitions |
 
 ## Search Options
 

--- a/searchlite-node/src/schemas.ts
+++ b/searchlite-node/src/schemas.ts
@@ -31,24 +31,44 @@ interface JsonSchemaOutput {
 }
 
 export function expandSchema(input: Record<string, unknown>): JsonSchemaOutput {
-	if (!input || typeof input !== "object") {
-		throw new Error("schema must be an object");
+	if (!input || typeof input !== "object" || Array.isArray(input)) {
+		throw new Error("schema must be a plain object");
 	}
 
 	// Already in JSON Schema format (has `properties` or `$schema`)
 	if ("properties" in input || "$schema" in input) {
+		if (input.type !== "object") {
+			throw new Error('JSON Schema input must have `type: "object"` at the root');
+		}
+		if (
+			typeof input.properties !== "object" ||
+			input.properties === null ||
+			Array.isArray(input.properties)
+		) {
+			throw new Error("JSON Schema input must have `properties` as a plain object");
+		}
 		return input as unknown as JsonSchemaOutput;
 	}
 
-	// Reject old-format schemas
-	if (Array.isArray(input.text_fields)) {
+	// Reject old-format schemas (any of the three legacy field arrays)
+	if (
+		Array.isArray(input.text_fields) ||
+		Array.isArray(input.keyword_fields) ||
+		Array.isArray(input.numeric_fields)
+	) {
 		throw new Error(
-			"legacy field-array schema format (text_fields/keyword_fields) is no longer supported. " +
+			"legacy field-array schema format (text_fields/keyword_fields/numeric_fields) is no longer supported. " +
 				"Use JSON Schema with `searchlite:` vocabulary keywords.",
 		);
 	}
 
-	const docIdField = (input.doc_id_field as string) ?? "_id";
+	let docIdField = "_id";
+	if ("doc_id_field" in input && input.doc_id_field !== undefined) {
+		if (typeof input.doc_id_field !== "string" || input.doc_id_field.length === 0) {
+			throw new Error("doc_id_field must be a non-empty string");
+		}
+		docIdField = input.doc_id_field;
+	}
 	const properties: Record<string, Record<string, unknown>> = {};
 
 	for (const [name, def] of Object.entries(input)) {

--- a/searchlite-node/src/schemas.ts
+++ b/searchlite-node/src/schemas.ts
@@ -5,8 +5,8 @@ import { z } from "zod";
 const FIELD_DEFAULTS = {
 	text: { stored: true, indexed: true, analyzer: "default", nullable: false },
 	keyword: { stored: true, indexed: true, fast: true, nullable: false },
-	integer: { i64: true, fast: true, stored: false, nullable: false },
-	float: { i64: false, fast: true, stored: false, nullable: false },
+	integer: { fast: true, stored: false, nullable: false },
+	float: { fast: true, stored: false, nullable: false },
 } as const;
 
 type FieldType = keyof typeof FIELD_DEFAULTS;
@@ -20,47 +20,36 @@ interface FieldDef {
 	nullable?: boolean;
 }
 
-interface CoreSchema {
-	doc_id_field: string;
-	analyzers: unknown[];
-	text_fields: Array<{
-		name: string;
-		analyzer: string;
-		stored: boolean;
-		indexed: boolean;
-		nullable: boolean;
-	}>;
-	keyword_fields: Array<{
-		name: string;
-		stored: boolean;
-		indexed: boolean;
-		fast: boolean;
-		nullable: boolean;
-	}>;
-	numeric_fields: Array<{
-		name: string;
-		i64: boolean;
-		fast: boolean;
-		stored: boolean;
-		nullable: boolean;
-	}>;
-	nested_fields: unknown[];
+/** JSON Schema output with `searchlite:` vocabulary keywords. */
+interface JsonSchemaOutput {
+	$schema?: string;
+	type: "object";
+	"searchlite:docIdField"?: string;
+	"searchlite:analyzers"?: unknown[];
+	properties: Record<string, Record<string, unknown>>;
+	[key: string]: unknown;
 }
 
-export function expandSchema(input: Record<string, unknown>): CoreSchema {
+export function expandSchema(input: Record<string, unknown>): JsonSchemaOutput {
 	if (!input || typeof input !== "object") {
 		throw new Error("schema must be an object");
 	}
 
-	// Already in core format (has text_fields array)
-	if (Array.isArray((input as Record<string, unknown>).text_fields)) {
-		return input as unknown as CoreSchema;
+	// Already in JSON Schema format (has `properties` or `$schema`)
+	if ("properties" in input || "$schema" in input) {
+		return input as unknown as JsonSchemaOutput;
+	}
+
+	// Reject old-format schemas
+	if (Array.isArray(input.text_fields)) {
+		throw new Error(
+			"legacy field-array schema format (text_fields/keyword_fields) is no longer supported. " +
+				"Use JSON Schema with `searchlite:` vocabulary keywords.",
+		);
 	}
 
 	const docIdField = (input.doc_id_field as string) ?? "_id";
-	const textFields: CoreSchema["text_fields"] = [];
-	const keywordFields: CoreSchema["keyword_fields"] = [];
-	const numericFields: CoreSchema["numeric_fields"] = [];
+	const properties: Record<string, Record<string, unknown>> = {};
 
 	for (const [name, def] of Object.entries(input)) {
 		if (name === "doc_id_field" || name === "analyzers") continue;
@@ -85,45 +74,52 @@ export function expandSchema(input: Record<string, unknown>): CoreSchema {
 			);
 		}
 
-		const defaults = FIELD_DEFAULTS[type];
+		const prop: Record<string, unknown> = {};
 
 		if (type === "text") {
-			textFields.push({
-				name,
-				analyzer: fieldDef.analyzer ?? (defaults as (typeof FIELD_DEFAULTS)["text"]).analyzer,
-				stored: fieldDef.stored ?? defaults.stored,
-				indexed: fieldDef.indexed ?? (defaults as (typeof FIELD_DEFAULTS)["text"]).indexed,
-				nullable: fieldDef.nullable ?? defaults.nullable,
-			});
+			const defaults = FIELD_DEFAULTS.text;
+			prop.type = fieldDef.nullable ? ["string", "null"] : "string";
+			const analyzer = fieldDef.analyzer ?? defaults.analyzer;
+			if (analyzer !== "default") prop["searchlite:analyzer"] = analyzer;
+			if ((fieldDef.stored ?? defaults.stored) !== true) prop["searchlite:stored"] = false;
+			if ((fieldDef.indexed ?? defaults.indexed) !== true) prop["searchlite:indexed"] = false;
 		} else if (type === "keyword") {
-			keywordFields.push({
-				name,
-				stored: fieldDef.stored ?? defaults.stored,
-				indexed: fieldDef.indexed ?? (defaults as (typeof FIELD_DEFAULTS)["keyword"]).indexed,
-				fast: fieldDef.fast ?? (defaults as (typeof FIELD_DEFAULTS)["keyword"]).fast,
-				nullable: fieldDef.nullable ?? defaults.nullable,
-			});
+			const defaults = FIELD_DEFAULTS.keyword;
+			prop.type = fieldDef.nullable ? ["string", "null"] : "string";
+			prop["searchlite:kind"] = "keyword";
+			if ((fieldDef.stored ?? defaults.stored) !== true) prop["searchlite:stored"] = false;
+			if ((fieldDef.indexed ?? defaults.indexed) !== true) prop["searchlite:indexed"] = false;
+			if ((fieldDef.fast ?? defaults.fast) !== true) prop["searchlite:fast"] = false;
+		} else if (type === "integer") {
+			const defaults = FIELD_DEFAULTS.integer;
+			prop.type = fieldDef.nullable ? ["integer", "null"] : "integer";
+			if ((fieldDef.fast ?? defaults.fast) !== true) prop["searchlite:fast"] = false;
+			if ((fieldDef.stored ?? defaults.stored) !== false) prop["searchlite:stored"] = true;
 		} else {
-			// integer or float
-			const numDefaults = defaults as (typeof FIELD_DEFAULTS)["integer"];
-			numericFields.push({
-				name,
-				i64: numDefaults.i64,
-				fast: fieldDef.fast ?? numDefaults.fast,
-				stored: fieldDef.stored ?? numDefaults.stored,
-				nullable: fieldDef.nullable ?? numDefaults.nullable,
-			});
+			// float
+			const defaults = FIELD_DEFAULTS.float;
+			prop.type = fieldDef.nullable ? ["number", "null"] : "number";
+			if ((fieldDef.fast ?? defaults.fast) !== true) prop["searchlite:fast"] = false;
+			if ((fieldDef.stored ?? defaults.stored) !== false) prop["searchlite:stored"] = true;
 		}
+
+		properties[name] = prop;
 	}
 
-	return {
-		doc_id_field: docIdField,
-		analyzers: (input.analyzers as unknown[]) ?? [],
-		text_fields: textFields,
-		keyword_fields: keywordFields,
-		numeric_fields: numericFields,
-		nested_fields: [],
+	const result: JsonSchemaOutput = {
+		type: "object",
+		properties,
 	};
+
+	if (docIdField !== "_id") {
+		result["searchlite:docIdField"] = docIdField;
+	}
+
+	if (input.analyzers) {
+		result["searchlite:analyzers"] = input.analyzers as unknown[];
+	}
+
+	return result;
 }
 
 // --- Input schemas (camelCase) ---

--- a/searchlite-node/test/schemas.test.mjs
+++ b/searchlite-node/test/schemas.test.mjs
@@ -5,32 +5,26 @@ describe("expandSchema", () => {
 	describe("shorthand strings", () => {
 		it("expands 'text' with defaults", () => {
 			const schema = expandSchema({ title: "text" });
-			expect(schema.text_fields).toEqual([
-				{ name: "title", analyzer: "default", stored: true, indexed: true, nullable: false },
-			]);
-			expect(schema.keyword_fields).toEqual([]);
-			expect(schema.numeric_fields).toEqual([]);
+			expect(schema.type).toBe("object");
+			expect(schema.properties.title).toEqual({ type: "string" });
 		});
 
 		it("expands 'keyword' with defaults", () => {
 			const schema = expandSchema({ tag: "keyword" });
-			expect(schema.keyword_fields).toEqual([
-				{ name: "tag", stored: true, indexed: true, fast: true, nullable: false },
-			]);
+			expect(schema.properties.tag).toEqual({
+				type: "string",
+				"searchlite:kind": "keyword",
+			});
 		});
 
 		it("expands 'integer' with defaults", () => {
 			const schema = expandSchema({ year: "integer" });
-			expect(schema.numeric_fields).toEqual([
-				{ name: "year", i64: true, fast: true, stored: false, nullable: false },
-			]);
+			expect(schema.properties.year).toEqual({ type: "integer" });
 		});
 
 		it("expands 'float' with defaults", () => {
 			const schema = expandSchema({ price: "float" });
-			expect(schema.numeric_fields).toEqual([
-				{ name: "price", i64: false, fast: true, stored: false, nullable: false },
-			]);
+			expect(schema.properties.price).toEqual({ type: "number" });
 		});
 	});
 
@@ -39,12 +33,10 @@ describe("expandSchema", () => {
 			const schema = expandSchema({
 				body: { type: "text", stored: false, analyzer: "english" },
 			});
-			expect(schema.text_fields[0]).toEqual({
-				name: "body",
-				analyzer: "english",
-				stored: false,
-				indexed: true,
-				nullable: false,
+			expect(schema.properties.body).toEqual({
+				type: "string",
+				"searchlite:analyzer": "english",
+				"searchlite:stored": false,
 			});
 		});
 
@@ -52,12 +44,11 @@ describe("expandSchema", () => {
 			const schema = expandSchema({
 				status: { type: "keyword", stored: false, fast: false },
 			});
-			expect(schema.keyword_fields[0]).toEqual({
-				name: "status",
-				stored: false,
-				indexed: true,
-				fast: false,
-				nullable: false,
+			expect(schema.properties.status).toEqual({
+				type: "string",
+				"searchlite:kind": "keyword",
+				"searchlite:stored": false,
+				"searchlite:fast": false,
 			});
 		});
 
@@ -65,12 +56,9 @@ describe("expandSchema", () => {
 			const schema = expandSchema({
 				count: { type: "integer", stored: true },
 			});
-			expect(schema.numeric_fields[0]).toEqual({
-				name: "count",
-				i64: true,
-				fast: true,
-				stored: true,
-				nullable: false,
+			expect(schema.properties.count).toEqual({
+				type: "integer",
+				"searchlite:stored": true,
 			});
 		});
 
@@ -78,7 +66,7 @@ describe("expandSchema", () => {
 			const schema = expandSchema({
 				notes: { type: "text", nullable: true },
 			});
-			expect(schema.text_fields[0].nullable).toBe(true);
+			expect(schema.properties.notes.type).toEqual(["string", "null"]);
 		});
 	});
 
@@ -91,50 +79,57 @@ describe("expandSchema", () => {
 				year: "integer",
 				price: "float",
 			});
-			expect(schema.text_fields).toHaveLength(2);
-			expect(schema.keyword_fields).toHaveLength(1);
-			expect(schema.numeric_fields).toHaveLength(2);
+			expect(Object.keys(schema.properties)).toHaveLength(5);
+			expect(schema.properties.title.type).toBe("string");
+			expect(schema.properties.body["searchlite:analyzer"]).toBe("english");
+			expect(schema.properties.tag["searchlite:kind"]).toBe("keyword");
+			expect(schema.properties.year.type).toBe("integer");
+			expect(schema.properties.price.type).toBe("number");
 		});
 	});
 
 	describe("metadata fields", () => {
-		it("sets doc_id_field to _id by default", () => {
+		it("omits searchlite:docIdField when default _id", () => {
 			const schema = expandSchema({ title: "text" });
-			expect(schema.doc_id_field).toBe("_id");
+			expect(schema["searchlite:docIdField"]).toBeUndefined();
 		});
 
 		it("allows doc_id_field override", () => {
 			const schema = expandSchema({ doc_id_field: "uuid", title: "text" });
-			expect(schema.doc_id_field).toBe("uuid");
+			expect(schema["searchlite:docIdField"]).toBe("uuid");
 		});
 
 		it("passes through analyzers", () => {
 			const schema = expandSchema({ analyzers: [{ name: "custom" }], title: "text" });
-			expect(schema.analyzers).toEqual([{ name: "custom" }]);
+			expect(schema["searchlite:analyzers"]).toEqual([{ name: "custom" }]);
 		});
 
-		it("defaults analyzers to empty array", () => {
+		it("omits analyzers when not provided", () => {
 			const schema = expandSchema({ title: "text" });
-			expect(schema.analyzers).toEqual([]);
-		});
-
-		it("defaults nested_fields to empty array", () => {
-			const schema = expandSchema({ title: "text" });
-			expect(schema.nested_fields).toEqual([]);
+			expect(schema["searchlite:analyzers"]).toBeUndefined();
 		});
 	});
 
-	describe("core format pass-through", () => {
-		it("returns core format unchanged", () => {
-			const core = {
-				text_fields: [
-					{ name: "body", analyzer: "default", stored: true, indexed: true, nullable: false },
-				],
-				keyword_fields: [],
-				numeric_fields: [],
+	describe("JSON Schema pass-through", () => {
+		it("returns JSON Schema format unchanged", () => {
+			const jsonSchema = {
+				type: "object",
+				properties: {
+					body: { type: "string" },
+				},
 			};
-			const result = expandSchema(core);
-			expect(result).toBe(core);
+			const result = expandSchema(jsonSchema);
+			expect(result).toBe(jsonSchema);
+		});
+
+		it("passes through $schema-prefixed input", () => {
+			const jsonSchema = {
+				$schema: "https://searchlite.dev/draft/2025/schema",
+				type: "object",
+				properties: {},
+			};
+			const result = expandSchema(jsonSchema);
+			expect(result).toBe(jsonSchema);
 		});
 	});
 
@@ -163,6 +158,12 @@ describe("expandSchema", () => {
 
 		it("rejects non-object input", () => {
 			expect(() => expandSchema(null)).toThrowError(/schema must be an object/);
+		});
+
+		it("rejects old-format schemas", () => {
+			expect(() =>
+				expandSchema({ text_fields: [], keyword_fields: [], numeric_fields: [] }),
+			).toThrowError(/legacy field-array schema/);
 		});
 	});
 });

--- a/searchlite-node/test/schemas.test.mjs
+++ b/searchlite-node/test/schemas.test.mjs
@@ -157,13 +157,49 @@ describe("expandSchema", () => {
 		});
 
 		it("rejects non-object input", () => {
-			expect(() => expandSchema(null)).toThrowError(/schema must be an object/);
+			expect(() => expandSchema(null)).toThrowError(/schema must be a plain object/);
+		});
+
+		it("rejects array input", () => {
+			expect(() => expandSchema([])).toThrowError(/schema must be a plain object/);
 		});
 
 		it("rejects old-format schemas", () => {
 			expect(() =>
 				expandSchema({ text_fields: [], keyword_fields: [], numeric_fields: [] }),
 			).toThrowError(/legacy field-array schema/);
+		});
+
+		it("rejects old-format schemas with only keyword_fields", () => {
+			expect(() => expandSchema({ keyword_fields: [] })).toThrowError(/legacy field-array schema/);
+		});
+
+		it("rejects old-format schemas with only numeric_fields", () => {
+			expect(() => expandSchema({ numeric_fields: [] })).toThrowError(/legacy field-array schema/);
+		});
+
+		it("rejects JSON Schema input without type=object", () => {
+			expect(() => expandSchema({ properties: { x: { type: "string" } } })).toThrowError(
+				/type: "object"/,
+			);
+		});
+
+		it("rejects JSON Schema input with non-object properties", () => {
+			expect(() => expandSchema({ type: "object", properties: "not-an-object" })).toThrowError(
+				/properties.*plain object/,
+			);
+		});
+
+		it("rejects non-string doc_id_field", () => {
+			expect(() => expandSchema({ doc_id_field: 123, title: "text" })).toThrowError(
+				/doc_id_field must be a non-empty string/,
+			);
+		});
+
+		it("rejects empty doc_id_field", () => {
+			expect(() => expandSchema({ doc_id_field: "", title: "text" })).toThrowError(
+				/doc_id_field must be a non-empty string/,
+			);
 		});
 	});
 });


### PR DESCRIPTION
## Summary

- Replaces the custom field-array schema format (`text_fields`, `keyword_fields`, `numeric_fields`) with standard **JSON Schema 2020-12** annotated with `searchlite:` prefixed vocabulary keywords
- The schema now simultaneously describes the expected document shape AND configures the search index, integrating naturally with existing JSON Schema tooling
- This is a breaking change — existing indexes using the old format are no longer compatible

### Before
```json
{
  "text_fields": [{ "name": "title", "analyzer": "default", "stored": true, "indexed": true }],
  "keyword_fields": [{ "name": "tag", "stored": true, "indexed": true, "fast": true }],
  "numeric_fields": [{ "name": "year", "i64": true, "fast": true }]
}
```

### After
```json
{
  "$schema": "https://searchlite.dev/draft/2025/schema",
  "type": "object",
  "properties": {
    "title": { "type": "string" },
    "tag": { "type": "string", "searchlite:kind": "keyword" },
    "year": { "type": "integer" }
  }
}
```

### What changed

| Area | Files | Summary |
|------|-------|---------|
| Core converter | `searchlite-core/src/index/json_schema.rs` (new) | `parse_json_schema()` / `schema_to_json_schema()` + 23 unit tests |
| Schema serde | `manifest.rs` | Custom Serialize/Deserialize delegates to json_schema module; removed TextFieldSerde compat layer |
| Examples | `examples/recipes/schema.json`, `examples/video-games/schema.json` | Rewritten to JSON Schema format |
| Node.js | `schemas.ts`, `schemas.test.mjs` | `expandSchema()` now produces JSON Schema output |
| Tests | 8 test files across core, HTTP, integration | All inline schema JSON converted |
| Meta-schema | `index-schema.json` | Rewritten as meta-schema validating the vocabulary |
| Docs | `schema.md` + 5 other docs, `README.md` | Full rewrite with keyword reference, type inference table |

## Test plan

- [x] `cargo test --workspace --all-features` — all tests pass (0 failures)
- [x] `cargo clippy --workspace --all-features` — clean
- [ ] `cd searchlite-node && npm test` — Node.js test suite
- [ ] Verify a MANIFEST.json created by tests contains JSON Schema format
- [ ] Validate example schemas against the new meta-schema


🤖 Generated with [Claude Code](https://claude.com/claude-code)