### PR TITLE
fix(terms): reject non-UTF-8 term bytes in read_terms (BUG-010)

### DIFF
--- a/searchlite-core/src/index/terms.rs
+++ b/searchlite-core/src/index/terms.rs
@@ -47,7 +47,11 @@ pub fn read_terms(storage: &dyn Storage, path: &Path) -> Result<TinyFst> {
     if end > data.len() {
       bail!("terms file at {path:?} ended unexpectedly while reading term");
     }
-    let term = String::from_utf8_lossy(&data[cursor..end]).into_owned();
+    let term = std::str::from_utf8(&data[cursor..end])
+      .map_err(|e| {
+        anyhow::anyhow!("terms file at {path:?} contains non-UTF-8 term at offset {cursor}: {e}")
+      })?
+      .to_string();
     cursor = end;
     if cursor + 8 > data.len() {
       bail!("terms file at {path:?} ended unexpectedly while reading offset");
@@ -101,5 +105,54 @@ mod tests {
     std::fs::write(&path, data).unwrap();
     let err = read_terms(&storage, &path).unwrap_err();
     assert!(err.to_string().contains("failed checksum"));
+  }
+
+  #[test]
+  fn invalid_utf8_term_errors() {
+    // Regression test for BUG-010: read_terms should refuse to decode terms that
+    // contain non-UTF-8 bytes rather than silently replacing them with U+FFFD.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("terms");
+    let storage = crate::storage::FsStorage::new(dir.path().to_path_buf());
+
+    // Write a valid terms file containing a single ASCII term, then overwrite
+    // its payload with invalid UTF-8 bytes while keeping the CRC consistent.
+    write_terms(&storage, &path, &[("valid".to_string(), 1)]).unwrap();
+    let raw = std::fs::read(&path).unwrap();
+
+    // Layout: [term_count:u64][payload][crc32:u32]
+    let header_len = 8;
+    let payload = &raw[header_len..raw.len() - 4];
+    let mut payload = payload.to_vec();
+
+    // Locate the first byte of the term bytes: after the varint-encoded length.
+    // `write_u64(5, ..)` emits a single byte (0x05), followed by the 5 term bytes.
+    // Replace them with an overlong / invalid UTF-8 sequence (0xC3 is a 2-byte
+    // UTF-8 lead but is followed by ASCII bytes that are not valid continuation
+    // bytes, producing an ill-formed sequence that `from_utf8_lossy` would
+    // coerce to U+FFFD).
+    let term_offset = 1; // byte index within `payload` where the term bytes start
+    payload[term_offset] = 0xC3;
+    payload[term_offset + 1] = 0x28;
+    payload[term_offset + 2] = 0xA0;
+    payload[term_offset + 3] = 0xA1;
+    payload[term_offset + 4] = 0xFF;
+
+    // Recompute CRC over the mutated payload so the checksum check passes and
+    // the decoder actually reaches the UTF-8 validation step.
+    let new_crc = checksum(&payload);
+
+    let mut rebuilt = Vec::with_capacity(raw.len());
+    rebuilt.extend_from_slice(&raw[..header_len]);
+    rebuilt.extend_from_slice(&payload);
+    rebuilt.extend_from_slice(&new_crc.to_le_bytes());
+    std::fs::write(&path, rebuilt).unwrap();
+
+    let err = read_terms(&storage, &path).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+      msg.contains("non-UTF-8 term"),
+      "expected non-UTF-8 term error, got: {msg}"
+    );
   }
 }

--- a/searchlite-core/src/index/terms.rs
+++ b/searchlite-core/src/index/terms.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 
 use crate::storage::Storage;
 use crate::util::checksum::checksum;
