### PR TITLE
fix(aggs): reject degenerate histogram intervals to prevent OOM (BUG-027)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2355,8 +2355,20 @@ fn validate_aggregations_in_scope(
             crate::api::types::CompositeSource::Terms { field, .. } => {
               ensure_keyword_fast(schema, field, name, scope_path)?
             }
-            crate::api::types::CompositeSource::Histogram { field, .. } => {
-              ensure_numeric_fast(schema, field, name, scope_path)?
+            crate::api::types::CompositeSource::Histogram {
+              field, interval, ..
+            } => {
+              ensure_numeric_fast(schema, field, name, scope_path)?;
+              if !interval.is_finite() || *interval <= 0.0 {
+                return Err(
+                  AggregationError::InvalidConfig {
+                    reason: format!(
+                      "composite `{name}` histogram source requires interval to be a finite positive number (got {interval})"
+                    ),
+                  }
+                  .into(),
+                );
+              }
             }
           }
         }
@@ -2836,33 +2848,22 @@ fn validate_sampling(name: &str, sampling: &Option<AggregationSampling>) -> Resu
 }
 
 fn validate_histogram_config(name: &str, agg: &HistogramAggregation) -> Result<()> {
-  if agg.interval <= 0.0 {
+  if !agg.interval.is_finite() || agg.interval <= 0.0 {
     return Err(
       AggregationError::InvalidConfig {
-        reason: format!("histogram `{name}` requires interval > 0"),
+        reason: format!(
+          "histogram `{name}` requires interval to be a finite positive number (got {})",
+          agg.interval
+        ),
       }
       .into(),
     );
   }
   if let Some(bounds) = &agg.extended_bounds {
-    if bounds.min > bounds.max {
-      return Err(
-        AggregationError::InvalidConfig {
-          reason: format!("histogram `{name}` extended_bounds.min > max"),
-        }
-        .into(),
-      );
-    }
+    validate_histogram_bounds(name, "extended_bounds", bounds.min, bounds.max)?;
   }
   if let Some(bounds) = &agg.hard_bounds {
-    if bounds.min > bounds.max {
-      return Err(
-        AggregationError::InvalidConfig {
-          reason: format!("histogram `{name}` hard_bounds.min > max"),
-        }
-        .into(),
-      );
-    }
+    validate_histogram_bounds(name, "hard_bounds", bounds.min, bounds.max)?;
     if let Some(ext) = &agg.extended_bounds {
       if ext.min < bounds.min || ext.max > bounds.max {
         return Err(
@@ -2874,8 +2875,48 @@ fn validate_histogram_config(name: &str, agg: &HistogramAggregation) -> Result<(
       }
     }
   }
+  if let Some(bounds) = agg.extended_bounds.as_ref().or(agg.hard_bounds.as_ref()) {
+    let span_buckets = ((bounds.max - bounds.min) / agg.interval).floor();
+    if !span_buckets.is_finite() || span_buckets >= MAX_HISTOGRAM_BOUND_BUCKETS as f64 {
+      return Err(
+        AggregationError::InvalidConfig {
+          reason: format!(
+            "histogram `{name}` bounds span produces too many empty buckets (limit {})",
+            MAX_HISTOGRAM_BOUND_BUCKETS
+          ),
+        }
+        .into(),
+      );
+    }
+  }
   Ok(())
 }
+
+fn validate_histogram_bounds(name: &str, which: &str, min: f64, max: f64) -> Result<()> {
+  if !min.is_finite() || !max.is_finite() {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!("histogram `{name}` {which} must be finite (got min={min}, max={max})"),
+      }
+      .into(),
+    );
+  }
+  if min > max {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!("histogram `{name}` {which}.min > max"),
+      }
+      .into(),
+    );
+  }
+  Ok(())
+}
+
+/// Hard limit on the number of empty buckets a histogram's
+/// `extended_bounds`/`hard_bounds` span may materialize. Prevents pathological
+/// `(max - min) / interval` ratios (including those produced by crafted tiny
+/// intervals) from exhausting memory.
+const MAX_HISTOGRAM_BOUND_BUCKETS: i64 = 65_536;
 
 fn validate_date_histogram_config(name: &str, agg: &DateHistogramAggregation) -> Result<()> {
   let has_calendar = agg.calendar_interval.is_some();

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2859,6 +2859,15 @@ fn validate_histogram_config(name: &str, agg: &HistogramAggregation) -> Result<(
       .into(),
     );
   }
