### PR TITLE
fix(query): clamp phrase slop and saturate i32 cast (BUG-026)

### DIFF
--- a/searchlite-core/src/query/phrase.rs
+++ b/searchlite-core/src/query/phrase.rs
@@ -38,10 +38,12 @@ pub fn matches_phrase(postings: &[Vec<PostingEntry>], doc_id: DocId, slop: u32) 
     }
     false
   }
-  // Saturate to i32::MAX: callers should clamp well below this at the query
-  // planning boundary (see planner::MAX_PHRASE_SLOP), but using `as i32` here
-  // would wrap values >= 2^31 to a negative remaining budget and silently
-  // reject every document, the opposite of the caller's intent.
+  // Saturate to i32::MAX: callers already saturate at the query planning
+  // boundary (see planner::MAX_PHRASE_SLOP), but using `as i32` here would
+  // wrap values >= 2^31 to a negative remaining budget and silently reject
+  // every document — the opposite of the caller's intent — so we keep the
+  // saturating cast as defence-in-depth for any future caller that reaches
+  // the matcher without going through the planner.
   let remaining = i32::try_from(slop).unwrap_or(i32::MAX);
   for start in positions_per_term[0].iter().copied() {
     if search(&positions_per_term, 1, start, remaining) {

--- a/searchlite-core/src/query/phrase.rs
+++ b/searchlite-core/src/query/phrase.rs
@@ -38,7 +38,11 @@ pub fn matches_phrase(postings: &[Vec<PostingEntry>], doc_id: DocId, slop: u32) 
     }
     false
   }
-  let remaining = slop as i32;
+  // Saturate to i32::MAX: callers should clamp well below this at the query
+  // planning boundary (see planner::MAX_PHRASE_SLOP), but using `as i32` here
+  // would wrap values >= 2^31 to a negative remaining budget and silently
+  // reject every document, the opposite of the caller's intent.
+  let remaining = i32::try_from(slop).unwrap_or(i32::MAX);
   for start in positions_per_term[0].iter().copied() {
     if search(&positions_per_term, 1, start, remaining) {
       return true;
@@ -113,5 +117,28 @@ mod tests {
     ];
     assert!(!matches_phrase(&postings, 3, 0));
     assert!(matches_phrase(&postings, 3, 3));
+  }
+
+  #[test]
+  fn saturates_large_slop_instead_of_wrapping_to_negative() {
+    // Regression test for BUG-026. Previously `slop as i32` wrapped any value
+    // >= 2^31 into a negative "remaining" budget, so the phrase matched zero
+    // documents — the exact opposite of the caller's "very loose match"
+    // intent. The saturating cast keeps the loose-match semantics.
+    let postings = vec![
+      vec![PostingEntry {
+        doc_id: 1,
+        term_freq: 1,
+        positions: smallvec![1],
+      }],
+      vec![PostingEntry {
+        doc_id: 1,
+        term_freq: 1,
+        positions: smallvec![2],
+      }],
+    ];
+    assert!(matches_phrase(&postings, 1, 0));
+    assert!(matches_phrase(&postings, 1, u32::MAX));
+    assert!(matches_phrase(&postings, 1, (i32::MAX as u32) + 1));
   }
 }

--- a/searchlite-core/src/query/planner.rs
+++ b/searchlite-core/src/query/planner.rs
@@ -13,6 +13,14 @@ const DEFAULT_PREFIX_MAX_EXPANSIONS: usize = 50;
 const DEFAULT_WILDCARD_MAX_EXPANSIONS: usize = 100;
 const DEFAULT_REGEX_MAX_EXPANSIONS: usize = 100;
 
