### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/integration/CHANGELOG.md
+++ b/integration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/davidkelley/searchlite/compare/integration-v0.2.1...integration-v0.2.2) - 2026-04-13
+
+### Added
+
+- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
+
 ## [0.2.0](https://github.com/davidkelley/searchlite/compare/integration-v0.1.5...integration-v0.2.0) - 2026-04-10
 
 ### Other

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.8...searchlite-cli-v0.1.9) - 2026-04-13
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.7...searchlite-cli-v0.1.8) - 2026-04-10
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.6.1...searchlite-core-v0.6.2) - 2026-04-13
+
+### Added
+
+- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
+
 ## [0.6.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.6.0...searchlite-core-v0.6.1) - 2026-04-10
 
 ### Fixed

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.1...searchlite-http-v0.2.2) - 2026-04-13
+
+### Added
+
+- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
+
 ## [0.2.0](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.1.5...searchlite-http-v0.2.0) - 2026-04-10
 
 ### Added

--- a/searchlite-node/CHANGELOG.md
+++ b/searchlite-node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.1...searchlite-node-v0.2.2) - 2026-04-13
+
+### Added
+
+- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
+
 ## [0.2.1](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.0...searchlite-node-v0.2.1) - 2026-04-10
 
 ### Other

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {
@@ -21,7 +21,15 @@
 	},
 	"homepage": "https://github.com/davidkelley/searchlite/tree/main/searchlite-node#readme",
 	"bugs": "https://github.com/davidkelley/searchlite/issues",
-	"keywords": ["search", "full-text", "index", "native", "rust", "napi", "embedded"],
+	"keywords": [
+		"search",
+		"full-text",
+		"index",
+		"native",
+		"rust",
+		"napi",
+		"embedded"
+	],
 	"exports": {
 		".": {
 			"types": "./dist/index.d.ts",
@@ -58,5 +66,9 @@
 		"lint": "biome check .",
 		"lint:fix": "biome check --write ."
 	},
-	"files": ["dist", "LICENSE", "*.node"]
+	"files": [
+		"dist",
+		"LICENSE",
+		"*.node"
+	]
 }


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `searchlite-http`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `integration`: 0.2.1 -> 0.2.2 (✓ API compatible changes)
* `searchlite-cli`: 0.1.8 -> 0.1.9
* `searchlite-node`: 0.2.1 -> 0.2.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.6.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.6.1...searchlite-core-v0.6.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.1...searchlite-http-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>

## `integration`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/integration-v0.2.1...integration-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.8...searchlite-cli-v0.1.9) - 2026-04-13

### Other

- update Cargo.lock dependencies
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.1...searchlite-node-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).