### PR TITLE
docs: close documentation gaps and add worked examples

### DIFF
--- a/docs/aggregations.md
+++ b/docs/aggregations.md
@@ -189,8 +189,165 @@ For very large result sets, aggregations can be sampled to trade precision for s
 }
 ```
 
+The sampling block accepts three optional fields:
+
+- **`probability`** -- fraction of matching documents to sample (e.g., `0.1` = 10%).
+- **`size`** -- hard cap on the number of documents sampled, regardless of `probability`.
+- **`seed`** -- deterministic seed so repeated runs sample the same documents.
+
 Responses include `sampled: true` when sampling is active. Counts become approximate
 but ordering remains deterministic for a fixed seed.
+
+---
+
+## Worked examples
+
+These examples focus on the aggregation types that were summarised above but
+didn't have a concrete payload. Paste them into your search request's `aggs`
+map -- each top-level key is the aggregation's name (it can be anything you
+like) and appears in the response under the same name.
+
+### `percentiles` — response time distribution
+
+```json
+{
+  "query": { "type": "match_all" },
+  "limit": 0,
+  "aggs": {
+    "latency_percentiles": {
+      "type": "percentiles",
+      "field": "latency_ms",
+      "percents": [50, 90, 95, 99, 99.9]
+    }
+  }
+}
+```
+
+### `percentile_ranks` — "what percent of prices are below $50?"
+
+```json
+{
+  "query": { "type": "match_all" },
+  "limit": 0,
+  "aggs": {
+    "price_ranks": {
+      "type": "percentile_ranks",
+      "field": "price_cents",
+      "values": [2500, 5000, 10000]
+    }
+  }
+}
+```
+
+### `top_hits` — showcase the best result per bucket
+
+```json
+{
+  "query": "wireless headphones",
+  "limit": 0,
+  "aggs": {
+    "by_brand": {
+      "type": "terms", "field": "brand", "size": 5,
+      "aggs": {
+        "best": {
+          "type": "top_hits",
+          "size": 1,
+          "sort": [{ "field": "_score", "order": "desc" }]
+        }
+      }
+    }
+  }
+}
+```
+
+The result has one "best" hit per brand bucket -- ideal for a "top seller per
+category" strip on a search results page.
+
+### `significant_terms` — what's unusual about this subset?
+
+```json
+{
+  "query": { "type": "query_string", "query": "tag:ai" },
+  "limit": 0,
+  "aggs": {
+    "trending_authors": {
+      "type": "significant_terms",
+      "field": "author",
+      "size": 5
+    }
+  }
+}
+```
+
+Returns authors who appear disproportionately often in AI-tagged articles
+compared to the rest of the index -- useful for "who are the experts on X?"
+and discovery UIs.
+
+### `rare_terms` — surface long-tail categories
+
+```json
+{
+  "query": { "type": "match_all" },
+  "limit": 0,
+  "aggs": {
+    "rare_languages": {
+      "type": "rare_terms",
+      "field": "language",
+      "max_doc_count": 3
+    }
+  }
+}
+```
+
+### `bucket_sort` — reorder or paginate a bucket list
+
+```json
+{
+  "aggs": {
+    "by_brand": {
+      "type": "terms", "field": "brand", "size": 50,
+      "aggs": {
+        "avg_price": { "type": "stats", "field": "price_cents" },
+        "sort_by_avg": {
+          "type": "bucket_sort",
+          "sort": [ { "avg_price.avg": "desc" } ],
+          "from": 0,
+          "size": 5
+        }
+      }
+    }
+  }
+}
+```
+
+`bucket_sort` runs *after* the parent aggregation: the 50 brand buckets get
+re-ordered by average price descending, then the first 5 are returned.
+
+### `bucket_script` — arithmetic over bucket values
+
+```json
+{
+  "aggs": {
+    "daily": {
+      "type": "date_histogram",
+      "field": "timestamp_ms",
+      "fixed_interval": "1d",
+      "aggs": {
+        "revenue":   { "type": "stats", "field": "order_cents" },
+        "customers": { "type": "cardinality", "field": "customer_id" },
+        "revenue_per_customer": {
+          "type": "bucket_script",
+          "buckets_path": { "rev": "revenue.sum", "custs": "customers" },
+          "script": "rev / custs"
+        }
+      }
+    }
+  }
+}
+```
+
+Every bucket gains a synthetic `revenue_per_customer` value computed from its
+siblings -- perfect for dashboards.
 
 ---
 

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -37,7 +37,7 @@ All FFI functions that return `c_int` use the following codes:
 
 ### WASM threading
 
-Call `await Searchlite.init_threads(threads?)` before any search if you want multi-threaded execution. The optional `threads` parameter defaults to `navigator.hardwareConcurrency`. Threading requires:
+Call `await db.init_threads(threads?)` on the index instance (returned from `Searchlite.init(...)`) before any search if you want multi-threaded execution. The optional `threads` parameter defaults to `navigator.hardwareConcurrency`. Threading requires:
 
 - The `threads` crate feature enabled at build time (`--features threads`).
 - The page served with COOP/COEP headers (`Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`) so that `SharedArrayBuffer` is available.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -123,8 +123,10 @@ searchlite delete "$INDEX" /tmp/ids.txt
 searchlite commit "$INDEX"
 ```
 
-Blank lines and trailing whitespace are ignored, and IDs are validated before
-anything is queued.
+Blank lines are ignored, and IDs are validated before anything is queued.
+Note that surrounding whitespace is **not** stripped -- if a line has
+leading or trailing spaces, those spaces become part of the ID. Make sure
+your `ids.txt` has exactly the IDs you stored, with no accidental padding.
 
 ### Structured queries with filters
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,10 +41,30 @@ Supported platforms: `x86_64`/`aarch64` Linux and macOS, Windows via Git Bash/WS
 | `search <index> [options]` | Query the index and return JSON results |
 | `inspect <index>` | Print manifest and segment metadata |
 | `compact <index>` | Merge all segments to reduce fragmentation |
+| `http [options]` | Run the HTTP server. See [http.md](http.md) |
 
 Documents are **buffered** when added -- they won't appear in search results until
 you run `commit`. This lets you batch thousands of documents before making them
 visible, which is much faster than committing after each one.
+
+### Common flags for every write command
+
+All write commands (`init`, `add`, `update`, `delete`, `commit`, `compact`) accept
+the optional `--write-key <KEY>` flag. If the index was created with a write key,
+you **must** supply the same key for every subsequent write, or the operation
+fails with an authorization error. See [write-key.md](write-key.md) for details.
+
+```bash
+# Create a protected index
+searchlite init "$INDEX" schema.json --write-key "my-secret"
+
+# Every subsequent write must pass the same key
+searchlite add "$INDEX" docs.jsonl --write-key "my-secret"
+searchlite commit "$INDEX" --write-key "my-secret"
+searchlite compact "$INDEX" --write-key "my-secret"
+```
+
+Read commands (`search`, `inspect`) never require a write key.
 
 ---
 
@@ -69,8 +89,42 @@ searchlite add "$INDEX" /tmp/docs.jsonl
 searchlite commit "$INDEX"
 
 # 4. Search!
