### PR TITLE
fix: authenticate git push in release package.json sync step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
         run: |
           set -euo pipefail
           branch="${{ steps.release-pr.outputs.branch }}"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           git fetch origin "$branch"
           git checkout "$branch"
 


### PR DESCRIPTION
## Summary
- The "Sync package.json version" step in the release workflow fails with `fatal: could not read Username for 'https://github.com'` when trying to push the version sync commit
- Root cause: `actions/checkout@v6` uses `persist-credentials: false`, so no git credentials are available to subsequent steps. Fetches work because the repo is public, but pushes require authentication.
- Fix: configure the remote URL with the `RELEASE_PLZ_TOKEN` before git operations

Fixes the failure in https://github.com/davidkelley/searchlite/actions/runs/24308138343

## Test plan
- [ ] Merge this PR, then verify the next release workflow run successfully pushes the package.json sync commit to the release-plz PR branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)