### PR TITLE
fix(http): drop index_path from /stats response (BUG-015)

### DIFF
--- a/integration/src/surfaces/core.rs
+++ b/integration/src/surfaces/core.rs
@@ -148,7 +148,6 @@ impl SurfaceHarness for CoreHarness {
       "segments": manifest.segments.len(),
       "committed_at": manifest.committed_at,
       "index_uuid": manifest.uuid.to_string(),
-      "index_path": self.index_path.display().to_string(),
       "index_name": "core",
     }))
   }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -744,11 +744,9 @@ components:
           type: string
         index_uuid:
           type: string
-        index_path:
-          type: string
         index_name:
           type: string
-      required: [documents, deleted_documents, segments, committed_at, index_uuid, index_path, index_name]
+      required: [documents, deleted_documents, segments, committed_at, index_uuid, index_name]
     SearchResult:
       type: object
       properties:

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -811,6 +811,9 @@ struct InspectResponse {
   manifest: Manifest,
 }
 
+// Note: `index_path` was removed from this response as a Security fix (BUG-015).
+// The on-disk filesystem path of an index is an operator-side implementation
+// detail and must not be exposed to unauthenticated callers of `/stats`.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct StatsResponse {
   documents: u64,
@@ -818,7 +821,6 @@ struct StatsResponse {
   segments: usize,
   committed_at: String,
   index_uuid: String,
-  index_path: String,
   index_name: String,
 }
 
@@ -2290,7 +2292,6 @@ async fn stats(
     segments: manifest.segments.len(),
     committed_at: manifest.committed_at.clone(),
     index_uuid: manifest.uuid.to_string(),
-    index_path: managed.path.display().to_string(),
     index_name: managed.name.clone(),
   }))
 }
@@ -2615,6 +2616,66 @@ mod tests {
     assert_eq!(first_after["exists"], true);
     assert!(first_after["committed_at"].as_str().is_some());
     assert_eq!(first_after["doc_count"], 1);
+
+    handle.abort();
+    let _ = handle.await;
+  }
+
+  // Regression test for BUG-015: the public `/stats` endpoint must not leak
+  // the on-disk filesystem path of the index. Operator-only details are
+  // confined to server logs / admin tooling.
+  #[tokio::test]
+  async fn stats_response_does_not_expose_filesystem_path() {
+    init_tracing();
+    let dir = tempdir().unwrap();
+    let index_path = dir.path().join("idx-stats-no-path");
+    let (client, _base, index_base, handle, _state, _args) = setup_server(index_path.clone()).await;
+
+    client
+      .post(format!("{index_base}/init"))
+      .json(&Schema::default_text_body())
+      .send()
+      .await
+      .unwrap();
+    client
+      .post(format!("{index_base}/add"))
+      .body("{\"_id\":\"1\",\"body\":\"doc\"}\n")
+      .send()
+      .await
+      .unwrap();
+    client
+      .post(format!("{index_base}/commit"))
+      .send()
+      .await
+      .unwrap();
+
+    let stats: serde_json::Value = client
+      .get(format!("{index_base}/stats"))
+      .send()
+      .await
+      .unwrap()
+      .json()
+      .await
+      .unwrap();
+
+    // Path-leaking fields must not appear in the serialized body under any
+    // alias — check the literal field name and the raw path as a safety net.
+    let stats_obj = stats.as_object().expect("stats body is a JSON object");
+    assert!(
+      !stats_obj.contains_key("index_path"),
+      "stats response must not include `index_path` (leaks FS layout): {stats_obj:?}"
+    );
+    let raw_body = serde_json::to_string(&stats).unwrap();
+    let fs_path_str = index_path.display().to_string();
+    assert!(
+      !raw_body.contains(fs_path_str.as_str()),
+      "stats response must not contain the raw index filesystem path: {raw_body}"
+    );
+
+    // Sanity: the public fields are still present.
+    assert_eq!(stats["index_name"], INDEX_NAME);
+    assert!(stats["index_uuid"].as_str().is_some());
+    assert_eq!(stats["documents"], 1);
 
     handle.abort();
     let _ = handle.await;

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -2658,18 +2658,33 @@ mod tests {
       .await
       .unwrap();
 
-    // Path-leaking fields must not appear in the serialized body under any
-    // alias — check the literal field name and the raw path as a safety net.
+    // Path-leaking fields must not appear in the response under any alias.
+    // Walk the parsed JSON and check string values directly so we are not
+    // tricked by JSON escaping (e.g. Windows backslashes are doubled in the
+    // raw serialized form, which would let a regression slip past a naive
+    // substring check on the wire bytes).
+    fn json_contains_string_value(value: &serde_json::Value, target: &str) -> bool {
+      match value {
+        serde_json::Value::String(s) => s == target,
+        serde_json::Value::Array(values) => values
+          .iter()
+          .any(|value| json_contains_string_value(value, target)),
+        serde_json::Value::Object(map) => map
+          .values()
+          .any(|value| json_contains_string_value(value, target)),
+        _ => false,
+      }
+    }
+
     let stats_obj = stats.as_object().expect("stats body is a JSON object");
     assert!(
       !stats_obj.contains_key("index_path"),
       "stats response must not include `index_path` (leaks FS layout): {stats_obj:?}"
     );
-    let raw_body = serde_json::to_string(&stats).unwrap();
     let fs_path_str = index_path.display().to_string();
     assert!(
-      !raw_body.contains(fs_path_str.as_str()),
-      "stats response must not contain the raw index filesystem path: {raw_body}"
+      !json_contains_string_value(&stats, fs_path_str.as_str()),
+      "stats response must not contain the raw index filesystem path: {stats:?}"
     );
 
     // Sanity: the public fields are still present.


### PR DESCRIPTION
## Summary

Fixes BUG-015 (#153).

The public `/stats` handler (`searchlite-http/src/lib.rs:2287-2295`) serialized `managed.path.display().to_string()` into every response as `index_path`. `/stats` is a read-side endpoint and does not require the `x-write-key` header, so a read-only caller — including an unauthenticated one in deployments that gate only writes — could retrieve the absolute on-disk filesystem path of every named index.

In multi-tenant hosts where the operator namespaces indexes by customer in the path, the leaked string is enough to enumerate tenant directories and confirm mount-point / container topology. Public responses should only surface operator-chosen logical identifiers (`index_name`, `index_uuid`) and aggregate counts — the filesystem layout belongs in operator tooling and logs.

## Changes

- `searchlite-http/src/lib.rs`
  - Remove `index_path` from the `StatsResponse` struct and stop populating it in the `stats` handler. Add a note explaining why the field cannot return.
  - Add `stats_response_does_not_expose_filesystem_path` — a regression test that asserts the `/stats` body contains neither the `index_path` key nor the raw temp-dir path string, while confirming `index_name` / `index_uuid` / `documents` are still present.
- `openapi.yaml` — drop `index_path` from the `StatsResponse` schema and from the `required` list so the spec matches the wire format.
- `integration/src/surfaces/core.rs` — drop the same field from the core harness's synthesized stats JSON so the cross-surface shape check keeps matching what HTTP actually returns.

No callers or tests read `stats.index_path`; none needed updating beyond what is above.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test -p searchlite-http --lib` — 44 passed, including the new `stats_response_does_not_expose_filesystem_path`
- [x] Visual diff review against `openapi.yaml` ensures `required` stays consistent