-searchlite search "$INDEX" --q "rust language" --limit 5
+searchlite search "$INDEX" -q "rust language" --limit 5
 ```
+
+### Updating documents (upsert)
+
+`update` is an alias for `add` -- both perform upserts keyed by `_id`. Use
+`update` in scripts when you want the intent of "replace an existing document"
+to be explicit:
+
+```bash
+# The file format is identical to `add` -- NDJSON keyed by _id
+cat > /tmp/patch.jsonl <<'EOF'
+{"_id":"1","body":"Rust is a safe systems language","lang":"en","year":2025}
+EOF
+searchlite update "$INDEX" /tmp/patch.jsonl
+searchlite commit "$INDEX"
+```
+
+Documents that share an existing `_id` replace the old version on the next
+commit. New IDs are inserted. The update is not visible until `commit` runs.
+
+### Deleting documents
+
+`delete` takes a plain text file with one document ID per line:
+
+```bash
+cat > /tmp/ids.txt <<'EOF'
+2
+3
+EOF
+searchlite delete "$INDEX" /tmp/ids.txt
+searchlite commit "$INDEX"
+```
+
+Blank lines and trailing whitespace are ignored, and IDs are validated before
+anything is queued.
 
 ### Structured queries with filters
 
@@ -150,6 +204,56 @@ Compaction reduces fragmentation and improves search performance after many comm
 
 ---
 
+## All `search` flags
+
+| Flag | Purpose |
+|---|---|
+| `-q, --query <STRING>` | Free-text query. Searches all indexed text fields by default. |
+| `--fields <A,B,C>` | Comma-separated list restricting which text fields are searched. |
+| `--limit <N>` | Max hits to return (default: `10`). Set to `0` to skip hit ranking and only run aggregations. |
+| `--execution <wand\|bmw\|bm25>` | Scoring strategy (default: `wand`). See [Query execution modes](#query-execution-modes) below. |
+| `--bmw-block-size <N>` | Override the block size used by the `bmw` strategy. Only meaningful with `--execution bmw`. |
+| `--return-stored` | Include stored fields in each hit. Off by default so results stay compact. |
+| `--return-hits <bool>` | Whether to include the hits array. Set to `false` for pure aggregation queries (default: `true`). |
+| `--highlight <FIELD>` | Single-field highlighting. The hit's `snippet` is populated with `<em>...</em>` markup. |
+| `--sort <FIELD[:asc\|desc],…>` | Comma-separated sort spec, e.g. `year:desc,title:asc`. Sort fields must be fast. |
+| `--cursor <TOKEN>` | Resume from a previous response's `next_cursor`. |
+| `--aggs <JSON>` | Inline aggregations JSON. |
+| `--aggs-file <PATH>` | Load aggregations JSON from a file (alternative to `--aggs`). |
+| `--request <PATH>` | Use a full `SearchRequest` JSON file. Overrides all other flags. |
+| `--request-stdin` | Read a full `SearchRequest` JSON from stdin. Overrides all other flags. |
+
+When compiled with the `vectors` feature, the following additional flags are
+available for simple vector/hybrid queries (for anything more complex, use
+`--request` with a full JSON body):
+
+| Flag | Purpose |
+|---|---|
+| `--vector-field <NAME>` | Vector field to search. |
+| `--vector <JSON>` | Query vector as a JSON array, e.g. `[0.1,-0.2,0.5]`. |
+| `--alpha <0.0-1.0>` | Hybrid blend (default `0.5`; `0.0` = pure vector, `1.0` = pure BM25). |
+| `--vector-k <N>` | Number of ANN neighbours to retrieve. |
+| `--vector-ef-search <N>` | HNSW beam width at query time. |
+| `--vector-candidates <N>` | Over-sampling size before re-ranking. |
+
+### Reading a request from stdin
+
+`--request-stdin` is handy when you want to build a request from another tool
+(e.g., `jq`, a shell variable, or another program):
+
+```bash
+cat request.json | searchlite search "$INDEX" --request-stdin
+
+# Or build one on the fly
+jq -n '{query: "rust", limit: 5, return_stored: true}' \
+  | searchlite search "$INDEX" --request-stdin
+```
+
+When `--request` or `--request-stdin` is used, every other flag is ignored --
+the JSON body is authoritative.
+
+---
+
 ## Pagination with cursors
 
 Search responses include `next_cursor` when more results are available:
@@ -186,6 +290,79 @@ large indexes where you need maximum throughput.
 ## Tips
 
 - Use `--request-stdin` to pipe a JSON request from another command.
-- When a `--request` file is provided, individual CLI flags (`--q`, `--filter`, etc.) are ignored.
+- When a `--request` file is provided, individual CLI flags (`-q`, `--filter`, etc.) are ignored.
 - The CLI uses filesystem storage only; for in-memory indexes, use the Rust API.
 - For development, you can run the CLI via cargo: `cargo run -p searchlite-cli -- <command> ...`
+
+---
+
+## A complete worked example
+
+This end-to-end script walks through the full lifecycle -- schema, ingest,
+search, maintenance -- using only the CLI.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+INDEX=/tmp/blog_idx
+
+# --- 1. Schema: title + body for text search, tag + year for filtering ---
+cat > /tmp/schema.json <<'EOF'
+{
+  "doc_id_field": "_id",
+  "analyzers": [
+    { "name": "en", "tokenizer": "default",
+      "filters": [{ "stopwords": "en" }, { "stemmer": "english" }] }
+  ],
+  "text_fields": [
+    { "name": "title", "analyzer": "en", "stored": true, "indexed": true },
+    { "name": "body",  "analyzer": "en", "stored": true, "indexed": true }
+  ],
+  "keyword_fields": [
+    { "name": "tag",  "stored": true, "indexed": true, "fast": true }
+  ],
+  "numeric_fields": [
+    { "name": "year", "i64": true,  "fast": true, "stored": true }
+  ]
+}
+EOF
+
+# --- 2. Create the index ---
+searchlite init "$INDEX" /tmp/schema.json
+
+# --- 3. Add a handful of documents ---
+cat > /tmp/posts.jsonl <<'EOF'
+{"_id":"p1","title":"Why Rust is winning",       "body":"Safe systems programming",       "tag":"rust",   "year":2024}
+{"_id":"p2","title":"Intro to BM25",             "body":"How search engines rank results", "tag":"search", "year":2023}
+{"_id":"p3","title":"SQLite for embedded data",  "body":"A single-file database",          "tag":"data",   "year":2022}
+EOF
+searchlite add    "$INDEX" /tmp/posts.jsonl
+searchlite commit "$INDEX"
+
+# --- 4. A plain full-text query ---
+searchlite search "$INDEX" -q "rust" --return-stored --limit 5
+
+# --- 5. Aggregations (faceted navigation) ---
+searchlite search "$INDEX" -q "*" --limit 0 \
+  --aggs '{"tags": {"type": "terms", "field": "tag", "size": 10}}'
+
+# --- 6. Full JSON request (filters + highlighting) ---
+cat > /tmp/req.json <<'EOF'
+{
+  "query": { "type": "query_string", "query": "rust search" },
+  "filter": { "I64Range": { "field": "year", "min": 2023, "max": 2025 } },
+  "return_stored": true,
+  "highlight_field": "body",
+  "limit": 5
+}
+EOF
+searchlite search "$INDEX" --request /tmp/req.json
+
+# --- 7. Maintenance ---
+searchlite inspect "$INDEX"      # Inspect manifest and segments
+searchlite compact "$INDEX"      # Merge segments when the index is hot
+```
+
+Run it once and you have a fully working, searchable index -- with no servers
+to run, no cluster to provision, and no build tools beyond `sh` and `curl`.

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -64,10 +64,13 @@ Key notes:
 This is a minimal but complete C program that opens an index, adds two
 documents, commits, and runs a search. Save it as `demo.c`.
 
-> Before running it, initialize the index with the CLI so the schema is
-> already on disk (the FFI surface does not include schema creation). Run
-> `searchlite init /tmp/ffi_idx schema.json` where `schema.json` contains at
-> least a text `body` field.
+> The example below calls `searchlite_index_open(..., create_if_missing=true)`
+> which creates a new index with the built-in default schema
+> (`Schema::default_text_body()` -- a single text `body` field). The FFI surface
+> does not let you *customise* the schema, so if you need keyword fields,
+> numeric fields, nested fields, or analyzer configuration, initialise the
+> index first with the CLI (`searchlite init /tmp/ffi_idx schema.json`) or the
+> HTTP `/init` endpoint, then open it from C with `create_if_missing=false`.
 
 ```c
 #include <stdio.h>

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -56,3 +56,113 @@ Key notes:
 - Searches default to `return_stored: false` -- set it explicitly when you need field values.
 - All strings are C-compatible null-terminated UTF-8.
 - See [bindings.md](bindings.md) for a quick reference of binding behaviors and memory management.
+
+---
+
+## A complete C example
+
+This is a minimal but complete C program that opens an index, adds two
+documents, commits, and runs a search. Save it as `demo.c`.
+
+> Before running it, initialize the index with the CLI so the schema is
+> already on disk (the FFI surface does not include schema creation). Run
+> `searchlite init /tmp/ffi_idx schema.json` where `schema.json` contains at
+> least a text `body` field.
+
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "searchlite.h"
+
+int main(void) {
+  // 1. Open (or create) the index. Pass `true` for create_if_missing to auto-
+  //    initialize the directory. If you need a custom schema, initialize via
+  //    the CLI (`searchlite init ... schema.json`) beforehand.
+  IndexHandle* idx = searchlite_index_open("/tmp/ffi_idx", true);
+  if (!idx) {
+    fprintf(stderr, "failed to open index\n");
+    return 1;
+  }
+
+  // 2. Queue two documents. The bodies are JSON objects keyed by field names.
+  const char* doc1 = "{\"_id\":\"1\",\"body\":\"Rust is fast\"}";
+  const char* doc2 = "{\"_id\":\"2\",\"body\":\"SQLite is embedded\"}";
+  if (searchlite_add_json(idx, doc1, strlen(doc1)) < 0 ||
+      searchlite_add_json(idx, doc2, strlen(doc2)) < 0) {
+    fprintf(stderr, "add failed\n");
+    searchlite_index_close(idx);
+    return 1;
+  }
+
+  // 3. Commit to make the docs searchable.
+  if (searchlite_commit(idx) < 0) {
+    fprintf(stderr, "commit failed\n");
+    searchlite_index_close(idx);
+    return 1;
+  }
+
+  // 4. Run a search. We allocate a buffer for the JSON response; if the
+  //    result is truncated, retry with a bigger buffer.
+  const char* request =
+    "{\"query\":\"rust\",\"limit\":5,\"return_stored\":true}";
+  char buf[64 * 1024] = {0};
+  size_t written = searchlite_search_request(
+      idx, request, strlen(request), buf, sizeof(buf));
+
+  if (written == 0) {
+    fprintf(stderr, "search produced no bytes\n");
+  } else if (written == sizeof(buf) - 1) {
+    fprintf(stderr, "result may be truncated -- retry with larger buffer\n");
+  } else {
+    printf("%s\n", buf);
+  }
+
+  // 5. Always close the handle.
+  searchlite_index_close(idx);
+  return 0;
+}
+```
+
+Compile and run on Linux:
+
+```bash
+# Build the shared library + header
+cargo build -p searchlite-ffi --release --features ffi
+
+# Compile the C demo against it
+cc demo.c \
+   -I searchlite-ffi \
+   -L target/release -lsearchlite_ffi \
+   -o demo
+LD_LIBRARY_PATH=target/release ./demo
+```
+
+(macOS users swap `LD_LIBRARY_PATH` for `DYLD_LIBRARY_PATH` and link against
+`libsearchlite_ffi.dylib` -- the compile line is otherwise identical.)
+
+### Working with a write-key protected index
+
+If the index was created with a write key, every mutating call needs the
+matching `_with_write_key` variant:
+
+```c
+IndexHandle* idx =
+  searchlite_index_open_with_write_key("/tmp/ffi_idx", false, "my-secret");
+
+int rc = searchlite_add_json_with_write_key(idx, doc1, strlen(doc1), "my-secret");
+if (rc == SEARCHLITE_ERR_WRITE_KEY) {
+  fprintf(stderr, "missing or incorrect write key\n");
+}
+```
+
+Read calls (`searchlite_search`, `searchlite_search_request`) never take a
+write key. See [write-key.md](write-key.md) for how to create a protected index.
+
+### Handling panics across the boundary
+
+A bug in Searchlite could theoretically panic inside a mutating call. If that
+happens, the FFI catches the panic and returns `SEARCHLITE_ERR_PANIC` (`-100`).
+Treat it as a hard error: close the handle, reopen it, and decide whether to
+retry. Never keep using a handle that returned `-100` from an `add`/`commit`
+call without reopening -- on-disk state may be mid-write.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -203,3 +203,57 @@ You can freely combine top-level field filters with nested filters.
 - For nested filters, wrap each condition in its own `Nested` block to enforce per-object binding.
 - Stored nested fields preserve their original structure in results; unstored fields are omitted.
 - Filters are applied after scoring, so they don't affect relevance rankings -- they only include/exclude documents.