@@ -47,9 +47,14 @@ pub fn read_terms(storage: &dyn Storage, path: &Path) -> Result<TinyFst> {
     if end > data.len() {
       bail!("terms file at {path:?} ended unexpectedly while reading term");
     }
+    // `buf` prepended an 8-byte term_count header before this payload, so translate
+    // the payload-relative `cursor` to an absolute file offset to help operators
+    // locate the corruption. `with_context` preserves the underlying `Utf8Error`
+    // so the error chain keeps the low-level failure as a source.
+    let file_offset = cursor + 8;
     let term = std::str::from_utf8(&data[cursor..end])
-      .map_err(|e| {
-        anyhow::anyhow!("terms file at {path:?} contains non-UTF-8 term at offset {cursor}: {e}")
+      .with_context(|| {
+        format!("terms file at {path:?} contains non-UTF-8 term at file offset {file_offset}")
       })?
       .to_string();
     cursor = end;
@@ -117,26 +122,28 @@ mod tests {
 
     // Write a valid terms file containing a single ASCII term, then overwrite
     // its payload with invalid UTF-8 bytes while keeping the CRC consistent.
-    write_terms(&storage, &path, &[("valid".to_string(), 1)]).unwrap();
+    let original_term = "valid";
+    write_terms(&storage, &path, &[(original_term.to_string(), 1)]).unwrap();
     let raw = std::fs::read(&path).unwrap();
 
     // Layout: [term_count:u64][payload][crc32:u32]
     let header_len = 8;
-    let payload = &raw[header_len..raw.len() - 4];
-    let mut payload = payload.to_vec();
+    let mut payload = raw[header_len..raw.len() - 4].to_vec();
 
-    // Locate the first byte of the term bytes: after the varint-encoded length.
-    // `write_u64(5, ..)` emits a single byte (0x05), followed by the 5 term bytes.
-    // Replace them with an overlong / invalid UTF-8 sequence (0xC3 is a 2-byte
-    // UTF-8 lead but is followed by ASCII bytes that are not valid continuation
-    // bytes, producing an ill-formed sequence that `from_utf8_lossy` would
-    // coerce to U+FFFD).
-    let term_offset = 1; // byte index within `payload` where the term bytes start
-    payload[term_offset] = 0xC3;
-    payload[term_offset + 1] = 0x28;
-    payload[term_offset + 2] = 0xA0;
-    payload[term_offset + 3] = 0xA1;
-    payload[term_offset + 4] = 0xFF;
+    // Locate the term bytes by parsing the varint-encoded length prefix so the
+    // test stays correct regardless of how many bytes the varint encoding uses.
+    let (term_len, varint_len) = read_u64(&payload).unwrap();
+    assert_eq!(term_len as usize, original_term.len());
+    let term_start = varint_len;
+    let term_end = term_start + term_len as usize;
+
+    // Overwrite the term bytes with an ill-formed UTF-8 sequence: 0xC3 is a
+    // 2-byte UTF-8 lead followed by bytes that are not valid continuation
+    // bytes. `from_utf8_lossy` would coerce this to U+FFFD; strict `from_utf8`
+    // must reject it.
+    let invalid = [0xC3, 0x28, 0xA0, 0xA1, 0xFF];
+    assert_eq!(term_end - term_start, invalid.len());
+    payload[term_start..term_end].copy_from_slice(&invalid);
 
     // Recompute CRC over the mutated payload so the checksum check passes and
     // the decoder actually reaches the UTF-8 validation step.
@@ -149,10 +156,15 @@ mod tests {
     std::fs::write(&path, rebuilt).unwrap();
 
     let err = read_terms(&storage, &path).unwrap_err();
-    let msg = err.to_string();
+    let msg = format!("{err:#}");
     assert!(
       msg.contains("non-UTF-8 term"),
       "expected non-UTF-8 term error, got: {msg}"
+    );
+    // The underlying Utf8Error should be preserved as the source of the chain.
+    assert!(
+      err.chain().any(|cause| cause.is::<std::str::Utf8Error>()),
+      "expected Utf8Error in error chain, got: {msg}"
     );
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-010 (#148).

`read_terms` (`searchlite-core/src/index/terms.rs:50`) decoded term bytes with `String::from_utf8_lossy(&data[cursor..end]).into_owned()`. `from_utf8_lossy` silently replaces every ill-formed UTF-8 sequence with `U+FFFD` rather than surfacing the error. Because `write_terms` accepts arbitrary bytes via `term.as_bytes()` and the FST/CRC layers treat the term payload as opaque, corruption in the terms file round-trips as a *different, still valid* key: postings lookups for the original term miss, and lookups for the mangled U+FFFD-containing key may collide with a legitimate term. The only integrity check today is the CRC32 trailer, which does not catch whole-block corruption whose CRC happens to be valid (e.g. a bad storage migration).

Terms are UTF-8 by construction — analyzers always emit `String` — so a non-UTF-8 byte sequence in the terms file is a corruption signal that should surface as an error, not be rewritten.

## Changes

- `searchlite-core/src/index/terms.rs`
  - Replace `String::from_utf8_lossy(..).into_owned()` with `std::str::from_utf8(..)?.to_string()`. On failure, return an error that names the file path and the byte offset of the offending term so operators can pinpoint the corruption.
  - Add `invalid_utf8_term_errors` — a regression test that writes a valid single-term file, overwrites the term payload with an ill-formed UTF-8 sequence, rewrites the CRC so the checksum check passes, and asserts the decoder reports `non-UTF-8 term` rather than silently producing a U+FFFD key.

No callers needed updating: every call site already propagates the `Result` from `read_terms`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-core --lib index::terms` — 3 passed (`roundtrips_terms_file`, `invalid_checksum_errors`, new `invalid_utf8_term_errors`)
- [x] `cargo test -p searchlite-core --lib` — 167 passed