+/// Upper bound on phrase `slop` applied at query planning time. User-supplied
+/// values (which flow in as `usize`) are clamped to this ceiling before being
+/// narrowed to `u32` for the matcher. This prevents the cast from silently
+/// truncating and — together with the saturating `i32` cast inside
+/// `matches_phrase` — preserves the "more slop → looser match" invariant for
+/// every input value. 256 is well above the 0-20 range real callers use.
+pub(crate) const MAX_PHRASE_SLOP: u32 = 256;
+
 /// Expands query terms into field-qualified terms using default fields when no explicit field is given.
 pub fn expand_terms(query: &ParsedQuery, default_fields: &[String]) -> Vec<(String, String)> {
   let mut out = Vec::new();
@@ -639,7 +647,11 @@ impl<'a> QueryPlanBuilder<'a> {
           Some(field) => vec![field.clone()],
           None => self.default_fields.to_vec(),
         };
-        let idx = self.push_phrase(fields, terms.clone(), slop.unwrap_or(0) as u32);
+        let slop_raw = slop.unwrap_or(0);
+        let slop = u32::try_from(slop_raw)
+          .unwrap_or(MAX_PHRASE_SLOP)
+          .min(MAX_PHRASE_SLOP);
+        let idx = self.push_phrase(fields, terms.clone(), slop);
         Ok((QueryMatcher::Phrase(idx), None, ScoreNode::Empty))
       }
       QueryNode::Bool {
@@ -1002,6 +1014,47 @@ mod tests {
         ("body".to_string(), "boring".to_string())
       ]
     );
+  }
+
+  #[test]
+  fn phrase_slop_is_clamped_to_ceiling() {
+    // Regression test for BUG-026. User-supplied `slop` is a `usize`; before
+    // the fix it was narrowed with `as u32`, which truncated high bits on
+    // 64-bit platforms and then wrapped to a negative `i32` inside
+    // `matches_phrase`. Every out-of-range value now collapses to the same
+    // `MAX_PHRASE_SLOP` ceiling.
+    for input in [
+      Some(MAX_PHRASE_SLOP as usize + 1),
+      Some(usize::MAX),
+      Some(u32::MAX as usize),
+      Some((i32::MAX as usize) + 1),
+    ] {
+      let plan = build_query_plan(
+        &Query::Node(QueryNode::Phrase {
+          field: Some("body".into()),
+          terms: vec!["hello".into(), "world".into()],
+          slop: input,
+          boost: None,
+        }),
+        &["body".to_string()],
+      )
+      .unwrap();
+      assert_eq!(plan.phrase_specs.len(), 1);
+      assert_eq!(plan.phrase_specs[0].slop, MAX_PHRASE_SLOP);
+    }
+
+    // In-range values pass through unchanged.
+    let plan = build_query_plan(
+      &Query::Node(QueryNode::Phrase {
+        field: Some("body".into()),
+        terms: vec!["hello".into(), "world".into()],
+        slop: Some(5),
+        boost: None,
+      }),
+      &["body".to_string()],
+    )
+    .unwrap();
+    assert_eq!(plan.phrase_specs[0].slop, 5);
   }
 
   #[test]

--- a/searchlite-core/src/query/planner.rs
+++ b/searchlite-core/src/query/planner.rs
@@ -14,12 +14,14 @@ const DEFAULT_WILDCARD_MAX_EXPANSIONS: usize = 100;
 const DEFAULT_REGEX_MAX_EXPANSIONS: usize = 100;
 
 /// Upper bound on phrase `slop` applied at query planning time. User-supplied