+
+---
+
+## Filter cheat sheet
+
+A single glance reference for every variant shipped with Searchlite. Every
+filter is a JSON object keyed by its variant name -- Searchlite dispatches on
+the key.
+
+| Variant | Shape | Typical use |
+|---|---|---|
+| `KeywordEq` | `{ field, value }` | Single exact match on a keyword field |
+| `KeywordIn` | `{ field, values[] }` | Multi-select checkboxes ("red OR blue") |
+| `I64Range` | `{ field, min, max }` | Inclusive integer range, e.g. year/count |
+| `F64Range` | `{ field, min, max }` | Inclusive float range, e.g. price/rating |
+| `Nested` | `{ path, filter }` | Enforce per-object binding on nested arrays |
+| `And` | `[filter, filter, ...]` | All clauses must match |
+| `Or` | `[filter, filter, ...]` | Any clause must match |
+| `Not` | `filter` | Invert a filter (useful for "hide archived") |
+
+### A tour in one request
+
+Below is a single request that uses nearly every filter variant. Read it as a
+realistic "e-commerce catalog" request:
+
+```json
+{
+  "query": "wireless headphones",
+  "filter": {
+    "And": [
+      { "KeywordEq": { "field": "category", "value": "electronics" } },
+      { "Or": [
+        { "KeywordIn": { "field": "brand", "values": ["AudioCo", "SoundPro"] } },
+        { "F64Range":  { "field": "rating", "min": 4.5, "max": 5.0 } }
+      ]},
+      { "Not": { "KeywordEq": { "field": "status", "value": "archived" } } },
+      { "I64Range": { "field": "price_cents", "min": 2000, "max": 25000 } },
+      { "Nested": {
+          "path": "review",
+          "filter": { "And": [
+            { "KeywordEq": { "field": "author", "value": "alice" } },
+            { "I64Range":  { "field": "rating", "min": 4, "max": 5 } }
+          ]}
+      }}
+    ]
+  },
+  "limit": 10,
+  "return_stored": true
+}
+```
+
+In plain English: *show me electronics in stock for $20-$250, either from an
+approved brand OR with a rating >= 4.5, excluding anything archived, where
+Alice left a 4- or 5-star review on the same product.*

