### PR TITLE
perf: eliminate per-document String allocations in filter evaluation

### DIFF
--- a/searchlite-core/src/query/filters.rs
+++ b/searchlite-core/src/query/filters.rs
@@ -1,3 +1,4 @@
+use std::borrow::Borrow;
 use std::borrow::Cow;
 
 use crate::api::types::Filter;
@@ -12,16 +13,17 @@ pub fn passes_filter(reader: &FastFieldsReader, doc_id: DocId, filter: &Filter) 
   filter_matches(reader, doc_id, filter, "", None)
 }
 
-fn passes_filters_at<'a>(
+/// Evaluate a slice of filters, accepting both `&[Filter]` and `&[&Filter]`.
+fn passes_filters_at<F: Borrow<Filter>>(
   reader: &FastFieldsReader,
   doc_id: DocId,
-  filters: &'a [Filter],
+  filters: &[F],
   base_path: &str,
   object_idx: Option<usize>,
 ) -> bool {
-  let mut nested: std::collections::HashMap<&str, Vec<&'a Filter>> =
-    std::collections::HashMap::new();
+  let mut nested: std::collections::HashMap<&str, Vec<&Filter>> = std::collections::HashMap::new();
   for filter in filters.iter() {
+    let filter = filter.borrow();
     match filter {
       Filter::Nested { path, filter } => {
         nested
@@ -71,51 +73,11 @@ fn nested_group_passes(
         continue;
       }
     }
-    if filters_ref_all_match(reader, doc_id, filters, &full_path, Some(idx)) {
+    if passes_filters_at(reader, doc_id, filters, &full_path, Some(idx)) {
       return true;
     }
   }
   false
-}
-
-/// Evaluate a slice of filter references without cloning them into owned values.
-fn filters_ref_all_match(
-  reader: &FastFieldsReader,
-  doc_id: DocId,
-  filters: &[&Filter],
-  base_path: &str,
-  object_idx: Option<usize>,
-) -> bool {
-  let mut nested: std::collections::HashMap<&str, Vec<&Filter>> =
-    std::collections::HashMap::new();
-  for filter in filters.iter() {
-    match filter {
-      Filter::Nested { path, filter } => {
-        nested
-          .entry(path.as_str())
-          .or_default()
-          .push(filter.as_ref());
-      }
-      _ => {
-        if !filter_matches(reader, doc_id, filter, base_path, object_idx) {
-          return false;
-        }
-      }
-    }
-  }
-  for (path, group) in nested.into_iter() {
-    if !nested_group_passes(
-      reader,
-      doc_id,
-      base_path,
-      path,
-      object_idx,
-      group.as_slice(),
-    ) {
-      return false;
-    }
-  }
-  true
 }
 
 fn filter_matches(
@@ -127,7 +89,7 @@ fn filter_matches(
 ) -> bool {
   match filter {
     Filter::KeywordEq { field, value } => {
-      let full = qualified_field(base_path, field);
+      let full = join_path(base_path, field);
       match object_idx {
         Some(idx) => reader
           .nested_str_values(&full, doc_id)
@@ -138,7 +100,7 @@ fn filter_matches(
       }
     }
     Filter::KeywordIn { field, values } => {
-      let full = qualified_field(base_path, field);
+      let full = join_path(base_path, field);
       match object_idx {
         Some(idx) => reader
           .nested_str_values(&full, doc_id)
@@ -153,7 +115,7 @@ fn filter_matches(
       }
     }
     Filter::I64Range { field, min, max } => {
-      let full = qualified_field(base_path, field);
+      let full = join_path(base_path, field);
       match object_idx {
         Some(idx) => reader
           .nested_i64_values(&full, doc_id)
@@ -164,7 +126,7 @@ fn filter_matches(
       }
     }
     Filter::F64Range { field, min, max } => {
-      let full = qualified_field(base_path, field);
+      let full = join_path(base_path, field);
       match object_idx {
         Some(idx) => reader
           .nested_f64_values(&full, doc_id)
@@ -212,16 +174,7 @@ fn nested_filter_passes(
   false
 }
 
-/// Build a qualified field path without allocating when `base` is empty.
-fn qualified_field<'a>(base: &str, field: &'a str) -> Cow<'a, str> {
-  if base.is_empty() {
-    Cow::Borrowed(field)
-  } else {
-    Cow::Owned(format!("{base}.{field}"))
-  }
-}
-
-/// Join a base path with a child segment, borrowing when no join is needed.
+/// Join two dot-separated path segments, borrowing when no join is needed.
 fn join_path<'a>(base: &str, child: &'a str) -> Cow<'a, str> {
   if base.is_empty() {
     Cow::Borrowed(child)

--- a/searchlite-core/src/query/filters.rs
+++ b/searchlite-core/src/query/filters.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use crate::api::types::Filter;
 use crate::index::fastfields::{case_insensitive_equals, FastFieldsReader};
 use crate::DocId;
@@ -57,16 +59,11 @@ fn nested_group_passes(
   parent_idx: Option<usize>,
   filters: &[&Filter],
 ) -> bool {
-  let full_path = if base_path.is_empty() {
-    path.to_string()
-  } else {
-    format!("{base_path}.{path}")
-  };
+  let full_path = join_path(base_path, path);
   let object_count = reader.nested_object_count(&full_path, doc_id);
   if object_count == 0 {
     return false;
   }
-  let owned: Vec<Filter> = filters.iter().map(|f| (*f).clone()).collect();
   let parents = reader.nested_parents(&full_path, doc_id);
   for idx in 0..object_count {
     if let Some(p) = parent_idx {
@@ -74,11 +71,51 @@ fn nested_group_passes(
         continue;
       }
     }
-    if passes_filters_at(reader, doc_id, &owned, &full_path, Some(idx)) {
+    if filters_ref_all_match(reader, doc_id, filters, &full_path, Some(idx)) {
       return true;
     }
   }
   false
+}
+
+/// Evaluate a slice of filter references without cloning them into owned values.
+fn filters_ref_all_match(
+  reader: &FastFieldsReader,
+  doc_id: DocId,
+  filters: &[&Filter],
+  base_path: &str,
+  object_idx: Option<usize>,
+) -> bool {
+  let mut nested: std::collections::HashMap<&str, Vec<&Filter>> =
+    std::collections::HashMap::new();
+  for filter in filters.iter() {
+    match filter {
+      Filter::Nested { path, filter } => {
+        nested
+          .entry(path.as_str())
+          .or_default()
+          .push(filter.as_ref());
+      }
+      _ => {
+        if !filter_matches(reader, doc_id, filter, base_path, object_idx) {
+          return false;
+        }
+      }
+    }
+  }
+  for (path, group) in nested.into_iter() {
+    if !nested_group_passes(
+      reader,
+      doc_id,
+      base_path,
+      path,
+      object_idx,
+      group.as_slice(),
+    ) {
+      return false;
+    }
+  }
+  true
 }
 
 fn filter_matches(
@@ -156,11 +193,7 @@ fn nested_filter_passes(
   parent_idx: Option<usize>,
   filter: &Filter,
 ) -> bool {
-  let full_path = if base_path.is_empty() {
-    path.to_string()
-  } else {
-    format!("{base_path}.{path}")
-  };
+  let full_path = join_path(base_path, path);
   let object_count = reader.nested_object_count(&full_path, doc_id);
   if object_count == 0 {
     return false;
@@ -179,11 +212,21 @@ fn nested_filter_passes(
   false
 }
 
-fn qualified_field(base: &str, field: &str) -> String {
+/// Build a qualified field path without allocating when `base` is empty.
+fn qualified_field<'a>(base: &str, field: &'a str) -> Cow<'a, str> {
   if base.is_empty() {
-    field.to_string()
+    Cow::Borrowed(field)
   } else {
-    format!("{base}.{field}")
+    Cow::Owned(format!("{base}.{field}"))
+  }
+}
+
+/// Join a base path with a child segment, borrowing when no join is needed.
+fn join_path<'a>(base: &str, child: &'a str) -> Cow<'a, str> {
+  if base.is_empty() {
+    Cow::Borrowed(child)
+  } else {
+    Cow::Owned(format!("{base}.{child}"))
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace `String` allocations in `qualified_field()` and `join_path()` with `Cow<str>`. For top-level filters (the common case with no nesting), the field name is borrowed directly — zero allocation. Only nested paths that require a `"base.field"` join allocate.
- Replace the `Vec<Filter>` clone in `nested_group_passes` with a new `filters_ref_all_match` helper that accepts `&[&Filter]` directly, avoiding a full clone of every filter in the nested group for every candidate document.

These functions run for **every candidate document** during filtered search. On queries returning 10K+ candidates with filters, this eliminates tens of thousands of short-lived heap allocations per query.

## Test plan
- [x] All 280 existing tests pass (`cargo test -p searchlite-core`)
- [x] All 10 filter-specific tests pass including nested object scoping, parent binding, numeric ranges, and boolean combinators

🤖 Generated with [Claude Code](https://claude.com/claude-code)