### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2173,7 +2173,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.10...searchlite-cli-v0.1.11) - 2026-04-14
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.1.10](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.9...searchlite-cli-v0.1.10) - 2026-04-13
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.7.0...searchlite-core-v0.7.1) - 2026-04-14
+
+### Fixed
+
+- *(query)* clamp phrase slop and saturate i32 cast (BUG-026) ([#175](https://github.com/davidkelley/searchlite/pull/175))
+- *(postings)* always skip on-disk position bytes regardless of caller flag (BUG-001) ([#173](https://github.com/davidkelley/searchlite/pull/173))
+- *(aggs)* reject degenerate histogram intervals to prevent OOM (BUG-027) ([#169](https://github.com/davidkelley/searchlite/pull/169))
+- *(api)* reject non-ASCII cursor input without panicking ([#168](https://github.com/davidkelley/searchlite/pull/168))
+
 ## [0.7.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.6.4...searchlite-core-v0.7.0) - 2026-04-13
 
 ### Fixed

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.3...searchlite-http-v0.2.4) - 2026-04-14
+
+### Other
+
+- update Cargo.lock dependencies
+
 ## [0.2.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.2...searchlite-http-v0.2.3) - 2026-04-13
 
 ### Other

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `searchlite-http`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `integration`: 0.2.3 -> 0.2.4
* `searchlite-cli`: 0.1.10 -> 0.1.11
* `searchlite-node`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.7.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.7.0...searchlite-core-v0.7.1) - 2026-04-14

### Fixed

- *(query)* clamp phrase slop and saturate i32 cast (BUG-026) ([#175](https://github.com/davidkelley/searchlite/pull/175))
- *(postings)* always skip on-disk position bytes regardless of caller flag (BUG-001) ([#173](https://github.com/davidkelley/searchlite/pull/173))
- *(aggs)* reject degenerate histogram intervals to prevent OOM (BUG-027) ([#169](https://github.com/davidkelley/searchlite/pull/169))
- *(api)* reject non-ASCII cursor input without panicking ([#168](https://github.com/davidkelley/searchlite/pull/168))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.3...searchlite-http-v0.2.4) - 2026-04-14

### Other

- update Cargo.lock dependencies
</blockquote>

## `integration`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/integration-v0.2.1...integration-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.11](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.10...searchlite-cli-v0.1.11) - 2026-04-14

### Other

- update Cargo.lock dependencies
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.1...searchlite-node-v0.2.2) - 2026-04-13

### Added

- replace custom index schema with JSON Schema + searchlite: vocabulary ([#118](https://github.com/davidkelley/searchlite/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).