### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.9...searchlite-cli-v0.1.10) - 2026-04-13
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.8...searchlite-cli-v0.1.9) - 2026-04-13
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.2...searchlite-http-v0.2.3) - 2026-04-13
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.1...searchlite-http-v0.2.2) - 2026-04-13
 
 ### Added

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {


### PR DESCRIPTION



## 🤖 New release

* `searchlite-http`: 0.2.2 -> 0.2.3 (✓ API compatible changes)
* `integration`: 0.2.2 -> 0.2.3
* `searchlite-cli`: 0.1.9 -> 0.1.10
* `searchlite-node`: 0.2.2 -> 0.2.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-http`

<blockquote>

## [0.2.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.2...searchlite-http-v0.2.3) - 2026-04-13

### Other

- update Cargo.lock dependencies
</blockquote>

## `integration`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/integration-v0.2.1...integration-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.10](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.9...searchlite-cli-v0.1.10) - 2026-04-13

### Other

- update Cargo.lock dependencies
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.1...searchlite-node-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).