--- a/docs/http.md
+++ b/docs/http.md
@@ -37,25 +37,66 @@ You can mount multiple indexes with repeated `--index` flags (e.g., `--index pro
 
 ## Configuration
 
-| Flag / Env Var | Default | Purpose |
-|---|---|---|
-| `--index` / `SEARCHLITE_INDEX_MAP` | -- | NAME:PATH index mounts (repeatable; semicolon-delimited for env). Per-index overrides: `--index "items:/data,auto_commit=30,auto_refresh=10"` |
-| `--alias` / `SEARCHLITE_INDEX_ALIASES` | -- | ALIAS:TARGET indirections (semicolon-delimited for env) |
-| `--bind` / `SEARCHLITE_BIND_ADDR` | `127.0.0.1:8080` | Listen address |
-| `--require-existing-index` | false | Fail at startup if manifest is missing |
-| `--auto-commit-interval-secs` / `SEARCHLITE_AUTO_COMMIT_INTERVAL_SECS` | `0` (disabled) | Global auto-commit interval. Disabled on write-key-protected indexes |
-| `--auto-refresh-interval-secs` / `SEARCHLITE_AUTO_REFRESH_INTERVAL_SECS` | `0` (disabled) | Global auto-refresh interval |
-| `--max-body-bytes` | -- | Max request body size |
-| `--max-concurrency` | -- | Max concurrent requests |
-| `--request-timeout-secs` | -- | Per-request timeout |
-| `--shutdown-grace-secs` | -- | Graceful shutdown window |
-| `--refresh-on-commit` | false | Auto-refresh readers after each commit |
+| Flag | Env Var | Default | Purpose |
+|---|---|---|---|
+| `--index`, `-I` | `SEARCHLITE_INDEX_MAP` | *(required)* | `NAME:PATH` index mount (repeatable; semicolon-delimited for env). Supports per-index overrides, see below. |
+| `--alias` | `SEARCHLITE_INDEX_ALIASES` | -- | `ALIAS:TARGET` indirections that point one name at another mounted index (semicolon-delimited for env) |
+| `--bind` | `SEARCHLITE_BIND_ADDR` | `127.0.0.1:8080` | Listen address |
+| `--require-existing-index` | `SEARCHLITE_REQUIRE_EXISTING_INDEX` | `false` | Fail at startup if an index's manifest is missing |
+| `--max-body-bytes` | `SEARCHLITE_MAX_BODY_BYTES` | `52428800` (50 MiB) | Max request body size in bytes |
+| `--max-concurrency` | `SEARCHLITE_MAX_CONCURRENCY` | `64` | Max concurrent in-flight requests |
+| `--request-timeout-secs` | `SEARCHLITE_REQUEST_TIMEOUT_SECS` | `30` | Per-request timeout in seconds |
+| `--shutdown-grace-secs` | `SEARCHLITE_GRACEFUL_SHUTDOWN_SECS` | `5` | Graceful shutdown window after a SIGTERM/SIGINT |
+| `--refresh-on-commit` | `SEARCHLITE_REFRESH_ON_COMMIT` | `false` | Auto-refresh readers after each commit so writes become searchable immediately |
+| `--auto-commit-interval-secs` | `SEARCHLITE_AUTO_COMMIT_INTERVAL_SECS` | `0` (disabled) | Default auto-commit interval for all indexes (seconds). Disabled on write-key-protected indexes. |
+| `--auto-refresh-interval-secs` | `SEARCHLITE_AUTO_REFRESH_INTERVAL_SECS` | `0` (disabled) | Default auto-refresh interval for all indexes (seconds) |
+| `--max-vector-candidates`&nbsp;⚙️ | `SEARCHLITE_MAX_VECTOR_CANDIDATES` | *(vectors feature only)* | Global cap on combined vector candidates across clauses |
 
 All errors return `{"error": {"type": "...", "reason": "..."}}`.
+
+### Per-index overrides
+
+The `--index` flag accepts a comma-delimited tail that overrides global settings
+for a single mount. Useful when you want different refresh cadences per index:
+
+```bash
+# Two indexes with different auto-commit/auto-refresh cadences:
+searchlite http \
+  --index "orders:/data/orders,auto_commit=5,auto_refresh=5" \
+  --index "catalog:/data/catalog,auto_commit=300"
+```
+
+Supported override keys:
+- `auto_commit=<seconds>` -- overrides `--auto-commit-interval-secs` for this index
+- `auto_refresh=<seconds>` -- overrides `--auto-refresh-interval-secs` for this index
+
+Per-index values take precedence over the global defaults.
+
+### Environment variables
+
+Every CLI flag can be set via environment variable. This is the typical pattern
+for containerised deployments:
+
+```bash
+export SEARCHLITE_INDEX_MAP="default:/data;orders:/data/orders"
+export SEARCHLITE_BIND_ADDR="0.0.0.0:8080"
+export SEARCHLITE_REFRESH_ON_COMMIT=true
+searchlite http
+```
+
+Use `;` (semicolon) to separate multiple entries in `SEARCHLITE_INDEX_MAP` and
+`SEARCHLITE_INDEX_ALIASES`.
 
 ---
 
 ## API endpoints
+
+### Service-level
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| GET | `/healthz` | Liveness probe. Returns `{ "status": "ok" }` — use it from load balancers and Kubernetes liveness/readiness checks. |
+| GET | `/indexes` | List every mounted index and alias, with document counts, last commit times, and per-index auto-commit/auto-refresh settings. |
 
 ### Index lifecycle
 
@@ -82,11 +123,23 @@ All errors return `{"error": {"type": "...", "reason": "..."}}`.
 
 | Method | Endpoint | Purpose |
 |---|---|---|
-| POST | `/indexes/{name}/update` | Partial update (set/unset fields) |
-| POST | `/indexes/{name}/_bulk_update` | Batch partial updates (NDJSON) |
+| POST | `/indexes/{name}/update` | Partial update (set/unset fields on a single document) |
+| POST | `/indexes/{name}/_bulk_update` | Batch partial updates (NDJSON action/patch pairs) |
 | POST | `/indexes/{name}/delete` | Delete documents by ID |
 
 Writes are **buffered** -- documents are not visible to search until you call `/commit`.
+
+### Request body formats at a glance
+
+| Endpoint | Content-Type | Body shape |
+|---|---|---|
+| `/init` | `application/json` | A `Schema` object (see [schema.md](schema.md)) |
+| `/add` | `application/x-ndjson` | One JSON document per line (NDJSON) |
+| `/bulk` | `application/json` | `{ "docs": [ {...}, {...} ] }` -- must contain at least one document |
+| `/update` | `application/json` | `{ "id": "...", "set": {...}, "unset": [...] }` -- at least one of set/unset required |
+| `/_bulk_update` | `application/x-ndjson` | Alternating lines: an action (`{"update": {"_id":"..."}}`) followed by the patch body |
+| `/delete` | `application/json` | `{ "ids": ["id1", "id2"] }` -- at least one id required |
+| `/search`, `/multi_search`, `/mget` | `application/json` | Fully-typed request objects (see below) |
 
 ---
 
@@ -129,17 +182,40 @@ curl -XPOST http://localhost:8080/indexes/products/search \
 
 ### Pagination
 
-Three mutually exclusive pagination modes:
+Searchlite supports three mutually exclusive pagination modes. Pick the one
+that best matches your UI:
+
+| Mode | Best for | Scaling |
+|---|---|---|
+| **Offset** (`from` + `size`) | Classic "page 1, 2, 3" navigation with a known page count. | Bounded to `from + size <= 1000`. Use cursor or search_after for deep pagination. |
+| **`search_after`** | "Next page" APIs that sort by stable fields (dates, IDs, prices). | Unbounded; requires an explicit `sort` clause. |
+| **`cursor`** | Infinite scroll or "load more" where you don't sort. | Unbounded; tokens are opaque and bounded to ~50K results per cursor. |
 
 ```bash
-# Offset pagination (from + size, max 1000)
+# 1. Offset pagination
 curl -XPOST .../search -d '{"query": "rust", "from": 10, "size": 5}'
 
-# search_after (use next_search_after from previous response)
-curl -XPOST .../search -d '{"query": "rust", "sort": [{"field": "year", "order": "asc"}], "size": 5, "search_after": [2024, "doc-42", 0]}'
+# 2. search_after -- use next_search_after from the previous response
+curl -XPOST .../search -d '{
+  "query": "rust",
+  "sort":  [{"field": "year", "order": "asc"}, {"field": "_id", "order": "asc"}],
+  "size":  5,
+  "search_after": [2024, "doc-42"]
+}'
 
-# Cursor (use next_cursor from previous response)
-curl -XPOST .../search -d '{"query": "rust", "limit": 5, "cursor": "..."}'
+# 3. Cursor -- pull next_cursor from the previous response
+curl -XPOST .../search -d '{"query": "rust", "limit": 5, "cursor": "AAEFMTIzNA=="}'
+```
+
+A typical client loop with `search_after`:
+
+```bash
+# page 1
+resp=$(curl -s -XPOST .../search -d '{"query":"rust","sort":[{"field":"_id","order":"asc"}],"size":5}')
+after=$(echo "$resp" | jq -c '.next_search_after')
+
+# page 2
+curl -s -XPOST .../search -d "{\"query\":\"rust\",\"sort\":[{\"field\":\"_id\",\"order\":\"asc\"}],\"size\":5,\"search_after\":$after}"
 ```
 
 ### Fetch documents by ID
@@ -152,10 +228,46 @@ curl -XPOST http://localhost:8080/indexes/products/mget \
 
 ### Partial update
 
+A single-document patch. `set` writes or overwrites fields, `unset` removes
+them. You must provide at least one of the two.
+
 ```bash
 curl -XPOST http://localhost:8080/indexes/products/update \
   -H 'Content-Type: application/json' \
-  -d '{"id": "product-1", "set": {"in_stock": true, "price_cents": 2499}, "unset": ["sale_label"]}'
+  -d '{
+    "id": "product-1",
+    "set":   { "in_stock": true, "price_cents": 2499 },
+    "unset": ["sale_label"]
+  }'
+```
+
+### Bulk updates (NDJSON action stream)
+
+For updating many documents in one request, use `_bulk_update`. The body is
+NDJSON with two lines per operation: an action descriptor followed by the
+patch body.
+
+```bash
+cat > /tmp/bulk.ndjson <<'EOF'
+{"update":{"_id":"product-1"}}
+{"set":{"in_stock":true,"price_cents":2499}}
+{"update":{"_id":"product-2"}}
+{"set":{"price_cents":3499},"unset":["sale_label"]}
+EOF
+
+curl -XPOST http://localhost:8080/indexes/products/_bulk_update \
+  -H 'Content-Type: application/x-ndjson' \
+  --data-binary @/tmp/bulk.ndjson
+curl -XPOST http://localhost:8080/indexes/products/commit
+```
+
+### Delete documents
+
+```bash
+curl -XPOST http://localhost:8080/indexes/products/delete \
+  -H 'Content-Type: application/json' \
+  -d '{"ids": ["product-discontinued-1", "product-discontinued-2"]}'
+curl -XPOST http://localhost:8080/indexes/products/commit
 ```
 
 ### Multi-search
@@ -184,6 +296,80 @@ curl -XPOST .../indexes/products/refresh   # reload readers
 curl -XPOST .../indexes/products/compact    # merge segments
 curl -XGET  .../indexes/products/inspect    # view manifest
 curl -XGET  .../indexes/products/stats      # doc/segment counts
+```
+
+### Service-level: health and discovery
+
+```bash
+# Liveness probe (no index required)
+curl -s http://localhost:8080/healthz
+# -> {"status":"ok"}
+
+# List every mounted index (and aliases)
+curl -s http://localhost:8080/indexes
+# -> {
+#      "indexes": [
+#        { "name": "products", "path": "/data/products", "exists": true,
+#          "doc_count": 1042, "committed_at": "2025-01-03T12:01:04Z",
+#          "auto_commit_secs": 0, "auto_refresh_secs": 0,
+#          "refresh_on_commit": false }
+#      ],
+#      "aliases": []
+#    }
+```
+
+`/healthz` is cheap and never touches the indexes -- wire it into your load
+balancer's health check. `/indexes` is ideal for building admin UIs or
+verifying a deployment mounted what you expected.
+
+---
+
+## End-to-end: a minimal HTTP tour
+
+This is a complete, copy-paste-able script that exercises most of the HTTP API.
+It assumes a server running on `localhost:8080` with `--index default:/tmp/http_tour`.
+
+```bash
+BASE=http://localhost:8080/indexes/default
+
+# 1. Schema: one text field, one keyword field, one numeric
+cat > /tmp/schema.json <<'EOF'
+{
+  "doc_id_field": "_id",
+  "text_fields":    [{"name": "body", "analyzer": "default", "stored": true, "indexed": true}],
+  "keyword_fields": [{"name": "tag",  "stored": true, "indexed": true, "fast": true}],
+  "numeric_fields": [{"name": "year", "i64": true,  "fast": true, "stored": true}]
+}
+EOF
+curl -s -XPOST "$BASE/init" -H 'Content-Type: application/json' --data-binary @/tmp/schema.json
+
+# 2. Ingest via NDJSON
+cat > /tmp/docs.ndjson <<'EOF'
+{"_id":"a","body":"Rust search","tag":"rust","year":2024}
+{"_id":"b","body":"SQLite internals","tag":"data","year":2023}
+{"_id":"c","body":"BM25 explained","tag":"search","year":2024}
+EOF
+curl -s -XPOST "$BASE/add" -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/docs.ndjson
+curl -s -XPOST "$BASE/commit"
+
+# 3. Search with a filter and an aggregation
+curl -s -XPOST "$BASE/search" -H 'Content-Type: application/json' -d '{
+  "query": "search",
+  "filter": { "I64Range": { "field": "year", "min": 2024, "max": 2024 } },
+  "return_stored": true,
+  "aggs": { "tags": { "type": "terms", "field": "tag", "size": 5 } }
+}'
+
+# 4. Patch one document
+curl -s -XPOST "$BASE/update" -H 'Content-Type: application/json' \
+  -d '{"id":"a","set":{"year":2025}}'
+curl -s -XPOST "$BASE/commit"
+
+# 5. Clean up stale content
+curl -s -XPOST "$BASE/delete" -H 'Content-Type: application/json' \
+  -d '{"ids":["b"]}'
+curl -s -XPOST "$BASE/commit"
+curl -s -XPOST "$BASE/compact"
 ```
 
 The full API surface is also documented in `openapi.yaml` at the repo root.

