### PR TITLE
fix: WAND inner-loop sort and highlight UTF-8 boundary safety

### DIFF
--- a/searchlite-core/src/index/highlight.rs
+++ b/searchlite-core/src/index/highlight.rs
@@ -47,9 +47,12 @@ pub fn highlight_fragments(
   let mut offset = 0usize;
   for _ in 0..opts.number_of_fragments {
     if let Some(m) = re.find_at(text, offset) {
-      let start = m.start().saturating_sub(opts.fragment_size / 2);
-      let end = usize::min(text.len(), start.saturating_add(opts.fragment_size));
-      let fragment = text.get(start..end).unwrap_or("").to_string();
+      let raw_start = m.start().saturating_sub(opts.fragment_size / 2);
+      let raw_end = usize::min(text.len(), raw_start.saturating_add(opts.fragment_size));
+      // Snap to character boundaries to avoid slicing mid-character.
+      let start = snap_char_boundary_left(text, raw_start);
+      let end = snap_char_boundary_right(text, raw_end);
+      let fragment = text[start..end].to_string();
       let highlighted = re
         .replace_all(&fragment, |caps: &regex::Captures<'_>| {
           format!("{}{}{}", opts.pre_tag, &caps[0], opts.post_tag)
@@ -62,6 +65,24 @@ pub fn highlight_fragments(
     }
   }
   out
+}
+
+/// Snap a byte index to the nearest char boundary at or before `idx`.
+fn snap_char_boundary_left(text: &str, idx: usize) -> usize {
+  let mut i = idx.min(text.len());
+  while i > 0 && !text.is_char_boundary(i) {
+    i -= 1;
+  }
+  i
+}
+
+/// Snap a byte index to the nearest char boundary at or after `idx`.
+fn snap_char_boundary_right(text: &str, idx: usize) -> usize {
+  let mut i = idx.min(text.len());
+  while i < text.len() && !text.is_char_boundary(i) {
+    i += 1;
+  }
+  i
 }
 
 pub fn make_snippet(text: &str, terms: &[String], phrases: &[Vec<String>]) -> Option<String> {
@@ -90,5 +111,41 @@ mod tests {
     assert!(snippet.contains("**systems**"));
     let none = make_snippet("", &[String::from("systems")], &[]);
     assert!(none.is_none());
+  }
+
+  #[test]
+  fn highlights_multibyte_text_without_panic() {
+    // The fragment window may land mid-character for multi-byte UTF-8.
+    // Use accented Latin text so \b word boundaries work.
+    let text = "Un résumé très détaillé du système de recherche avancée";
+    let frags = highlight_fragments(
+      text,
+      &[String::from("système")],
+      &[],
+      HighlightOptions {
+        pre_tag: "<em>",
+        post_tag: "</em>",
+        fragment_size: 20, // small size forces mid-char slicing
+        number_of_fragments: 1,
+      },
+    );
+    assert!(!frags.is_empty(), "should produce a fragment");
+    assert!(
+      frags[0].contains("<em>système</em>"),
+      "fragment should contain highlighted term, got: {}",
+      frags[0]
+    );
+  }
+
+  #[test]
+  fn snap_boundaries_are_correct() {
+    // "café": c(0) a(1) f(2) é(3..5) — é is 2 bytes, index 4 is mid-char
+    let text = "café";
+    assert_eq!(snap_char_boundary_left(text, 3), 3); // start of é
+    assert_eq!(snap_char_boundary_left(text, 4), 3); // mid-é snaps back
+    assert_eq!(snap_char_boundary_left(text, 5), 5); // end of string
+    assert_eq!(snap_char_boundary_right(text, 3), 3); // start of é
+    assert_eq!(snap_char_boundary_right(text, 4), 5); // mid-é snaps forward
+    assert_eq!(snap_char_boundary_right(text, 5), 5); // end of string
   }
 }

--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -681,8 +681,31 @@ fn wand_loop<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
   let mut prune_done = false;
 
   fn bubble_reposition(queue: &mut [TermState], advanced: usize) {
-    let _ = advanced;
-    queue.sort_unstable_by_key(|t| t.doc_id());
+    if advanced == 0 || queue.len() <= 1 {
+      return;
+    }
+    if advanced >= queue.len() {
+      queue.sort_unstable_by_key(|t| t.doc_id());
+      return;
+    }
+    // Sort the modified prefix (typically 1-5 elements).
+    if advanced > 1 {
+      queue[..advanced].sort_unstable_by_key(|t| t.doc_id());
+    }
+    // Merge two sorted runs in-place. For each element from the suffix
+    // that belongs before the current prefix element, rotate it into
+    // place. Since `advanced` is small, this is effectively O(n).
+    let mut i = 0;
+    let mut j = advanced;
+    while i < j && j < queue.len() {
+      if queue[i].doc_id() <= queue[j].doc_id() {
+        i += 1;
+      } else {
+        queue[i..=j].rotate_right(1);
+        i += 1;
+        j += 1;
+      }
+    }
   }
 
   loop {


### PR DESCRIPTION
## Summary
- **WAND scoring loop**: Replace `O(n log n)` full sort on every iteration with an in-place merge of two sorted runs. Only the first `advanced` elements (typically 1-5 query terms) change per iteration, so merging is effectively `O(n)`. This is the hottest path in the search engine and fires for every scored document.
- **Highlight fragments**: Fix fragment extraction slicing mid-character on multi-byte UTF-8 text. Byte offsets are now snapped to valid char boundaries, preventing silent empty fragments for non-ASCII content (accented text, CJK, emoji).

## Test plan
- [x] All 282 existing tests pass (`cargo test -p searchlite-core`)
- [x] New unit tests for UTF-8 boundary snapping (`snap_boundaries_are_correct`)
- [x] New test for multi-byte highlight extraction (`highlights_multibyte_text_without_panic`)
- [x] WAND correctness verified via `brute_force_matches_wand_results` (scores match brute-force)

🤖 Generated with [Claude Code](https://claude.com/claude-code)