+  let offset = agg.offset.unwrap_or(0.0);
+  if !offset.is_finite() {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!("histogram `{name}` requires offset to be finite (got {offset})"),
+      }
+      .into(),
+    );
+  }
   if let Some(bounds) = &agg.extended_bounds {
     validate_histogram_bounds(name, "extended_bounds", bounds.min, bounds.max)?;
   }
@@ -2876,13 +2885,23 @@ fn validate_histogram_config(name: &str, agg: &HistogramAggregation) -> Result<(
     }
   }
   if let Some(bounds) = agg.extended_bounds.as_ref().or(agg.hard_bounds.as_ref()) {
-    let span_buckets = ((bounds.max - bounds.min) / agg.interval).floor();
-    if !span_buckets.is_finite() || span_buckets >= MAX_HISTOGRAM_BOUND_BUCKETS as f64 {
+    // Mirror the collector's bucket-id formula so the count we compare against
+    // the cap is exactly what `HistogramCollector::finish` would materialize:
+    //   bucket_id = floor((val - offset) / interval)
+    //   count     = end - start + 1   (inclusive range `start..=end`)
+    // Using `(max - min) / interval` here would miss the fence-post bucket and
+    // ignore `offset`, letting a request sneak past the cap by 1-2 buckets.
+    let start_bucket = ((bounds.min - offset) / agg.interval).floor();
+    let end_bucket = ((bounds.max - offset) / agg.interval).floor();
+    let span_buckets = (end_bucket - start_bucket) + 1.0;
+    // Align the validator with the runtime cap (`MAX_BUCKETS`) so requests that
+    // would silently truncate at collection time are rejected up front.
+    if !span_buckets.is_finite() || span_buckets > crate::query::aggs::MAX_BUCKETS as f64 {
       return Err(
         AggregationError::InvalidConfig {
           reason: format!(
             "histogram `{name}` bounds span produces too many empty buckets (limit {})",
-            MAX_HISTOGRAM_BOUND_BUCKETS
+            crate::query::aggs::MAX_BUCKETS
           ),
         }
         .into(),
@@ -2911,12 +2930,6 @@ fn validate_histogram_bounds(name: &str, which: &str, min: f64, max: f64) -> Res
   }
   Ok(())
 }
-
-/// Hard limit on the number of empty buckets a histogram's
-/// `extended_bounds`/`hard_bounds` span may materialize. Prevents pathological
-/// `(max - min) / interval` ratios (including those produced by crafted tiny
-/// intervals) from exhausting memory.
-const MAX_HISTOGRAM_BOUND_BUCKETS: i64 = 65_536;
 
 fn validate_date_histogram_config(name: &str, agg: &DateHistogramAggregation) -> Result<()> {
   let has_calendar = agg.calendar_interval.is_some();

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1290,19 +1290,37 @@ impl<'a> HistogramCollector<'a> {
     let mut buckets = self.buckets;
     let bucket_key = |val: f64| ((val - offset) / interval).floor() as i64;
     let bucket_value = |bucket_id: i64| bucket_id as f64 * interval + offset;
-    if let Some((min, max)) = extended_bounds.or(hard_bounds) {
-      let mut bucket_id = bucket_key(min);
-      let end = bucket_key(max);
-      while bucket_id <= end {
-        buckets.entry(bucket_id).or_insert_with(|| BucketState {
-          key: serde_json::Value::Number(
-            serde_json::Number::from_f64(bucket_value(bucket_id))
-              .unwrap_or_else(|| serde_json::Number::from(0)),
-          ),
-          doc_count: 0,
-          aggs: BTreeMap::new(),
-        });
-        bucket_id += 1;
+    // Defense-in-depth: the request validator rejects non-finite / non-positive
+    // intervals (see `validate_histogram_config`). Skip bounds materialization
+    // entirely in the unlikely case we got here with a degenerate interval so
+    // that the loop below cannot become unbounded (BUG-027).
+    let bounds_materializable = interval.is_finite() && interval > 0.0;
+    if bounds_materializable {
+      if let Some((min, max)) = extended_bounds.or(hard_bounds) {
+        let mut bucket_id = bucket_key(min);
+        let end = bucket_key(max);
+        let mut materialized: usize = 0;
+        while bucket_id <= end {
+          buckets.entry(bucket_id).or_insert_with(|| BucketState {
+            key: serde_json::Value::Number(
+              serde_json::Number::from_f64(bucket_value(bucket_id))
+                .unwrap_or_else(|| serde_json::Number::from(0)),
+            ),
+            doc_count: 0,
+            aggs: BTreeMap::new(),
+          });
+          // Guard against saturating-cast + wrapping addition producing an
+          // infinite loop if somehow `end == i64::MAX` (belt-and-braces: the
+          // validator caps the span well below this).
+          let Some(next) = bucket_id.checked_add(1) else {
+            break;
+          };
+          bucket_id = next;
+          materialized = materialized.saturating_add(1);
+          if materialized >= MAX_BUCKETS {
+            break;
+          }
+        }
       }
     }
     let mut buckets: Vec<BucketIntermediate> = buckets

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -41,7 +41,7 @@ pub struct AggregationContext<'a> {
 /// `10_000` is a pragmatic default that keeps memory bounded for typical analytics workloads while
 /// still allowing thousands of buckets. Deployments that need a different limit can adjust this
 /// constant at compile time.
-const MAX_BUCKETS: usize = 10_000;
+pub(crate) const MAX_BUCKETS: usize = 10_000;
 const TDIGEST_MAX_SIZE: usize = 200;
 const PERCENTILE_EXACT_LIMIT: usize = 256;
 

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -3,10 +3,10 @@ use std::collections::BTreeMap;
 use chrono::DateTime;
 use searchlite_core::api::builder::IndexBuilder;
 use searchlite_core::api::types::{
-  Aggregation, DateHistogramAggregation, DateHistogramBounds, Document, ExecutionStrategy,
-  HistogramAggregation, HistogramBounds, IndexOptions, KeywordField, MetricAggregation,
-  NumericField, Schema, SearchRequest, SortOrder, SortSpec, StorageType, TermsAggregation,
-  TopHitsAggregation,
+  Aggregation, CompositeAggregation, CompositeSource, DateHistogramAggregation,
+  DateHistogramBounds, Document, ExecutionStrategy, HistogramAggregation, HistogramBounds,
+  IndexOptions, KeywordField, MetricAggregation, NumericField, Schema, SearchRequest, SortOrder,
+  SortSpec, StorageType, TermsAggregation, TopHitsAggregation,
 };
 use searchlite_core::api::Index;
 use serde_json::json;
@@ -195,7 +195,10 @@ fn histogram_requires_positive_interval() {
   });
   assert!(resp.is_err());
   let msg = resp.err().unwrap().to_string();
-  assert!(msg.contains("interval > 0"));
+  assert!(
+    msg.contains("finite positive number"),
+    "expected error to mention finite positive interval, got: {msg}"
+  );
 }
 
 #[test]
@@ -758,5 +761,241 @@ fn date_histogram_calendar_month_interval() {
     assert_eq!(buckets[2].doc_count, 0);
   } else {
     panic!("expected date histogram response");
+  }
+}
+
+/// Regression tests for BUG-027 — `HistogramAggregation` with a degenerate
+/// (zero / NaN / infinite) `interval` combined with `extended_bounds` or
+/// `hard_bounds` previously drove `HistogramCollector::finish` into an
+/// unbounded bucket-insertion loop that exhausted memory.
+mod bug_027 {
+  use super::*;
+
+  fn numeric_score_index(path: &std::path::Path) -> searchlite_core::api::Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "score".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = Index::create(path, schema, build_base_options(path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      writer
+        .add_document(&doc(
+          "doc-1",
+          vec![("body", json!("rust")), ("score", json!(1))],
+        ))
+        .unwrap();
+      writer.commit().unwrap();
+    }
+    idx
+  }
+
+  fn search_with_agg(
+    idx: &searchlite_core::api::Index,
+    aggs: BTreeMap<String, Aggregation>,
+  ) -> anyhow::Result<()> {
+    let mut req = SearchRequest::new("rust");
+    req.aggs = aggs;
+    idx.reader().unwrap().search(&req)?;
+    Ok(())
+  }
+
+  fn assert_invalid_histogram(err: anyhow::Error, expected_substr: &str) {
+    let msg = err.to_string();
+    assert!(
+      msg.contains(expected_substr),
+      "expected error message to contain {expected_substr:?}, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn zero_interval_with_extended_bounds_is_rejected_without_infinite_loop() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: 0.0,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: Some(HistogramBounds {
+          min: 0.0,
+          max: 100.0,
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err("zero interval must be rejected");
+    assert_invalid_histogram(err, "finite positive number");
+  }
+
+  #[test]
+  fn nan_interval_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: f64::NAN,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err("NaN interval must be rejected");
+    assert_invalid_histogram(err, "finite positive number");
+  }
+
+  #[test]
+  fn positive_infinite_interval_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: f64::INFINITY,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err("infinite interval must be rejected");
+    assert_invalid_histogram(err, "finite positive number");
+  }
+
+  #[test]
+  fn non_finite_bounds_are_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: 10.0,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: Some(HistogramBounds {
+          min: 0.0,
+          max: f64::INFINITY,
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err("non-finite bounds must be rejected");
+    assert_invalid_histogram(err, "finite");
+  }
+
+  #[test]
+  fn bounds_span_exceeding_bucket_cap_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        // 1_000_000 / 1.0 = 1_000_000 buckets — well above the 65_536 cap.
+        interval: 1.0,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: Some(HistogramBounds {
+          min: 0.0,
+          max: 1_000_000.0,
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err("excessive bounds span must be rejected");
+    assert_invalid_histogram(err, "too many empty buckets");
+  }
+
+  #[test]
+  fn composite_histogram_source_rejects_zero_interval() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "c".into(),
+      Aggregation::Composite(Box::new(CompositeAggregation {
+        sources: vec![CompositeSource::Histogram {
+          name: "score_buckets".into(),
+          field: "score".into(),
+          interval: 0.0,
+        }],
+        size: 10,
+        after: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("composite histogram source with zero interval must be rejected");
+    assert_invalid_histogram(err, "finite positive number");
+  }
+
+  #[test]
+  fn composite_histogram_source_rejects_nan_interval() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "c".into(),
+      Aggregation::Composite(Box::new(CompositeAggregation {
+        sources: vec![CompositeSource::Histogram {
+          name: "score_buckets".into(),
+          field: "score".into(),
+          interval: f64::NAN,
+        }],
+        size: 10,
+        after: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("composite histogram source with NaN interval must be rejected");
+    assert_invalid_histogram(err, "finite positive number");
   }
 }

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -928,7 +928,7 @@ mod bug_027 {
       "h".into(),
       Aggregation::Histogram(Box::new(HistogramAggregation {
         field: "score".into(),
-        // 1_000_000 / 1.0 = 1_000_000 buckets — well above the 65_536 cap.
+        // 1_000_000 / 1.0 = 1_000_000 buckets — well above the cap.
         interval: 1.0,
         offset: None,
         min_doc_count: None,
@@ -945,6 +945,135 @@ mod bug_027 {
 
     let err = search_with_agg(&idx, aggs).expect_err("excessive bounds span must be rejected");
     assert_invalid_histogram(err, "too many empty buckets");
+  }
+
+  /// Codex P1 regression: validation and the runtime `MAX_BUCKETS` cap must
+  /// agree, otherwise a request sitting between the two caps would pass
+  /// validation and then silently truncate at collection time. 15_000 buckets
+  /// is above the 10_000 runtime cap but below the previous (draft) 65_536
+  /// validation cap — it must be rejected, not truncated.
+  #[test]
+  fn bounds_span_between_runtime_cap_and_draft_cap_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: 1.0,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: Some(HistogramBounds {
+          min: 0.0,
+          max: 15_000.0,
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("bounds span above the runtime cap must be rejected, not silently truncated");
+    assert_invalid_histogram(err, "too many empty buckets");
+  }
+
+  /// Copilot regression: the bucket-count check must mirror the collector's
+  /// `bucket_key(min)..=bucket_key(max)` (inclusive) formula so the
+  /// fence-post bucket is not double-counted as "within cap". With
+  /// interval=1.0 and bounds=[0.0, 10000.0], the collector would materialize
+  /// 10_001 buckets; a naïve `(max-min)/interval = 10_000` check would
+  /// (incorrectly) allow it.
+  #[test]
+  fn bounds_span_fence_post_respects_cap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: 1.0,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: Some(HistogramBounds {
+          min: 0.0,
+          max: 10_000.0,
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("10_001 inclusive buckets must be rejected (fence-post), not accepted as 10_000");
+    assert_invalid_histogram(err, "too many empty buckets");
+  }
+
+  /// Copilot regression: `offset` shifts the bucket grid, which the old
+  /// formula ignored. This test locks in that a request sitting exactly at
+  /// the cap (accounting for offset) is still accepted.
+  #[test]
+  fn bounds_span_with_offset_at_cap_boundary_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: 1.0,
+        // floor((0 - 0.5)/1) = -1, floor((9998.5 - 0.5)/1) = 9998,
+        // span = 9998 - (-1) + 1 = 10_000 — exactly at the cap.
+        offset: Some(0.5),
+        min_doc_count: None,
+        extended_bounds: Some(HistogramBounds {
+          min: 0.0,
+          max: 9998.5,
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    search_with_agg(&idx, aggs).expect("bounds span exactly at cap must be accepted");
+  }
+
+  /// Guard against a non-finite `offset` slipping through — otherwise the
+  /// bucket-count computation becomes NaN and the cap check becomes
+  /// meaningless.
+  #[test]
+  fn non_finite_offset_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = numeric_score_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "h".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval: 10.0,
+        offset: Some(f64::NAN),
+        min_doc_count: None,
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err("NaN offset must be rejected");
+    assert_invalid_histogram(err, "offset");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Fixes [BUG-027 (#165)](https://github.com/davidkelley/searchlite/issues/165) — `HistogramAggregation` with a degenerate `interval` (`0`, `NaN`, `+inf`) combined with `extended_bounds`/`hard_bounds` drove `HistogramCollector::finish` into an unbounded bucket-materialization loop that exhausted memory. Reachable from any unauthenticated HTTP `POST /indexes/{name}/search` caller.

The same hazard existed on the `CompositeSource::Histogram` collector, where `(v / interval).floor()` produced `NaN` that collapsed every value into a single bucket via `NaN.to_bits()`.

## Changes

- **`validate_histogram_config`**: require `interval` to be finite *and* `> 0` (previously only rejected `<= 0` — NaN and `+inf` slipped through). Require `extended_bounds`/`hard_bounds` min/max to be finite. Reject bound spans that would materialize more than `MAX_HISTOGRAM_BOUND_BUCKETS = 65_536` empty buckets.
- **Composite aggregation validation**: `CompositeSource::Histogram` now has its `interval` checked with the same "finite and positive" gate. Previously the composite path had no `interval` validation at all.
- **Defense-in-depth in `HistogramCollector::finish`**: skip bounds materialization entirely for a non-finite/non-positive interval, use `checked_add` instead of `+= 1` to stop at `i64::MAX` (the saturating-cast + wrapping `+=` was the release-mode infinite loop), and cap the loop at `MAX_BUCKETS` as a final safety net.

## Tests

- Updated existing `histogram_requires_positive_interval` to assert the new, more descriptive error phrasing ("finite positive number").
- New `bug_027` module in `searchlite-core/tests/aggregation_bounds.rs` with seven focused tests:
  - `zero_interval_with_extended_bounds_is_rejected_without_infinite_loop` — the exact reproducer from the issue body.
  - `nan_interval_is_rejected` / `positive_infinite_interval_is_rejected` — cover the two values that previously bypassed `<= 0.0`.
  - `non_finite_bounds_are_rejected` — guards against `+inf` bounds producing giant spans.
  - `bounds_span_exceeding_bucket_cap_is_rejected` — exercises the new `MAX_HISTOGRAM_BOUND_BUCKETS` cap.
  - `composite_histogram_source_rejects_zero_interval` / `composite_histogram_source_rejects_nan_interval` — pin the composite-source path.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` — clean
- [x] `cargo test --all --all-features` — all pass, including the new `bug_027::*` tests

Fixes #165