--- a/docs/http.md
+++ b/docs/http.md
@@ -189,14 +189,15 @@ that best matches your UI:
 |---|---|---|
 | **Offset** (`from` + `size`) | Classic "page 1, 2, 3" navigation with a known page count. | Bounded to `from + size <= 1000`. Use cursor or search_after for deep pagination. |
 | **`search_after`** | "Next page" APIs that sort by stable fields (dates, IDs, prices). | Unbounded; requires an explicit `sort` clause. |
-| **`cursor`** | Infinite scroll or "load more" where you don't sort. | Unbounded; tokens are opaque and bounded to ~50K results per cursor. |
+| **`cursor`** | Infinite scroll or "load more". Works with or without an explicit `sort`. | Tokens are opaque hex strings bounded to ~50K results per cursor. Cursors can become stale if the index is committed to between pages. |
 
 ```bash
 # 1. Offset pagination
 curl -XPOST .../search -d '{"query": "rust", "from": 10, "size": 5}'
 
-# 2. Cursor -- pull next_cursor from the previous response
-curl -XPOST .../search -d '{"query": "rust", "limit": 5, "cursor": "AAEFMTIzNA=="}'
+# 2. Cursor -- pull next_cursor from the previous response and pass it through
+#    verbatim. Cursors are hex-encoded opaque tokens; do not hand-craft them.
+curl -XPOST .../search -d "{\"query\": \"rust\", \"limit\": 5, \"cursor\": \"$NEXT_CURSOR\"}"
 ```
 
 `search_after` tokens are opaque positional arrays whose exact shape depends

--- a/docs/http.md
+++ b/docs/http.md
@@ -195,28 +195,36 @@ that best matches your UI:
 # 1. Offset pagination
 curl -XPOST .../search -d '{"query": "rust", "from": 10, "size": 5}'
 
-# 2. search_after -- use next_search_after from the previous response
-curl -XPOST .../search -d '{
-  "query": "rust",
-  "sort":  [{"field": "year", "order": "asc"}, {"field": "_id", "order": "asc"}],
-  "size":  5,
-  "search_after": [2024, "doc-42"]
-}'
-
-# 3. Cursor -- pull next_cursor from the previous response
+# 2. Cursor -- pull next_cursor from the previous response
 curl -XPOST .../search -d '{"query": "rust", "limit": 5, "cursor": "AAEFMTIzNA=="}'
 ```
 
-A typical client loop with `search_after`:
+`search_after` tokens are opaque positional arrays whose exact shape depends
+on your `sort` clause (one entry per sort field, plus the document ID and
+segment ordinal that uniquely anchor the cursor on the previous page's last
+hit). Treat them as black boxes: always lift `next_search_after` verbatim
+from the previous response and hand it back to the next request. Hand-crafting
+the values is error-prone and will be rejected.
 
 ```bash
 # page 1
-resp=$(curl -s -XPOST .../search -d '{"query":"rust","sort":[{"field":"_id","order":"asc"}],"size":5}')
+resp=$(curl -s -XPOST .../search -d '{
+  "query": "rust",
+  "sort":  [{"field": "year", "order": "asc"}, {"field": "_id", "order": "asc"}],
+  "size":  5
+}')
 after=$(echo "$resp" | jq -c '.next_search_after')
 
