### PR TITLE
perf: replace TinyFst BTreeMap with HashMap + sorted Vec

### DIFF
--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -175,7 +175,7 @@ pub(crate) fn expand_term_groups(
                 qualified_terms.extend(scored);
               }
               for key in expanded_keys.drain(..) {
-                if seen_keys.insert(key.clone()) {
+                if seen_keys.insert(key.to_owned()) {
                   keys.push(key);
                 }
               }
@@ -201,7 +201,7 @@ pub(crate) fn expand_term_groups(
             qualified_terms.extend(scored);
           }
           for key in expanded_keys.drain(..) {
-            if seen_keys.insert(key.clone()) {
+            if seen_keys.insert(key.to_owned()) {
               keys.push(key);
             }
           }
@@ -329,7 +329,7 @@ fn expand_prefix(
       if key.len() <= field_prefix_len {
         continue;
       }
-      if !seen.insert(key.clone()) {
+      if !seen.insert(key.to_owned()) {
         continue;
       }
       let term = key[field_prefix_len..].to_string();
@@ -338,14 +338,14 @@ fn expand_prefix(
           qualified.push(QualifiedTerm {
             field: field.to_string(),
             term: term.clone(),
-            key: key.clone(),
+            key: key.to_owned(),
             weight: boost,
             leaf: idx,
             group_fields: group_fields.clone(),
           });
         }
       }
-      keys.push(key.clone());
+      keys.push(key.to_owned());
       expanded += 1;
     }
   }
@@ -406,7 +406,7 @@ fn expand_wildcard(
       if !regex.is_match(term) {
         continue;
       }
-      if !seen.insert(key.clone()) {
+      if !seen.insert(key.to_owned()) {
         continue;
       }
       if score {
@@ -414,14 +414,14 @@ fn expand_wildcard(
           qualified.push(QualifiedTerm {
             field: field.to_string(),
             term: term.to_string(),
-            key: key.clone(),
+            key: key.to_owned(),
             weight: boost,
             leaf: idx,
             group_fields: group_fields.clone(),
           });
         }
       }
-      keys.push(key.clone());
+      keys.push(key.to_owned());
       expanded += 1;
     }
   }
@@ -499,7 +499,7 @@ fn expand_regex(
       if !regex.is_match(term) {
         continue;
       }
-      if !seen.insert(key.clone()) {
+      if !seen.insert(key.to_owned()) {
         continue;
       }
       if score {
@@ -507,14 +507,14 @@ fn expand_regex(
           qualified.push(QualifiedTerm {
             field: field.to_string(),
             term: term.to_string(),
-            key: key.clone(),
+            key: key.to_owned(),
             weight: boost,
             leaf: idx,
             group_fields: group_fields.clone(),
           });
         }
       }
-      keys.push(key.clone());
+      keys.push(key.to_owned());
       expanded += 1;
     }
   }
@@ -533,7 +533,7 @@ fn expand_term_exact(
     vec![QualifiedTerm {
       field: field.to_string(),
       term: term.to_string(),
-      key: key.clone(),
+      key: key.to_owned(),
       weight: boost,
       leaf,
       group_fields,
@@ -556,12 +556,12 @@ fn expand_term_fuzzy(
   let mut qualified = vec![QualifiedTerm {
     field: field.to_string(),
     term: term.to_string(),
-    key: exact_key.clone(),
+    key: exact_key.to_owned(),
     weight: boost * distance_weight(0),
     leaf,
     group_fields: group_fields.clone(),
   }];
-  let mut keys = vec![exact_key.clone()];
+  let mut keys = vec![exact_key.to_owned()];
   if term_len < fuzzy.min_length || fuzzy.max_expansions == 0 {
     return (qualified, keys);
   }
@@ -598,16 +598,16 @@ fn expand_term_fuzzy(
       if distance == 0 {
         continue;
       }
-      if seen.insert(key.clone()) {
+      if seen.insert(key.to_owned()) {
         qualified.push(QualifiedTerm {
           field: field.to_string(),
           term: candidate.to_string(),
-          key: key.clone(),
+          key: key.to_owned(),
           weight: boost * distance_weight(distance),
           leaf,
           group_fields: group_fields.clone(),
         });
-        keys.push(key.clone());
+        keys.push(key.to_owned());
         expansions += 1;
         if expansions >= fuzzy.max_expansions {
           break 'segments;

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -1343,7 +1343,7 @@ impl SegmentReader {
     read_doc_freq(&mut *file, offset).ok()
   }
 
-  pub fn terms_with_prefix<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item = &'a String> + 'a {
+  pub fn terms_with_prefix<'a>(&'a self, prefix: &'a str) -> impl Iterator<Item = &'a str> + 'a {
     self.terms.0.iter_prefix(prefix).map(|(term, _)| term)
   }
 

--- a/searchlite-core/src/util/fst.rs
+++ b/searchlite-core/src/util/fst.rs
@@ -1,17 +1,23 @@
-use std::collections::BTreeMap;
+use hashbrown::HashMap;
 
+/// Compact term dictionary with O(1) exact lookups and efficient prefix iteration.
+///
+/// Uses a `HashMap` for exact term lookups (the hot path during search) and a
+/// sorted `Vec` for ordered iteration and prefix queries. The sorted vec is
+/// built once at construction time and enables binary-search-based prefix
+/// scans without per-call allocations.
 #[derive(Debug, Clone, Default)]
 pub struct TinyFst {
-  map: BTreeMap<String, u64>,
+  map: HashMap<String, u64>,
+  sorted: Vec<(String, u64)>,
 }
 
 impl TinyFst {
   pub fn from_terms(terms: &[(String, u64)]) -> Self {
-    let mut map = BTreeMap::new();
-    for (t, off) in terms {
-      map.insert(t.clone(), *off);
-    }
-    Self { map }
+    let map: HashMap<String, u64> = terms.iter().cloned().collect();
+    let mut sorted: Vec<(String, u64)> = terms.to_vec();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    Self { map, sorted }
   }
 
   pub fn get(&self, term: &str) -> Option<u64> {
@@ -19,17 +25,19 @@ impl TinyFst {
   }
 
   pub fn iter(&self) -> impl Iterator<Item = (&String, &u64)> {
-    self.map.iter()
+    self.sorted.iter().map(|(k, v)| (k, v))
   }
 
   pub fn iter_prefix<'a>(
     &'a self,
     prefix: &'a str,
   ) -> impl Iterator<Item = (&'a String, &'a u64)> + 'a {
-    self
-      .map
-      .range(prefix.to_string()..)
+    // Binary search for the first entry >= prefix, then take while matching.
+    let start = self.sorted.partition_point(|(k, _)| k.as_str() < prefix);
+    self.sorted[start..]
+      .iter()
       .take_while(move |(k, _)| k.starts_with(prefix))
+      .map(|(k, v)| (k, v))
   }
 }
 
@@ -55,5 +63,24 @@ mod tests {
         ("gamma".to_string(), 3)
       ]
     );
+  }
+
+  #[test]
+  fn prefix_iteration_finds_matching_terms() {
+    let fst = TinyFst::from_terms(&[
+      ("body:apple".to_string(), 10),
+      ("body:application".to_string(), 20),
+      ("body:banana".to_string(), 30),
+      ("title:apple".to_string(), 40),
+    ]);
+    let prefixed: Vec<_> = fst
+      .iter_prefix("body:app")
+      .map(|(k, v)| (k.as_str(), *v))
+      .collect();
+    assert_eq!(
+      prefixed,
+      vec![("body:apple", 10), ("body:application", 20)]
+    );
+    assert_eq!(fst.iter_prefix("missing").count(), 0);
   }
 }

--- a/searchlite-core/src/util/fst.rs
+++ b/searchlite-core/src/util/fst.rs
@@ -89,10 +89,7 @@ mod tests {
       .iter_prefix("body:app")
       .map(|(k, v)| (k, *v))
       .collect();
-    assert_eq!(
-      prefixed,
-      vec![("body:apple", 10), ("body:application", 20)]
-    );
+    assert_eq!(prefixed, vec![("body:apple", 10), ("body:application", 20)]);
     assert_eq!(fst.iter_prefix("missing").count(), 0);
   }
 

--- a/searchlite-core/src/util/fst.rs
+++ b/searchlite-core/src/util/fst.rs
@@ -24,10 +24,7 @@ impl TinyFst {
       .collect();
     // Build sorted from the deduplicated map so iter/iter_prefix stay
     // consistent with get — HashMap::collect already resolved duplicate keys.
-    let mut sorted: Vec<(Arc<str>, u64)> = map
-      .iter()
-      .map(|(k, v)| (Arc::clone(k), *v))
-      .collect();
+    let mut sorted: Vec<(Arc<str>, u64)> = map.iter().map(|(k, v)| (Arc::clone(k), *v)).collect();
     sorted.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     Self { map, sorted }
   }
@@ -85,10 +82,7 @@ mod tests {
       ("body:banana".to_string(), 30),
       ("title:apple".to_string(), 40),
     ]);
-    let prefixed: Vec<_> = fst
-      .iter_prefix("body:app")
-      .map(|(k, v)| (k, *v))
-      .collect();
+    let prefixed: Vec<_> = fst.iter_prefix("body:app").map(|(k, v)| (k, *v)).collect();
     assert_eq!(prefixed, vec![("body:apple", 10), ("body:application", 20)]);
     assert_eq!(fst.iter_prefix("missing").count(), 0);
   }

--- a/searchlite-core/src/util/fst.rs
+++ b/searchlite-core/src/util/fst.rs
@@ -1,4 +1,5 @@
 use hashbrown::HashMap;
+use std::sync::Arc;
 
 /// Compact term dictionary with O(1) exact lookups and efficient prefix iteration.
 ///
@@ -6,17 +7,28 @@ use hashbrown::HashMap;
 /// sorted `Vec` for ordered iteration and prefix queries. The sorted vec is
 /// built once at construction time and enables binary-search-based prefix
 /// scans without per-call allocations.
+///
+/// Both structures share term strings via `Arc<str>` to avoid duplicating
+/// every term in memory (this struct is created per-segment).
 #[derive(Debug, Clone, Default)]
 pub struct TinyFst {
-  map: HashMap<String, u64>,
-  sorted: Vec<(String, u64)>,
+  map: HashMap<Arc<str>, u64>,
+  sorted: Vec<(Arc<str>, u64)>,
 }
 
 impl TinyFst {
   pub fn from_terms(terms: &[(String, u64)]) -> Self {
-    let map: HashMap<String, u64> = terms.iter().cloned().collect();
-    let mut sorted: Vec<(String, u64)> = terms.to_vec();
-    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let map: HashMap<Arc<str>, u64> = terms
+      .iter()
+      .map(|(k, v)| (Arc::from(k.as_str()), *v))
+      .collect();
+    // Build sorted from the deduplicated map so iter/iter_prefix stay
+    // consistent with get — HashMap::collect already resolved duplicate keys.
+    let mut sorted: Vec<(Arc<str>, u64)> = map
+      .iter()
+      .map(|(k, v)| (Arc::clone(k), *v))
+      .collect();
+    sorted.sort_unstable_by(|a, b| a.0.cmp(&b.0));
     Self { map, sorted }
   }
 
@@ -24,20 +36,20 @@ impl TinyFst {
     self.map.get(term).copied()
   }
 
-  pub fn iter(&self) -> impl Iterator<Item = (&String, &u64)> {
-    self.sorted.iter().map(|(k, v)| (k, v))
+  pub fn iter(&self) -> impl Iterator<Item = (&str, &u64)> {
+    self.sorted.iter().map(|(k, v)| (k.as_ref(), v))
   }
 
   pub fn iter_prefix<'a>(
     &'a self,
     prefix: &'a str,
-  ) -> impl Iterator<Item = (&'a String, &'a u64)> + 'a {
+  ) -> impl Iterator<Item = (&'a str, &'a u64)> + 'a {
     // Binary search for the first entry >= prefix, then take while matching.
-    let start = self.sorted.partition_point(|(k, _)| k.as_str() < prefix);
+    let start = self.sorted.partition_point(|(k, _)| k.as_ref() < prefix);
     self.sorted[start..]
       .iter()
       .take_while(move |(k, _)| k.starts_with(prefix))
-      .map(|(k, v)| (k, v))
+      .map(|(k, v)| (k.as_ref(), v))
   }
 }
 
@@ -54,7 +66,7 @@ mod tests {
     ]);
     assert_eq!(fst.get("beta"), Some(2));
     assert_eq!(fst.get("missing"), None);
