### PR TITLE
fix: add missing bench stubs to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,9 +20,12 @@ COPY searchlite-node/Cargo.toml searchlite-node/Cargo.toml
 COPY integration/Cargo.toml integration/Cargo.toml
 
 # Create dummy source files so cargo can resolve the workspace without pulling full sources yet.
-RUN mkdir -p searchlite-core/src searchlite-cli/src searchlite-http/src searchlite-ffi/src searchlite-wasm/src searchlite-node/src integration/src \
+RUN mkdir -p searchlite-core/src searchlite-core/benches searchlite-cli/src searchlite-http/src searchlite-ffi/src searchlite-wasm/src searchlite-node/src integration/src \
  && echo "fn main() {}" > searchlite-cli/src/main.rs \
  && echo "pub fn placeholder() {}" > searchlite-core/src/lib.rs \
+ && echo "fn main() {}" > searchlite-core/benches/aggs.rs \
+ && echo "fn main() {}" > searchlite-core/benches/end_to_end.rs \
+ && echo "fn main() {}" > searchlite-core/benches/scale.rs \
  && echo "pub fn placeholder() {}" > searchlite-http/src/lib.rs \
  && echo "pub fn placeholder() {}" > searchlite-ffi/src/lib.rs \
  && echo "pub fn placeholder() {}" > searchlite-wasm/src/lib.rs \


### PR DESCRIPTION
## Summary
- PR #116 added the missing workspace members (`searchlite-node`, `integration`) but the Docker build still fails because `searchlite-core` defines three `[[bench]]` targets (`aggs`, `end_to_end`, `scale`) that need dummy files during the dependency caching stage
- Adds `searchlite-core/benches` directory and stub files so `cargo fetch --locked` can parse the manifest

## Test plan
- [x] Built Docker image locally and verified it produces a working binary
- [x] Ran `docker run --rm searchlite:test --help` to confirm the CLI starts correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)