-# page 2
-curl -s -XPOST .../search -d "{\"query\":\"rust\",\"sort\":[{\"field\":\"_id\",\"order\":\"asc\"}],\"size\":5,\"search_after\":$after}"
+# page 2 — pass the token through unchanged
+curl -s -XPOST .../search -d "{
+  \"query\": \"rust\",
+  \"sort\":  [{\"field\":\"year\",\"order\":\"asc\"},{\"field\":\"_id\",\"order\":\"asc\"}],
+  \"size\":  5,
+  \"search_after\": $after
+}"
 ```
+
+When `next_search_after` is `null`, you've reached the last page.
 
 ### Fetch documents by ID
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -369,7 +369,7 @@ tune how the search engine runs. The most common are:
 | `track_total_hits` | `false` | When `true`, Searchlite counts every matching document, even with WAND pruning enabled. Set it when you need exact total counts (e.g., "Page 1 of 37"). Leave it off for infinite-scroll / "load more" UIs. |
 | `execution` | `"wand"` | Scoring strategy -- `"wand"`, `"bmw"`, or `"bm25"`. See [Query execution modes in the CLI guide](cli.md#query-execution-modes). |
 | `bmw_block_size` | engine default | Advanced: override the per-block posting size used by the `bmw` execution strategy. Only relevant when `"execution": "bmw"`. |
-| `candidate_size` | `limit` | Oversampling pool before re-ranking or collapsing (also used by hybrid vector search). Increase for better recall at the cost of latency. |
+| `candidate_size` | `from + limit` (the page window) | Oversampling pool before re-ranking or collapsing. When offset pagination is used the default grows to the page window so the engine can still fill `limit` hits after skipping `from`. Vector / hybrid queries compute their own default from `limit` and `k`. Increase explicitly for better recall at the cost of latency. |
 
 Example of "pure analytics" mode -- no hits, just facets:
 

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -26,6 +26,7 @@ The `query_string` node supports field-scoped terms (`title:rust`), phrases in q
 
 | Type | Purpose | Example use case |
 |---|---|---|
+| `match_all` | Match every document in the index | Pure aggregation requests, "browse all" UIs |
 | `query_string` | Free-text search across fields | Search bar in any application |
 | `term` | Exact match on a single analyzed term | Internal lookups by known token |
 | `prefix` | Match terms starting with a prefix | Autocomplete in a search box |
@@ -39,6 +40,81 @@ The `query_string` node supports field-scoped terms (`title:rust`), phrases in q
 | `function_score` | Customize scoring with functions | Boost popular or recent results |
 | `rank_feature` | Boost by a numeric field value | Sort-by-popularity without losing relevance |
 | `script_score` | Arithmetic expressions over fields | Custom ranking formulas |
+| `vector` ⚙️ | ANN search over an embedding field (requires `vectors` feature) | Semantic search / "find similar" |
+
+---
+
+## Simple queries, step by step
+
+If you're new to search engines, start here. Every example below produces a
+complete request body you can paste into `/indexes/{name}/search`.
+
+### `match_all` — "every document"
+
+Useful when you only care about aggregations, or when you need a paginated
+browse page with no search term entered yet:
+
+```json
+{
+  "query": { "type": "match_all" },
+  "limit": 20,
+  "return_stored": true
+}
+```
+
+### `query_string` — "the usual search bar"
+
+The input in most UIs. It tokenises the query with the target field's analyzer,
+supports field-scoped terms (`title:rust`), quoted phrases (`"machine learning"`),
+and negation (`-draft`):
+
+```json
+{
+  "query": {
+    "type": "query_string",
+    "query": "\"machine learning\" -draft title:rust",
+    "fields": ["title", "body"]
+  },
+  "limit": 10
+}
+```
+
+### `term` — "exact analyzed match on one field"
+
+Unlike `query_string`, `term` runs a single analyzed token straight against the
+inverted index. Use it when you already know the token you want (from a filter,
+an autocomplete suggestion, a link click, etc.):
+
+```json
+{ "query": { "type": "term", "field": "title", "value": "rust" } }
+```
+
+The value is still passed through the field's analyzer -- so for most text
+fields `"Rust"` and `"rust"` are equivalent.
+
+### `bool` — "combine clauses"
+
+`bool` is the workhorse of non-trivial search. Each slot has a defined role:
+
+- **`must`** -- clauses that *must* match and contribute to the score
+- **`should`** -- optional boosts; non-matching documents are still returned
+- **`must_not`** -- exclusions; non-scoring
+- **`filter`** -- *must* match, but like filters elsewhere, does not affect scores
+
+```json
+{
+  "query": {
+    "type": "bool",
+    "must":     [ { "type": "query_string", "query": "laptop" } ],
+    "should":   [ { "type": "term",         "field": "brand", "value": "framework" } ],
+    "must_not": [ { "type": "term",         "field": "status", "value": "archived" } ],
+    "filter":   [
+      { "type": "constant_score",
+        "filter": { "KeywordEq": { "field": "in_stock", "value": "true" } } }
+    ]
+  }
+}
+```
 
 ---
 
@@ -280,6 +356,36 @@ re-ranks them with phrase proximity. This gives you phrase-quality results at BM
 
 ---
 
+## Request-level tuning knobs
+
+Beyond the query itself, a `SearchRequest` exposes a handful of fields that
+tune how the search engine runs. The most common are:
+
+| Field | Default | What it does |
+|---|---|---|
+| `limit` | `10` | Max hits returned (alias: `size`). Set to `0` to skip hit ranking and only run aggregations. |
+| `from` | `0` | Offset-pagination skip count; `from + limit` must not exceed `1000`. |
+| `return_hits` | `true` | When `false`, omits the `hits` array from the response. Perfect for pure aggregation requests where you want the facets but not the documents. |
+| `return_stored` | `false` | When `true`, each hit includes the stored fields (title, body, price, …). Off by default so responses stay compact. |
+| `track_total_hits` | `false` | When `true`, Searchlite counts every matching document, even with WAND pruning enabled. Set it when you need exact total counts (e.g., "Page 1 of 37"). Leave it off for infinite-scroll / "load more" UIs. |
+| `execution` | `"wand"` | Scoring strategy -- `"wand"`, `"bmw"`, or `"bm25"`. See [Query execution modes in the CLI guide](cli.md#query-execution-modes). |
+| `bmw_block_size` | engine default | Advanced: override the per-block posting size used by the `bmw` execution strategy. Only relevant when `"execution": "bmw"`. |
+| `candidate_size` | `limit` | Oversampling pool before re-ranking or collapsing (also used by hybrid vector search). Increase for better recall at the cost of latency. |
+
+Example of "pure analytics" mode -- no hits, just facets:
+
+```json
+{
+  "query": { "type": "match_all" },
+  "limit": 0,
+  "return_hits": false,
+  "aggs": {
+    "tags":     { "type": "terms", "field": "tag", "size": 10 },
+    "by_year":  { "type": "histogram", "field": "year", "interval": 1 }
+  }
+}
+```
+
 ## Debugging aids
 
 When results don't look right, these flags help you understand what's happening:
@@ -290,5 +396,9 @@ When results don't look right, these flags help you understand what's happening:
 - **`profile: true`** -- attaches execution stats (`candidates_examined`, `scored_docs`,
   postings advances) and timing buckets (`search_ms`, `rescore_ms`). Useful for
   identifying slow queries.
+- **`track_total_hits: true`** -- when the `total_hits_estimate` you're seeing
+  doesn't match what you expected, this disables WAND's pruning shortcuts and
+  computes the exact total. Use it only while diagnosing -- it's measurably slower
+  on large indexes.
 
-Both flags are off by default to avoid overhead in production.
+All three flags are off by default to avoid overhead in production.

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -99,7 +99,7 @@ fields `"Rust"` and `"rust"` are equivalent.
 - **`must`** -- clauses that *must* match and contribute to the score
 - **`should`** -- optional boosts; non-matching documents are still returned
 - **`must_not`** -- exclusions; non-scoring
-- **`filter`** -- *must* match, but like filters elsewhere, does not affect scores
+- **`filter`** -- *must* match, but does not affect scores. Unlike `must`/`should`/`must_not`, each entry here is a `Filter` variant (`KeywordEq`, `I64Range`, `Nested`, …), not a query node.
 
 ```json
 {
@@ -109,8 +109,7 @@ fields `"Rust"` and `"rust"` are equivalent.
     "should":   [ { "type": "term",         "field": "brand", "value": "framework" } ],
     "must_not": [ { "type": "term",         "field": "status", "value": "archived" } ],
     "filter":   [
-      { "type": "constant_score",
-        "filter": { "KeywordEq": { "field": "in_stock", "value": "true" } } }
+      { "KeywordEq": { "field": "in_stock", "value": "true" } }
     ]
   }
 }

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -239,10 +239,11 @@ for hit in &results.hits {
 ### Available builder methods
 
 The builder only covers the most common fields; for anything else, construct
-the `SearchRequest` directly and override fields. All fields listed in
-[Request-level tuning knobs](queries.md#request-level-tuning-knobs) (including
-`track_total_hits`, `bmw_block_size`, `candidate_size`, `explain`, `profile`,
-`return_hits`, `execution`) are set this way.
+the `SearchRequest` directly and override fields. This is how you set the
+tuning knobs from [queries.md#request-level-tuning-knobs](queries.md#request-level-tuning-knobs)
+(`track_total_hits`, `bmw_block_size`, `candidate_size`, `return_hits`,
+`execution`) as well as the debugging flags from
+[queries.md#debugging-aids](queries.md#debugging-aids) (`explain`, `profile`).
 
 | Method | Purpose |
 |---|---|
@@ -300,8 +301,10 @@ pub struct Hit {
 
 ### Pagination: cursor, search_after, offset
 
-`SearchResult` exposes three mutually-exclusive pagination tokens; pick the one
-that matches how your UI lets users move through results.
+Searchlite supports three mutually-exclusive pagination modes. Pick the one
+that matches how your UI lets users move through results. The first mode
+(offset) uses `from`/`limit` directly; the other two use response tokens
+exposed on `SearchResult` (`next_cursor` / `next_search_after`).
 
 ```rust
 // Offset: classic "page 1, 2, 3" navigation (from + limit <= 1000)
@@ -332,7 +335,9 @@ if let Some(after) = first.next_search_after.clone() {
 ```
 
 Offset pagination is capped at `from + limit <= 1000`. For anything beyond
-that, use `search_after` (stable, sortable) or `cursor` (opaque, sortless).
+that, use `search_after` (unbounded, requires a stable sort) or `cursor`
+(opaque hex token bounded to ~50K advance; works with or without a sort
+clause but can become stale across commits).
 
 ### Fetching documents by ID
 

--- a/docs/rust-api.md
+++ b/docs/rust-api.md
@@ -238,6 +238,12 @@ for hit in &results.hits {
 
 ### Available builder methods
 
+The builder only covers the most common fields; for anything else, construct
+the `SearchRequest` directly and override fields. All fields listed in
+[Request-level tuning knobs](queries.md#request-level-tuning-knobs) (including
+`track_total_hits`, `bmw_block_size`, `candidate_size`, `explain`, `profile`,
+`return_hits`, `execution`) are set this way.
+
 | Method | Purpose |
 |---|---|
 | `SearchRequest::new(query)` | Create with a query (string or `QueryNode`) and sensible defaults |
@@ -250,6 +256,20 @@ for hit in &results.hits {
 | `.with_aggs(map)` | Add aggregations |
 | `.with_fuzzy(options)` | Enable typo-tolerant matching |
 | `.with_sort(specs)` | Custom sort order |
+
+For fields without a dedicated builder method, set them after construction:
+
+```rust
+let mut req = SearchRequest::new("rust search")
+    .with_limit(20)
+    .with_return_stored(true);
+req.explain = true;                                    // per-hit score breakdown
+req.profile = true;                                    // execution profile
+req.track_total_hits = Some(true);                     // exact total
+req.execution = ExecutionStrategy::Bmw;                // BMW pruning
+req.collapse = Some(CollapseRequest { /* ... */ });    // field collapsing
+req.rescore  = Some(RescoreRequest  { /* ... */ });    // two-pass re-ranking
+```
 
 ### Understanding search results
 
@@ -277,6 +297,42 @@ pub struct Hit {
     pub inner_hits: Option<Vec<Hit>>,         // when using collapse with inner_hits
 }
 ```
+
+### Pagination: cursor, search_after, offset
+
+`SearchResult` exposes three mutually-exclusive pagination tokens; pick the one
+that matches how your UI lets users move through results.
+
+```rust
+// Offset: classic "page 1, 2, 3" navigation (from + limit <= 1000)
+let page2 = reader.search(
+    &SearchRequest::new("rust").with_from(10).with_limit(10),
+)?;
+
+// Cursor: "load more" / infinite scroll -- opaque token
+let first = reader.search(&SearchRequest::new("rust").with_limit(10))?;
+if let Some(tok) = first.next_cursor.clone() {
+    let mut req = SearchRequest::new("rust").with_limit(10);
+    req.cursor = Some(tok);
+    let next = reader.search(&req)?;
+}
+
+// search_after: unbounded, needs a stable sort on at least one field
+let mut req = SearchRequest::new("rust")
+    .with_limit(10)
+    .with_sort(vec![
+        SortSpec { field: "year".into(), order: Some(SortOrder::Desc) },
+        SortSpec { field: "_id".into(),  order: Some(SortOrder::Asc)  },
+    ]);
+let first = reader.search(&req)?;
+if let Some(after) = first.next_search_after.clone() {
+    req.search_after = Some(after);
+    let next = reader.search(&req)?;
+}
+```
+
+Offset pagination is capped at `from + limit <= 1000`. For anything beyond
+that, use `search_after` (stable, sortable) or `cursor` (opaque, sortless).
 
 ### Fetching documents by ID
 

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -142,3 +142,122 @@ with defaults and tune only if you see relevant documents missing from results.
 - Responses include `vector_score` alongside `_score` (the blended score) when vector search runs.
 - Cosine vectors are normalized automatically; vectors with the wrong dimension are rejected.
 - ANN (Approximate Nearest Neighbor) via HNSW is not exact -- it trades a small amount of recall for significant speed. For most applications this is the right tradeoff.
+
+---
+
+## End-to-end: a hybrid search walkthrough
+
+This example walks through building a small semantic-search index in Rust. It
+uses 4-dimensional toy vectors so you can follow the arithmetic by eye; in
+production you'd plug in a real embedding model (see [Generating embeddings](#generating-embeddings-in-practice)
+below).
+
+```rust
+use searchlite_core::api::{
+    builder::IndexBuilder,
+    types::{
+        Document, IndexOptions, Schema, SearchRequest, StorageType,
+        TextField, VectorField, VectorMetric, VectorQuery, VectorQuerySpec,
+    },
+};
+use std::path::Path;
+
+// 1. Define a schema with a single text field and a 4-D vector field
+let mut schema = Schema::default_text_body();
+schema.vector_fields.push(VectorField {
+    name:   "embedding".into(),
+    dim:    4,
+    metric: VectorMetric::Cosine,
+    ..Default::default()
+});
+
+let opts = IndexOptions {
+    path: Path::new("/tmp/hybrid_idx").to_path_buf(),
+    create_if_missing: true,
+    enable_positions:  true,
+    bm25_k1: 0.9,
+    bm25_b:  0.4,
+    storage: StorageType::InMemory,       // swap for Filesystem to persist
+    vector_defaults: None,
+};
+let index = IndexBuilder::create(Path::new("/tmp/hybrid_idx"), schema, opts)?;
+
+// 2. Add three documents, each with an embedding
+let mut writer = index.writer()?;
+let docs = [
+    ("a", "Noise cancelling headphones",  [0.10,  0.95, 0.05, 0.00]),
+    ("b", "Studio monitor speakers",      [0.20,  0.80, 0.10, 0.05]),
+    ("c", "Wireless mechanical keyboard", [0.70,  0.10, 0.15, 0.80]),
+];
+for (id, body, emb) in docs {
+    writer.add_document(&Document {
+        fields: [
+            ("_id".into(),       serde_json::json!(id)),
+            ("body".into(),      serde_json::json!(body)),
+            ("embedding".into(), serde_json::json!(emb)),
+        ].into_iter().collect(),
+    })?;
+}
+writer.commit()?;
+
+// 3. Hybrid search: "sound equipment" (lexical) + a vector similar to audio gear
+let reader = index.reader()?;
+let req = SearchRequest::new("sound equipment")
+    .with_limit(2)
+    .with_return_stored(true);
+let req = SearchRequest {
+    vector_query: Some(VectorQuerySpec::Structured(VectorQuery {
+        field:  "embedding".into(),
+        vector: vec![0.15, 0.90, 0.07, 0.02],
+        k:      Some(10),
+        alpha:  Some(0.3),        // 70% vector, 30% BM25
+        ..Default::default()
+    })),
+    ..req
+};
+
+for hit in reader.search(&req)?.hits {
+    println!("{:<3} score={:.3} vector_score={:?}",
+        hit.doc_id, hit.score, hit.vector_score);
+}
+```
+
+Expected ordering: documents `a` and `b` (audio gear) outrank `c`, even though
+`c`'s text field matches the word "wireless" which appears elsewhere. The
+vector similarity pulls audio equipment to the top.
+
+### Generating embeddings in practice
+
+Searchlite stores and searches vectors -- it does not produce them. You create
+embeddings outside of Searchlite using an embedding model and write the
+resulting numbers into the `embedding` field of each document.
+
+Popular options:
+
+| Model | Dim | Where it runs |
+|---|---|---|
+| `all-MiniLM-L6-v2` | 384 | Locally via Sentence Transformers / `fastembed-rs` / ONNX |
+| OpenAI `text-embedding-3-small` | 1536 | OpenAI API |
+| OpenAI `text-embedding-3-large` | 3072 | OpenAI API |
+| Cohere `embed-english-v3.0` | 1024 | Cohere API |
+
+A typical pipeline looks like this:
+
+```text
+doc text ─► embedding model ─► Vec<f32> (length = dim) ─► Searchlite document
+user query ─► same embedding model ─► query vector ─► Searchlite hybrid search
+```
+
+Whatever model you pick, the **index `dim` must match the model's output
+dimension exactly**, and the **same model must be used for both indexing and
+query time** -- embeddings from different models are not compatible.
+
+### Tuning for recall
+
+Start with the defaults and only tune if you see obviously-relevant documents
+missing from results:
+
+- Raise `candidate_size` first (more candidates before re-ranking).
+- Then raise `ef_search` (HNSW beam width).
+- Only increase `m` / `ef_construction` at schema creation if the above aren't
+  enough -- they cost memory and indexing time.

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -131,9 +131,16 @@ content embedding):
 | `candidate_size` | -- | Oversampling during ANN search (higher = better recall, slower) |
 | `ef_search` | auto | HNSW beam width (higher = better recall, slower) |
 | `vector_filter` | -- | Pre-filter applied during vector candidate selection |
+| `max_global_vector_candidates` | server default | **Per-request** override of the server-wide cap on combined vector candidates across every clause in the query. Lower it to bound worst-case memory; raise it when a complex `bool`/`dis_max` with many vector subqueries is being unfairly truncated. |
 
 Raising `candidate_size` or `ef_search` improves recall at the cost of latency. Start
 with defaults and tune only if you see relevant documents missing from results.
+
+`max_global_vector_candidates` is a safety cap, not a recall lever. It is the
+per-request counterpart to the HTTP server's `--max-vector-candidates` flag
+(and `SEARCHLITE_MAX_VECTOR_CANDIDATES` env var): the server sets a ceiling,
+and an individual request can lower it further when you want tighter latency
+bounds on that one query.
 
 ---
 

--- a/docs/vectors.md
+++ b/docs/vectors.md
@@ -131,16 +131,30 @@ content embedding):
 | `candidate_size` | -- | Oversampling during ANN search (higher = better recall, slower) |
 | `ef_search` | auto | HNSW beam width (higher = better recall, slower) |
 | `vector_filter` | -- | Pre-filter applied during vector candidate selection |
-| `max_global_vector_candidates` | server default | **Per-request** override of the server-wide cap on combined vector candidates across every clause in the query. Lower it to bound worst-case memory; raise it when a complex `bool`/`dis_max` with many vector subqueries is being unfairly truncated. |
+| `max_global_vector_candidates` | server default | **Per-request** override of the default cap on combined vector candidates across every clause in the query. |
 
 Raising `candidate_size` or `ef_search` improves recall at the cost of latency. Start
 with defaults and tune only if you see relevant documents missing from results.
 
-`max_global_vector_candidates` is a safety cap, not a recall lever. It is the
-per-request counterpart to the HTTP server's `--max-vector-candidates` flag
-(and `SEARCHLITE_MAX_VECTOR_CANDIDATES` env var): the server sets a ceiling,
-and an individual request can lower it further when you want tighter latency
-bounds on that one query.
+### About `max_global_vector_candidates`
+
+This field is the per-request counterpart to the HTTP server's
+`--max-vector-candidates` flag (and `SEARCHLITE_MAX_VECTOR_CANDIDATES` env
+var). It works as a **default, not a ceiling**: when a request omits the
+field, the HTTP server fills it in with the server-configured value; when a
+request supplies it, that value wins -- whether it is lower *or* higher than
+the server default.
+
+In practice:
+
+- Operators should pick the server default to match a typical workload, not
+  to act as a hard enforcement limit. A misconfigured or malicious client can
+  set `max_global_vector_candidates` to any value it likes.
+- Clients should lower it when they want tighter latency bounds on a specific
+  query, or raise it when a complex `bool` / `dis_max` with many vector
+  subqueries is being unfairly truncated.
+- If you need an absolute enforcement ceiling, apply it in a proxy or
+  gateway in front of the HTTP service.
 
 ---
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -158,16 +158,19 @@ console.log(response.aggregations);   // { tags: { buckets: [...] } }
 
 ### Threaded queries
 
-Enable threading before the first search to let the engine use multiple cores.
-The build and the page both need extra configuration -- see the bullets below:
+Enable threading before the first search so the engine can use multiple cores.
+`init_threads` is an **instance method** on `Searchlite`, so you need to have
+initialised the index first. The build and the page both need extra
+configuration -- see the bullets below:
 
 ```javascript
-await Searchlite.init_threads();                    // uses navigator.hardwareConcurrency
-// or:
-await Searchlite.init_threads(4);
-
 const db = await Searchlite.init("docs-demo", JSON.stringify(schema), "indexeddb");
-// subsequent searches will now run across threads
+
+await db.init_threads();       // uses navigator.hardwareConcurrency
+// or:
+await db.init_threads(4);
+
+// subsequent searches on this `db` run across threads
 ```
 
 Requirements:

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -112,3 +112,79 @@ npx http-server -c-1 --cors -p 8080 \
 - Use `search_request_value` / `search_request` for advanced queries (filters,
   aggregations, highlighting).
 - See [bindings.md](bindings.md) for a reference of binding behaviors.
+
+---
+
+## Full examples
+
+### Advanced search with filters and facets
+
+`search()` is a convenience wrapper. For filters, aggregations, sorting, or
+highlighting, build a full request and pass it to `search_request_value`
+(which takes a plain JS object) or `search_request` (which takes a JSON
+string). These mirror the [HTTP API](http.md) payload exactly.
+
+```javascript
+import init, { Searchlite } from './pkg/searchlite_wasm.js';
+await init();
+
+const schema = {
+  doc_id_field: "_id",
+  text_fields:    [{ name: "title", analyzer: "default", stored: true, indexed: true }],
+  keyword_fields: [{ name: "tag",  stored: true, indexed: true, fast: true }],
+  numeric_fields: [{ name: "year", i64: true,  fast: true, stored: true }],
+};
+
+const db = await Searchlite.init("docs-demo", JSON.stringify(schema), "indexeddb");
+await db.add_documents([
+  { _id: "1", title: "Rust search",  tag: "rust",   year: 2024 },
+  { _id: "2", title: "BM25 basics",  tag: "search", year: 2023 },
+  { _id: "3", title: "Edge ranking", tag: "search", year: 2022 },
+]);
+await db.commit();
+
+const response = await db.search_request_value({
+  query:   { type: "query_string", query: "search" },
+  filter:  { I64Range: { field: "year", min: 2023, max: 2025 } },
+  aggs:    { tags: { type: "terms", field: "tag", size: 5 } },
+  highlight_field: "title",
+  return_stored: true,
+  limit: 10,
+});
+
+console.log(response.hits);           // Each hit has doc_id, score, fields, snippet
+console.log(response.aggregations);   // { tags: { buckets: [...] } }
+```
+
+### Threaded queries
+
+Enable threading before the first search to let the engine use multiple cores.
+The build and the page both need extra configuration -- see the bullets below:
+
+```javascript
+await Searchlite.init_threads();                    // uses navigator.hardwareConcurrency
+// or:
+await Searchlite.init_threads(4);
+
+const db = await Searchlite.init("docs-demo", JSON.stringify(schema), "indexeddb");
+// subsequent searches will now run across threads
+```
+
+Requirements:
+- Build with `--features threads` (e.g.
+  `wasm-pack build searchlite-wasm --target web --release -- --features threads`).
+- Serve the page with COOP/COEP headers so `SharedArrayBuffer` is available.
+- Not available in service workers.
+
+### Memory-only mode for tests and previews
+
+If the index is purely ephemeral (demos, tests, iframes that should not
+persist data), pass `"memory"` instead of `"indexeddb"`:
+
+```javascript
+const db = await Searchlite.init("throwaway", JSON.stringify(schema), "memory");
+```
+
+Do not mix storage modes for the same `db_name`. Switching from
+`indexeddb` to `memory` silently ignores the previously-persisted state -- use
+a fresh `db_name` whenever you change the backend.

--- a/docs/write-key.md
+++ b/docs/write-key.md
@@ -57,11 +57,25 @@ curl -XPOST http://localhost:8080/indexes/secure/init \
 
 ### CLI
 
-The CLI passes the write key via environment variable:
+Every write-capable CLI command accepts `--write-key <KEY>`:
 
 ```bash
-SEARCHLITE_WRITE_KEY=my-secret-key searchlite init /tmp/secure-idx schema.json
+# Create a protected index
+searchlite init /tmp/secure-idx schema.json --write-key "my-secret-key"
+
+# Every write command from here on must pass the same key
+searchlite add    /tmp/secure-idx docs.jsonl --write-key "my-secret-key"
+searchlite commit /tmp/secure-idx            --write-key "my-secret-key"
+searchlite delete /tmp/secure-idx ids.txt    --write-key "my-secret-key"
+searchlite compact /tmp/secure-idx           --write-key "my-secret-key"
+
+# Read commands never need it
+searchlite search  /tmp/secure-idx -q "example"
+searchlite inspect /tmp/secure-idx
 ```
+
+Supplying the wrong key (or forgetting it) fails with an authorization error
+and no changes are applied.
 
 ---
 


### PR DESCRIPTION
## Summary

Docs-only pass. An audit of `docs/` and `README.md` against the actual code surface in `searchlite-{cli,http,core,ffi,wasm,node}` found a number of features that were genuinely undocumented and many guides that lacked a concrete example for less advanced readers. This PR fills those gaps without touching any code.

### Undocumented features now covered

- **CLI** (`docs/cli.md`): the `--write-key` flag accepted by every write command (was completely absent despite being the only way to use write-key indexes from the CLI); `--aggs-file`, `--bmw-block-size`, `--return-hits`, `--fields`, `--request-stdin`; all `--vector-*` flags behind the vectors feature; walkthroughs for `update` and `delete`; the `http` subcommand.
- **HTTP** (`docs/http.md`): the previously missing `GET /healthz` and `GET /indexes` endpoints; real defaults for `--max-body-bytes` (50 MiB), `--max-concurrency` (64), `--request-timeout-secs` (30), `--shutdown-grace-secs` (5); every `SEARCHLITE_*` env var; per-index override syntax (`auto_commit=`, `auto_refresh=`); body shapes for `/bulk`, `/update`, `/_bulk_update`, `/delete`; reworked pagination coverage for offset / `search_after` / cursor.
- **SearchRequest fields**: `track_total_hits`, `return_hits`, `bmw_block_size`, `candidate_size`, `execution`, `search_after`, `max_global_vector_candidates`.
- **Query types**: `match_all` and `vector` added to the queries.md type table; step-by-step walkthroughs for `match_all`, `query_string`, `term`, `bool`.
- **Write key**: replaced the incorrect `SEARCHLITE_WRITE_KEY` env var example with the actual `--write-key` CLI flag usage on every write command.

### Worked examples added

- **FFI** (`docs/ffi.md`): a complete C program (open → add → commit → search → close) plus compile instructions, a write-key variant, and panic-handling notes.
- **WASM** (`docs/wasm.md`): a structured-request example via `search_request_value`, a threading walkthrough, and a memory-only storage note.
- **Vectors** (`docs/vectors.md`): a full Rust hybrid-search walkthrough, an embedding-generation primer, and a recall-tuning guide.
- **Aggregations** (`docs/aggregations.md`): worked JSON for `percentiles`, `percentile_ranks`, `top_hits`, `significant_terms`, `rare_terms`, `bucket_sort`, `bucket_script`; expanded sampling coverage.
- **Rust API** (`docs/rust-api.md`): pagination section (offset, cursor, `search_after`) and guidance on setting non-builder fields directly (`explain`, `profile`, `collapse`, `rescore`, etc.).
- **Filters** (`docs/filters.md`): a compact cheat sheet and a realistic request that exercises every variant (`KeywordEq`, `KeywordIn`, `I64Range`, `F64Range`, `Nested`, `And`, `Or`, `Not`).

### Scope

- Docs-only: 11 `.md` files touched, no code changes.
- Two commits: the main sweep and one follow-up that closes the last gap found during a second audit pass.

## Test plan

- [ ] CI (`cargo fmt`, `cargo clippy`, `cargo test --all --all-features`, benches) stays green — docs-only change should not affect it.
- [ ] Rendered output on GitHub is skimmed for any broken fenced blocks or link typos.

https://claude.ai/code/session_01JUSpxecd8x3ZVGfEcZ2PgN