-    let collected: Vec<_> = fst.iter().map(|(k, v)| (k.clone(), *v)).collect();
+    let collected: Vec<_> = fst.iter().map(|(k, v)| (k.to_owned(), *v)).collect();
     assert_eq!(
       collected,
       vec![
@@ -75,12 +87,26 @@ mod tests {
     ]);
     let prefixed: Vec<_> = fst
       .iter_prefix("body:app")
-      .map(|(k, v)| (k.as_str(), *v))
+      .map(|(k, v)| (k, *v))
       .collect();
     assert_eq!(
       prefixed,
       vec![("body:apple", 10), ("body:application", 20)]
     );
     assert_eq!(fst.iter_prefix("missing").count(), 0);
+  }
+
+  #[test]
+  fn duplicate_terms_are_deduplicated() {
+    let fst = TinyFst::from_terms(&[
+      ("alpha".to_string(), 1),
+      ("alpha".to_string(), 99),
+      ("beta".to_string(), 2),
+    ]);
+    // HashMap::collect keeps the last value for duplicate keys
+    assert_eq!(fst.get("alpha"), Some(99));
+    // iter must not yield duplicates — sorted is built from the deduplicated map
+    let collected: Vec<_> = fst.iter().map(|(k, _)| k).collect();
+    assert_eq!(collected, vec!["alpha", "beta"]);
   }
 }


### PR DESCRIPTION
## Summary
- Replace the term dictionary's `BTreeMap` with a `HashMap` for O(1) exact lookups (previously O(log n) with string comparisons at each tree node). This is the hottest path in search — every query does at least one lookup per segment per term.
- Keep a sorted `Vec` for ordered iteration and prefix queries, built once at construction time.
- Prefix iteration now uses `partition_point` (binary search) to find the start position instead of allocating a temporary `String` for `BTreeMap::range` on every call.

## Test plan
- [x] All 281 existing tests pass (`cargo test -p searchlite-core`)
- [x] New test for prefix iteration correctness (`prefix_iteration_finds_matching_terms`)
- [x] Existing `builds_and_queries_terms` test validates sorted iteration order is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)