### PR TITLE
fix: address perf PR review feedback — correctness and tests

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1689,14 +1689,14 @@ impl IndexReader {
         // own postings separately via build_phrase_runtimes.
         postings.strip_positions();
         let (avgdl, doc_lengths, min_doc_len) = if let Some(fields) = group_fields.as_deref() {
-          let (avgdl, dl) = cross_fields_stats_for(
+          let (avgdl, dl, mdl) = cross_fields_stats_for(
             field_lengths_cache,
             cross_lengths_cache,
             cross_avgdl_cache,
             fields,
             seg,
           );
-          (avgdl, dl, None)
+          (avgdl, dl, mdl)
         } else {
           let (dl, mdl) = field_lengths_for(field_lengths_cache, field, seg);
           (seg.avg_field_length(field), dl, mdl)
@@ -2133,7 +2133,7 @@ fn cross_fields_stats_for(
   cross_avgdl_cache: &mut HashMap<String, f32>,
   fields: &[String],
   seg: &SegmentReader,
-) -> (f32, Option<Arc<Vec<f32>>>) {
+) -> (f32, Option<Arc<Vec<f32>>>, Option<f32>) {
   let key = cross_fields_cache_key(fields);
   let avgdl = if let Some(value) = cross_avgdl_cache.get(&key).copied() {
     value
@@ -2153,7 +2153,12 @@ fn cross_fields_stats_for(
     value
   };
   if let Some(lengths) = cross_lengths_cache.get(&key) {
-    return (avgdl, Some(lengths.clone()));
+    let min_pos = lengths
+      .iter()
+      .copied()
+      .filter(|v| *v > 0.0)
+      .reduce(f32::min);
+    return (avgdl, Some(lengths.clone()), min_pos);
   }
   let mut combined = vec![0.0_f32; seg.meta.doc_count as usize];
   let mut contributing = 0usize;
@@ -2172,14 +2177,19 @@ fn cross_fields_stats_for(
       *len /= denom;
     }
   }
+  let min_pos = combined
+    .iter()
+    .copied()
+    .filter(|v| *v > 0.0)
+    .reduce(f32::min);
   let arc = Arc::new(combined);
   cross_lengths_cache.insert(key, arc.clone());
-  (avgdl, Some(arc))
+  (avgdl, Some(arc), min_pos)
 }
 
 struct CachedFieldLengths {
   lengths: Arc<Vec<f32>>,
-  min_positive: f32,
+  min_positive: Option<f32>,
 }
 
 fn field_lengths_for(
@@ -2188,7 +2198,7 @@ fn field_lengths_for(
   seg: &SegmentReader,
 ) -> (Option<Arc<Vec<f32>>>, Option<f32>) {
   if let Some(existing) = cache.get(field) {
-    return (Some(existing.lengths.clone()), Some(existing.min_positive));
+    return (Some(existing.lengths.clone()), existing.min_positive);
   }
   let key = doc_length_key(field);
   let mut lengths = Vec::with_capacity(seg.meta.doc_count as usize);
@@ -2200,18 +2210,22 @@ fn field_lengths_for(
     }
     lengths.push(len);
   }
-  if !min_positive.is_finite() {
-    min_positive = 1.0;
-  }
+  // When no positive lengths exist, report None so TermState::new uses
+  // its own conservative fallback instead of a potentially misleading value.
+  let min_opt = if min_positive.is_finite() {
+    Some(min_positive)
+  } else {
+    None
+  };
   let arc = Arc::new(lengths);
   cache.insert(
     field.to_string(),
     CachedFieldLengths {
       lengths: arc.clone(),
-      min_positive,
+      min_positive: min_opt,
     },
   );
-  (Some(arc), Some(min_positive))
+  (Some(arc), min_opt)
 }
 
 fn combine_rescore_scores(mode: RescoreMode, original: f32, rescore: f32) -> f32 {

--- a/searchlite-core/src/index/fastfields.rs
+++ b/searchlite-core/src/index/fastfields.rs
@@ -547,19 +547,13 @@ impl FastFieldsReader {
     }
   }
 
+  /// Check if a document's keyword field matches any of the given values.
+  ///
+  /// Uses zero-allocation `case_insensitive_equals` for each comparison,
+  /// which is O(stored_values × filter_values) but avoids all heap
+  /// allocations. For typical filter sizes this is faster than building
+  /// a `HashSet` (which requires `to_lowercase()` allocations).
   pub fn matches_keyword_in(&self, field: &str, doc_id: DocId, values: &[String]) -> bool {
-    // For small value lists, linear scan is faster than building a HashSet.
-    // For larger lists, build a lowered HashSet once for O(1) per-value checks.
-    if values.len() <= 4 {
-      self.matches_keyword_in_linear(field, doc_id, values)
-    } else {
-      let set: std::collections::HashSet<String> =
-        values.iter().map(|v| v.to_lowercase()).collect();
-      self.matches_keyword_in_set(field, doc_id, &set)
-    }
-  }
-
-  fn matches_keyword_in_linear(&self, field: &str, doc_id: DocId, values: &[String]) -> bool {
     match self.fields.get(field) {
       Some(Column::Str {
         dict,
@@ -598,65 +592,6 @@ impl FastFieldsReader {
                 dict
                   .get(*idx as usize)
                   .map(|s| values.iter().any(|v| case_insensitive_equals(s, v)))
-                  .unwrap_or(false)
-              }) {
-                return true;
-              }
-            }
-          }
-        }
-        false
-      }
-      _ => false,
-    }
-  }
-
-  /// Like `matches_keyword_in`, but accepts a pre-lowered `HashSet` for O(1)
-  /// membership checks instead of O(n) linear scans.
-  pub fn matches_keyword_in_set(
-    &self,
-    field: &str,
-    doc_id: DocId,
-    lowered_values: &std::collections::HashSet<String>,
-  ) -> bool {
-    match self.fields.get(field) {
-      Some(Column::Str {
-        dict,
-        values: lookup,
-      }) => lookup
-        .get(doc_id as usize)
-        .and_then(|opt| opt.and_then(|idx| dict.get(idx as usize)))
-        .map(|s| lowered_values.contains(&s.to_lowercase()))
-        .unwrap_or(false),
-      Some(Column::StrList {
-        dict,
-        offsets,
-        values: lookup,
-      }) => {
-        if let Some((start, end)) = doc_range(offsets, doc_id as usize) {
-          lookup[start..end].iter().any(|idx| {
-            dict
-              .get(*idx as usize)
-              .map(|s| lowered_values.contains(&s.to_lowercase()))
-              .unwrap_or(false)
-          })
-        } else {
-          false
-        }
-      }
-      Some(Column::StrNested {
-        dict,
-        doc_offsets,
-        object_offsets,
-        values: lookup,
-      }) => {
-        if let Some((obj_start, obj_end)) = doc_range(doc_offsets, doc_id as usize) {
-          for obj_idx in obj_start..obj_end {
-            if let Some((start, end)) = object_range(object_offsets, obj_idx) {
-              if lookup[start..end].iter().any(|idx| {
-                dict
-                  .get(*idx as usize)
-                  .map(|s| lowered_values.contains(&s.to_lowercase()))
                   .unwrap_or(false)
               }) {
                 return true;

--- a/searchlite-core/src/query/filters.rs
+++ b/searchlite-core/src/query/filters.rs
@@ -7,6 +7,11 @@ use crate::api::types::Filter;
 use crate::index::fastfields::{case_insensitive_equals, FastFieldsReader};
 use crate::DocId;
 
+/// Stack-friendly grouping of nested filters by path.
+/// Typical queries have 0–2 distinct nested paths, so `SmallVec`
+/// avoids heap allocation in the common case.
+type NestedFilterGroups<'a> = SmallVec<[(&'a str, SmallVec<[&'a Filter; 4]>); 4]>;
+
 pub fn passes_filters(reader: &FastFieldsReader, doc_id: DocId, filters: &[Filter]) -> bool {
   passes_filters_at(reader, doc_id, filters, "", None)
 }
@@ -28,9 +33,7 @@ fn passes_filters_at<F: Borrow<Filter>>(
   base_path: &str,
   object_idx: Option<usize>,
 ) -> bool {
-  // Stack-allocated grouping for nested filters. Typical queries have 0–2
-  // distinct nested paths, so SmallVec<[_; 4]> avoids heap allocation.
-  let mut nested: SmallVec<[(&str, SmallVec<[&Filter; 4]>); 4]> = SmallVec::new();
+  let mut nested: NestedFilterGroups<'_> = SmallVec::new();
   for filter in filters.iter() {
     let filter = filter.borrow();
     match filter {
@@ -52,7 +55,14 @@ fn passes_filters_at<F: Borrow<Filter>>(
     }
   }
   for (path, group) in nested.iter() {
-    if !nested_group_passes(reader, doc_id, base_path, path, object_idx, group.as_slice()) {
+    if !nested_group_passes(
+      reader,
+      doc_id,
+      base_path,
+      path,
+      object_idx,
+      group.as_slice(),
+    ) {
       return false;
     }
   }
@@ -108,27 +118,15 @@ fn filter_matches(
     Filter::KeywordIn { field, values } => {
       let full = join_path(base_path, field);
       match object_idx {
-        Some(idx) => {
-          if values.len() <= 4 {
-            reader
-              .nested_str_values(&full, doc_id)
-              .get(idx)
-              .map(|vals| {
-                vals
-                  .iter()
-                  .any(|v| values.iter().any(|t| case_insensitive_equals(t, v)))
-              })
-              .unwrap_or(false)
-          } else {
-            let set: std::collections::HashSet<String> =
-              values.iter().map(|v| v.to_lowercase()).collect();
-            reader
-              .nested_str_values(&full, doc_id)
-              .get(idx)
-              .map(|vals| vals.iter().any(|v| set.contains(&v.to_lowercase())))
-              .unwrap_or(false)
-          }
-        }
+        Some(idx) => reader
+          .nested_str_values(&full, doc_id)
+          .get(idx)
+          .map(|vals| {
+            vals
+              .iter()
+              .any(|v| values.iter().any(|t| case_insensitive_equals(t, v)))
+          })
+          .unwrap_or(false),
         None => reader.matches_keyword_in(&full, doc_id, values),
       }
     }
@@ -834,5 +832,113 @@ mod tests {
       }),
     }));
     assert!(passes_filter(&reader, 0, &accepting));
+  }
+
+  #[test]
+  fn keyword_in_with_many_values_matches_case_insensitively() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("fast.json");
+    let storage = crate::storage::FsStorage::new(dir.path().to_path_buf());
+    let mut writer = FastFieldsWriter::new();
+    writer.set("cat", 0, FastValue::Str("Science".into()));
+    writer.set(
+      "tags",
+      0,
+      FastValue::StrList(vec!["Rust".into(), "Wasm".into()]),
+    );
+    writer.write_to(&storage, &path).unwrap();
+    let reader = FastFieldsReader::open(&storage, &path).unwrap();
+
+    // More than 4 values to exercise the large-list path.
+    let many_values: Vec<String> = vec!["sports", "news", "tech", "health", "science", "music"]
+      .into_iter()
+      .map(String::from)
+      .collect();
+    let passing = Filter::KeywordIn {
+      field: "cat".into(),
+      values: many_values.clone(),
+    };
+    assert!(passes_filter(&reader, 0, &passing));
+
+    let failing = Filter::KeywordIn {
+      field: "cat".into(),
+      values: vec!["a".into(), "b".into(), "c".into(), "d".into(), "e".into()],
+    };
+    assert!(!passes_filter(&reader, 0, &failing));
+
+    // StrList field with many values.
+    let list_passing = Filter::KeywordIn {
+      field: "tags".into(),
+      values: vec![
+        "go".into(),
+        "python".into(),
+        "java".into(),
+        "c++".into(),
+        "rust".into(),
+      ],
+    };
+    assert!(passes_filter(&reader, 0, &list_passing));
+  }
+
+  #[test]
+  fn nested_keyword_in_with_many_values_scopes_to_object() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("fast.json");
+    let storage = crate::storage::FsStorage::new(dir.path().to_path_buf());
+    let mut writer = FastFieldsWriter::new();
+    writer.set(
+      &nested_count_key("item"),
+      0,
+      FastValue::NestedCount { objects: 2 },
+    );
+    writer.set(
+      "item.color",
+      0,
+      FastValue::StrNested {
+        object: 0,
+        values: vec!["Red".into()],
+      },
+    );
+    writer.set(
+      "item.color",
+      0,
+      FastValue::StrNested {
+        object: 1,
+        values: vec!["Blue".into()],
+      },
+    );
+    writer.write_to(&storage, &path).unwrap();
+    let reader = FastFieldsReader::open(&storage, &path).unwrap();
+
+    // >4 values in a nested KeywordIn filter.
+    let passing = Filter::Nested {
+      path: "item".into(),
+      filter: Box::new(Filter::KeywordIn {
+        field: "color".into(),
+        values: vec![
+          "green".into(),
+          "yellow".into(),
+          "orange".into(),
+          "purple".into(),
+          "red".into(),
+        ],
+      }),
+    };
+    assert!(passes_filter(&reader, 0, &passing));
+
+    let failing = Filter::Nested {
+      path: "item".into(),
+      filter: Box::new(Filter::KeywordIn {
+        field: "color".into(),
+        values: vec![
+          "green".into(),
+          "yellow".into(),
+          "orange".into(),
+          "purple".into(),
+          "white".into(),
+        ],
+      }),
+    };
+    assert!(!passes_filter(&reader, 0, &failing));
   }
 }

--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -109,12 +109,15 @@ impl TermState {
     let df = term.postings.len() as f32;
     let clamped_block = block_size.max(1);
     let block_meta = build_block_meta(&term.postings, clamped_block);
-    let fallback = term.avgdl.max(1.0);
+    let doc_lengths = term.doc_lengths.clone();
+    // The minimum doc length feeds WAND upper-bound calculations. Using a
+    // value larger than the true minimum can underestimate bounds and cause
+    // incorrect pruning, so we fall back to the most conservative value
+    // (1.0) rather than avgdl when no precomputed hint is available.
     let min_doc_len = term
       .min_doc_len
       .filter(|v| v.is_finite() && *v > 0.0)
-      .unwrap_or(fallback);
-    let doc_lengths = term.doc_lengths.clone();
+      .unwrap_or(1.0);
     let ub = upper_bound_tf(
       term.postings.max_tf,
       df,


### PR DESCRIPTION
## Summary

Follow-up to #135 addressing reviewer feedback.

- **Fix cross-fields WAND correctness bug**: `cross_fields_stats_for` now computes and returns the minimum positive combined doc length. Previously `min_doc_len` was `None` for cross-field terms, causing `TermState::new` to fall back to `avgdl` — which can exceed the true minimum and underestimate upper bounds, risking incorrect top-k pruning.
- **Conservative `TermState::new` fallback**: When `min_doc_len` is `None`, falls back to `1.0` (the most conservative value) instead of `avgdl`, ensuring WAND upper bounds are never underestimated.
- **Remove per-document `HashSet` construction**: Removed `matches_keyword_in_set` and the per-call `HashSet` + `to_lowercase()` path from `matches_keyword_in`. With the zero-alloc `case_insensitive_equals` from the parent PR, the linear scan is allocation-free and the `HashSet` approach was allocating more than it saved.
- **Fix clippy `type_complexity`**: Extracted `NestedFilterGroups` type alias.
- **Add missing tests**: Two new tests covering `KeywordIn` with >4 values for both flat and nested fields with case-insensitive matching.

## Test plan

- [x] All unit and integration tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Full workspace compiles (`cargo check --workspace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)