-/// values (which flow in as `usize`) are clamped to this ceiling before being
-/// narrowed to `u32` for the matcher. This prevents the cast from silently
-/// truncating and — together with the saturating `i32` cast inside
-/// `matches_phrase` — preserves the "more slop → looser match" invariant for
-/// every input value. 256 is well above the 0-20 range real callers use.
-pub(crate) const MAX_PHRASE_SLOP: u32 = 256;
+/// values (which flow in as `usize`) are saturated to this ceiling before
+/// being narrowed to `u32` for the matcher. The ceiling is `i32::MAX` — the
+/// largest value the matcher can faithfully represent in its `i32` "remaining
+/// budget" — so every in-range request is preserved exactly and only values
+/// beyond what the matcher could respect anyway get capped. Together with the
+/// saturating `i32` cast inside `matches_phrase` this preserves the "more
+/// slop → looser match" invariant for every input value.
+pub(crate) const MAX_PHRASE_SLOP: u32 = i32::MAX as u32;
 
 /// Expands query terms into field-qualified terms using default fields when no explicit field is given.
 pub fn expand_terms(query: &ParsedQuery, default_fields: &[String]) -> Vec<(String, String)> {
@@ -1023,11 +1025,13 @@ mod tests {
     // 64-bit platforms and then wrapped to a negative `i32` inside
     // `matches_phrase`. Every out-of-range value now collapses to the same
     // `MAX_PHRASE_SLOP` ceiling.
+    // Out-of-range values saturate to MAX_PHRASE_SLOP rather than truncating
+    // or wrapping. This covers usize values above u32::MAX (high-bit
+    // truncation) and values above i32::MAX (downstream i32 wrap).
     for input in [
       Some(MAX_PHRASE_SLOP as usize + 1),
       Some(usize::MAX),
       Some(u32::MAX as usize),
-      Some((i32::MAX as usize) + 1),
     ] {
       let plan = build_query_plan(
         &Query::Node(QueryNode::Phrase {
@@ -1043,18 +1047,22 @@ mod tests {
       assert_eq!(plan.phrase_specs[0].slop, MAX_PHRASE_SLOP);
     }
 
-    // In-range values pass through unchanged.
-    let plan = build_query_plan(
-      &Query::Node(QueryNode::Phrase {
-        field: Some("body".into()),
-        terms: vec!["hello".into(), "world".into()],
-        slop: Some(5),
-        boost: None,
-      }),
-      &["body".to_string()],
-    )
-    .unwrap();
-    assert_eq!(plan.phrase_specs[0].slop, 5);
+    // In-range values — including legitimate large slops beyond typical usage
+    // but still representable in the matcher's i32 budget — pass through
+    // unchanged.
+    for input in [0usize, 5, 500, 10_000, MAX_PHRASE_SLOP as usize] {
+      let plan = build_query_plan(
+        &Query::Node(QueryNode::Phrase {
+          field: Some("body".into()),
+          terms: vec!["hello".into(), "world".into()],
+          slop: Some(input),
+          boost: None,
+        }),
+        &["body".to_string()],
+      )
+      .unwrap();
+      assert_eq!(plan.phrase_specs[0].slop as usize, input);
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary
Fixes BUG-026 (#164). User-supplied phrase `slop` flowed through `Option<usize> -> u32 -> i32` without any bounds check. Values above `u32::MAX` truncated on the first cast, and values above `i32::MAX` wrapped to a negative "remaining" budget inside `matches_phrase`, causing the matcher to break out on the first positions pair and silently return zero documents — the exact opposite of the caller's "very loose match" intent.

## Changes
- `searchlite-core/src/query/planner.rs`: introduce `MAX_PHRASE_SLOP = i32::MAX as u32` and saturate `slop` at the query planning boundary using `u32::try_from(..).unwrap_or(MAX_PHRASE_SLOP).min(MAX_PHRASE_SLOP)` instead of an unchecked `as u32`. The ceiling is the largest value the matcher's `i32` remaining budget can faithfully represent, so every in-range request passes through unchanged.
- `searchlite-core/src/query/phrase.rs`: replace `slop as i32` with `i32::try_from(slop).unwrap_or(i32::MAX)` so the remaining budget stays non-negative even if a future caller reaches the matcher without going through the planner.
- Regression tests at both layers cover `u32::MAX`, `usize::MAX`, and the `MAX_PHRASE_SLOP + 1` boundary; in-range values (`0`, `5`, `500`, `10 000`, `MAX_PHRASE_SLOP`) pass through unchanged.

## Test plan
- [x] `cargo test -p searchlite-core --lib query::` — 35 tests pass, including the two new regression tests.
- [x] `cargo build --workspace` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy --workspace --all-targets --no-deps` — no new warnings introduced.

Closes #164