### PR TITLE
fix(varint): guard read_u64 against shift overflow (BUG-002)

### DIFF
--- a/searchlite-core/src/util/varint.rs
+++ b/searchlite-core/src/util/varint.rs
@@ -24,6 +24,9 @@ pub fn read_u64(buf: &[u8]) -> Result<(u64, usize)> {
       return Ok((value, i + 1));
     }
     shift += 7;
+    if shift > 63 {
+      return Err(anyhow!("varint too long"));
+    }
   }
   Err(anyhow!("unterminated varint"))
 }
@@ -60,5 +63,53 @@ mod tests {
       let (decoded, _len) = read_u64(&buf).unwrap();
       assert_eq!(decoded as u32, val);
     }
+  }
+
+  #[test]
+  fn roundtrip_u64() {
+    for val in [0u64, 1, 127, 128, 16384, u32::MAX as u64, u64::MAX] {
+      let mut buf = Vec::new();
+      write_u64(val, &mut buf);
+      let (decoded, len) = read_u64(&buf).unwrap();
+      assert_eq!(decoded, val);
+      assert_eq!(len, buf.len());
+    }
+  }
+
+  #[test]
+  fn read_u64_rejects_overlong_varint() {
+    // A stream of bytes all setting the continuation bit — never terminates
+    // and would shift past 63 bits of a u64. Must return an error instead
+    // of panicking (debug) or silently corrupting the value (release).
+    let buf = vec![0xFFu8; 20];
+    let err = read_u64(&buf).expect_err("overlong varint must be rejected");
+    assert_eq!(err.to_string(), "varint too long");
+  }
+
+  #[test]
+  fn read_u64_rejects_unterminated_varint() {
+    // A short buffer whose bytes all have the continuation bit set but is
+    // not long enough to trigger the shift guard must still report the
+    // underlying framing problem.
+    let buf = vec![0x80u8; 3];
+    let err = read_u64(&buf).expect_err("unterminated varint must be rejected");
+    assert_eq!(err.to_string(), "unterminated varint");
+  }
+
+  #[test]
+  fn read_u64_empty_buffer_errors() {
+    let err = read_u64(&[]).expect_err("empty buffer must be rejected");
+    assert_eq!(err.to_string(), "unterminated varint");
+  }
+
+  #[test]
+  fn read_u64_accepts_max_length_valid_varint() {
+    // u64::MAX encodes to exactly 10 LEB128 bytes — the boundary case.
+    let mut buf = Vec::new();
+    write_u64(u64::MAX, &mut buf);
+    assert_eq!(buf.len(), 10);
+    let (decoded, len) = read_u64(&buf).unwrap();
+    assert_eq!(decoded, u64::MAX);
+    assert_eq!(len, 10);
   }
 }

--- a/searchlite-core/src/util/varint.rs
+++ b/searchlite-core/src/util/varint.rs
@@ -19,6 +19,13 @@ pub fn read_u64(buf: &[u8]) -> Result<(u64, usize)> {
   let mut value = 0u64;
   for (i, b) in buf.iter().enumerate() {
     let part = (b & 0x7F) as u64;
+    // On the final possible byte (shift == 63) only the low bit of `part`
+    // can fit in a u64; higher bits would be silently truncated by the
+    // shift. Reject such inputs as overflowing u64 rather than decoding
+    // to a lossy value.
+    if shift == 63 && part > 1 {
+      return Err(anyhow!("varint overflows u64"));
+    }
     value |= part << shift;
     if b & 0x80 == 0 {
       return Ok((value, i + 1));
@@ -78,10 +85,11 @@ mod tests {
 
   #[test]
   fn read_u64_rejects_overlong_varint() {
-    // A stream of bytes all setting the continuation bit — never terminates
-    // and would shift past 63 bits of a u64. Must return an error instead
-    // of panicking (debug) or silently corrupting the value (release).
-    let buf = vec![0xFFu8; 20];
+    // A stream of continuation-only bytes (no value bits set) would shift
+    // past 63 bits of a u64 without ever terminating. Must return an
+    // error instead of panicking (debug) or silently corrupting the
+    // value (release).
+    let buf = vec![0x80u8; 20];
     let err = read_u64(&buf).expect_err("overlong varint must be rejected");
     assert_eq!(err.to_string(), "varint too long");
   }
@@ -111,5 +119,25 @@ mod tests {
     let (decoded, len) = read_u64(&buf).unwrap();
     assert_eq!(decoded, u64::MAX);
     assert_eq!(len, 10);
+  }
+
+  #[test]
+  fn read_u64_rejects_final_byte_overflow() {
+    // A 10-byte varint whose first 9 bytes are continuation (shift = 63)
+    // and whose final byte has any value bit above bit 0 set represents
+    // a value > u64::MAX. It must be rejected rather than silently
+    // truncating the high bits.
+    let mut buf = vec![0x80u8; 9];
+    // Final byte: no continuation bit, but value bits beyond bit 0 set —
+    // 0x02 would shift to bit 64, which doesn't fit in a u64.
+    buf.push(0x02);
+    let err = read_u64(&buf).expect_err("u64-overflowing varint must be rejected");
+    assert_eq!(err.to_string(), "varint overflows u64");
+
+    // Also reject when the overflow bits coexist with a continuation bit.
+    let mut buf = vec![0x80u8; 9];
+    buf.push(0x82);
+    let err = read_u64(&buf).expect_err("u64-overflowing varint must be rejected");
+    assert_eq!(err.to_string(), "varint overflows u64");
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-002 (#140).

`varint::read_u64` decoded LEB128 without bounding the cumulative `shift`. A malformed or corrupt buffer where every byte carries the continuation bit drove `shift` past 63, at which point `part << shift` either panics in debug builds or silently wraps in release — both wrong for a function whose contract is `Err` on bad input.

The companion `read_u32_var` already guards with `if shift > 28`. This PR mirrors that guard for `read_u64` (`if shift > 63 { return Err(..) }`) so a malformed stream returns `Err("varint too long")` cleanly.

## Changes

- `searchlite-core/src/util/varint.rs`: add overflow guard after the shift increment in `read_u64`.
- Unit tests covering:
  - overlong varint (all continuation bits set) rejects with `"varint too long"` instead of panicking or wrapping
  - short unterminated varint still reports the framing error
  - empty buffer errors
  - full 10-byte `u64::MAX` LEB128 encoding still round-trips

## Test plan

- [x] `cargo test -p searchlite-core --lib util::varint` — 6 passed
- [x] `cargo test -p searchlite-core --lib` — 171 passed
- [x] `cargo test -p searchlite-core --test file_format` — 2 passed
