### PR TITLE
fix(api): reject non-ASCII cursor input without panicking (BUG-023)

### DIFF
--- a/searchlite-core/src/api/pagination.rs
+++ b/searchlite-core/src/api/pagination.rs
@@ -55,9 +55,17 @@ impl PaginationCursor {
         raw.len()
       );
     }
+    if !raw.is_ascii() {
+      bail!("invalid cursor: must be ASCII hex");
+    }
     let mut bytes = [0u8; CURSOR_BYTES];
     for (i, chunk) in raw.as_bytes().chunks_exact(2).enumerate() {
-      let hex = std::str::from_utf8(chunk).unwrap();
+      // SAFETY of correctness: `raw.is_ascii()` guarantees each byte is ASCII,
+      // so every two-byte chunk is valid UTF-8. `from_utf8` cannot fail here,
+      // but we propagate the error via `?` rather than `unwrap()` to avoid a
+      // panic if the guard above ever regresses.
+      let hex = std::str::from_utf8(chunk)
+        .map_err(|_| anyhow::anyhow!("cursor contains non-ASCII bytes at index {i}"))?;
       let value = u8::from_str_radix(hex, 16)
         .with_context(|| format!("decoding cursor at byte index {i}"))?;
       bytes[i] = value;
@@ -147,9 +155,15 @@ pub(crate) fn hex_decode(raw: &str) -> Result<Vec<u8>> {
   if raw.len() & 1 != 0 {
     bail!("invalid cursor: expected even-length hex string");
   }
+  if !raw.is_ascii() {
+    bail!("invalid cursor: must be ASCII hex");
+  }
   let mut bytes = Vec::with_capacity(raw.len() / 2);
   for (i, chunk) in raw.as_bytes().chunks_exact(2).enumerate() {
-    let hex = std::str::from_utf8(chunk).unwrap();
+    // Guarded by `is_ascii()` above, so every two-byte chunk is valid UTF-8.
+    // Propagate via `?` instead of `unwrap()` to avoid a panic on regression.
+    let hex = std::str::from_utf8(chunk)
+      .map_err(|_| anyhow::anyhow!("cursor contains non-ASCII bytes at index {i}"))?;
     let value =
       u8::from_str_radix(hex, 16).with_context(|| format!("decoding cursor at byte index {i}"))?;
     bytes.push(value);
@@ -395,5 +409,38 @@ mod tests {
     buf[17..].copy_from_slice(&returned.to_be_bytes());
     let encoded = hex_encode(&buf);
     assert!(PaginationCursor::decode(&encoded).is_err());
+  }
+
+  #[test]
+  fn pagination_cursor_rejects_multibyte_utf8_without_panic() {
+    // 14 × U+4E16 ("世") = 42 bytes of valid UTF-8 that happens to match
+    // `CURSOR_HEX_LEN`, so the length check passes. Every two-byte chunk
+    // lands inside a three-byte UTF-8 sequence, which used to panic at
+    // `from_utf8(..).unwrap()`. The fix must surface an error instead.
+    let input: String = "\u{4E16}".repeat(14);
+    assert_eq!(input.len(), CURSOR_HEX_LEN);
+    let result = PaginationCursor::decode(&input);
+    assert!(
+      result.is_err(),
+      "expected Err for non-ASCII cursor, got {result:?}"
+    );
+  }
+
+  #[test]
+  fn hex_decode_rejects_multibyte_utf8_without_panic() {
+    // Two multi-byte characters produce 6 bytes — even-length, passes the
+    // original gate, and every chunk straddles a UTF-8 boundary.
+    let result = hex_decode("\u{4E16}\u{4E16}");
+    assert!(
+      result.is_err(),
+      "expected Err for non-ASCII hex input, got {result:?}"
+    );
+  }
+
+  #[test]
+  fn hex_decode_accepts_valid_ascii_hex() {
+    // Positive control: ensure the added ASCII guard doesn't break the happy path.
+    let decoded = hex_decode("deadbeef").expect("valid ASCII hex decodes");
+    assert_eq!(decoded, vec![0xde, 0xad, 0xbe, 0xef]);
   }
 }

--- a/searchlite-core/src/api/pagination.rs
+++ b/searchlite-core/src/api/pagination.rs
@@ -60,14 +60,17 @@ impl PaginationCursor {
     }
     let mut bytes = [0u8; CURSOR_BYTES];
     for (i, chunk) in raw.as_bytes().chunks_exact(2).enumerate() {
-      // SAFETY of correctness: `raw.is_ascii()` guarantees each byte is ASCII,
-      // so every two-byte chunk is valid UTF-8. `from_utf8` cannot fail here,
-      // but we propagate the error via `?` rather than `unwrap()` to avoid a
-      // panic if the guard above ever regresses.
-      let hex = std::str::from_utf8(chunk)
-        .map_err(|_| anyhow::anyhow!("cursor contains non-ASCII bytes at index {i}"))?;
+      // Report positions against the raw input string so diagnostics point the
+      // caller at the offending character, not the decoded byte slot.
+      let raw_offset = 2 * i;
+      // `raw.is_ascii()` guarantees each byte is ASCII, so every two-byte
+      // chunk is valid UTF-8. We propagate via `?` rather than `unwrap()` so a
+      // future regression of the guard remains non-fatal.
+      let hex = std::str::from_utf8(chunk).map_err(|_| {
+        anyhow::anyhow!("cursor contains non-ASCII bytes at raw offset {raw_offset}")
+      })?;
       let value = u8::from_str_radix(hex, 16)
-        .with_context(|| format!("decoding cursor at byte index {i}"))?;
+        .with_context(|| format!("decoding cursor at raw offset {raw_offset}"))?;
       bytes[i] = value;
     }
     let version = bytes[0];
@@ -160,12 +163,15 @@ pub(crate) fn hex_decode(raw: &str) -> Result<Vec<u8>> {
   }
   let mut bytes = Vec::with_capacity(raw.len() / 2);
   for (i, chunk) in raw.as_bytes().chunks_exact(2).enumerate() {
+    // Report positions against the raw input so diagnostics point the caller
+    // at the offending character, not the decoded byte slot.
+    let raw_offset = 2 * i;
     // Guarded by `is_ascii()` above, so every two-byte chunk is valid UTF-8.
     // Propagate via `?` instead of `unwrap()` to avoid a panic on regression.
     let hex = std::str::from_utf8(chunk)
-      .map_err(|_| anyhow::anyhow!("cursor contains non-ASCII bytes at index {i}"))?;
-    let value =
-      u8::from_str_radix(hex, 16).with_context(|| format!("decoding cursor at byte index {i}"))?;
+      .map_err(|_| anyhow::anyhow!("cursor contains non-ASCII bytes at raw offset {raw_offset}"))?;
+    let value = u8::from_str_radix(hex, 16)
+      .with_context(|| format!("decoding cursor at raw offset {raw_offset}"))?;
     bytes.push(value);
   }
   Ok(bytes)


### PR DESCRIPTION
## Summary

Fixes [BUG-023](https://github.com/davidkelley/searchlite/issues/161) — `PaginationCursor::decode` and `hex_decode` in `searchlite-core/src/api/pagination.rs` panicked on crafted multibyte UTF-8 input.

Both functions iterated `raw.as_bytes().chunks_exact(2)` and called `std::str::from_utf8(chunk).unwrap()`. While the full `&str` was guaranteed to be valid UTF-8, individual two-byte slices could fall inside a three- or four-byte sequence, returning `Err` — at which point `unwrap()` panicked.

The length gate on `PaginationCursor::decode` only checks byte count (`CURSOR_HEX_LEN = 42`), so 14 × `U+4E16` (`世` = 3 bytes) produced a valid 42-byte input that reached the panic. `hex_decode` had no length check at all. Both entry points are reachable from unauthenticated HTTP requests via `SearchRequest { cursor, search_after }`, so this was a trivial DoS primitive.

## Changes

- Add an `is_ascii()` guard at both entry points; reject non-ASCII input with a clear error before the decode loop.
- Replace `from_utf8(chunk).unwrap()` with `?`-propagation so any future regression remains non-fatal.
- Add three regression tests in `searchlite-core/src/api/pagination.rs`:
  - `pagination_cursor_rejects_multibyte_utf8_without_panic` — the exact reproducer from the issue
  - `hex_decode_rejects_multibyte_utf8_without_panic` — same for the second entry point
  - `hex_decode_accepts_valid_ascii_hex` — positive control to make sure the new guard doesn't break the happy path

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test --all --all-features` — all pass, including the three new regression tests

Fixes #161
