### PR TITLE
fix(postings): reject non-monotonic positions in write_term (BUG-004)

### DIFF
--- a/searchlite-core/src/index/postings.rs
+++ b/searchlite-core/src/index/postings.rs
@@ -117,9 +117,23 @@ impl<'a, W: Write + Seek + ?Sized> PostingsWriter<'a, W> {
       write_u32_var(p.term_freq, &mut buf);
       if self.keep_positions {
         write_u32_var(p.positions.len() as u32, &mut buf);
-        let mut prev = 0;
+        let mut prev = 0u32;
         for pos in p.positions.iter().copied() {
-          let delta = pos - prev;
+          // Positions must be non-decreasing so that delta encoding is
+          // reversible. `PostingEntry` is a public type and its `positions`
+          // field is directly constructible by external callers, so we
+          // cannot rely on convention — reject out-of-order input here
+          // rather than producing a segment that silently fails to decode
+          // (debug: subtract-overflow panic; release: wrapped delta that
+          // decodes into garbage positions — see BUG-003 / BUG-004).
+          let delta = pos.checked_sub(prev).ok_or_else(|| {
+            anyhow::anyhow!(
+              "positions must be non-decreasing (doc {} pos {} after {})",
+              p.doc_id,
+              pos,
+              prev
+            )
+          })?;
           write_u32_var(delta, &mut buf);
           prev = pos;
         }
@@ -448,6 +462,73 @@ mod tests {
     let collected: Vec<(u32, u32)> = reader.iter().map(|p| (p.doc_id, p.term_freq)).collect();
     assert_eq!(collected, expected);
     assert!(reader.iter().all(|p| p.positions.is_empty()));
+  }
+
+  /// Regression for BUG-004: writing a posting entry with non-monotonic
+  /// positions must return an error rather than panicking in debug or
+  /// silently producing a corrupt (un-decodable) segment in release.
+  #[test]
+  fn write_term_rejects_non_monotonic_positions() {
+    let tmp = NamedTempFile::new().unwrap();
+    let mut file = tmp.reopen().unwrap();
+    let postings = vec![PostingEntry {
+      doc_id: 0,
+      term_freq: 2,
+      positions: smallvec![5, 3], // out of order
+    }];
+    let mut writer = PostingsWriter::new(&mut file, true);
+    let err = writer
+      .write_term(&postings)
+      .expect_err("non-monotonic positions must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("non-decreasing"),
+      "unexpected error message: {msg}"
+    );
+  }
+
+  /// Regression for BUG-004: unchecked subtraction previously panicked in
+  /// debug builds when the first position was smaller than the implicit
+  /// starting value of zero — make sure a leading zero-prev is still fine,
+  /// but a subsequent backward step at any offset is rejected.
+  #[test]
+  fn write_term_rejects_backward_step_mid_list() {
+    let tmp = NamedTempFile::new().unwrap();
+    let mut file = tmp.reopen().unwrap();
+    let postings = vec![PostingEntry {
+      doc_id: 7,
+      term_freq: 3,
+      positions: smallvec![0, 10, 4],
+    }];
+    let mut writer = PostingsWriter::new(&mut file, true);
+    let err = writer
+      .write_term(&postings)
+      .expect_err("backward-step positions must be rejected");
+    assert!(err.to_string().contains("non-decreasing"));
+  }
+
+  /// Equal consecutive positions (delta = 0) are legal; the encoder must
+  /// accept them and the round-trip must preserve them.
+  #[test]
+  fn write_term_allows_equal_consecutive_positions() {
+    let tmp = NamedTempFile::new().unwrap();
+    let path = tmp.path().to_path_buf();
+    let mut file = tmp.reopen().unwrap();
+    let postings = vec![PostingEntry {
+      doc_id: 1,
+      term_freq: 3,
+      positions: smallvec![2, 2, 5],
+    }];
+    let mut writer = PostingsWriter::new(&mut file, true);
+    let offset = writer.write_term(&postings).unwrap();
+
+    let mut reader_file = std::fs::File::open(path).unwrap();
+    let reader = PostingsReader::read_at(&mut reader_file, offset, true).unwrap();
+    let round_tripped: Vec<_> = reader
+      .iter()
+      .map(|p| p.positions.iter().copied().collect::<Vec<_>>())
+      .collect();
+    assert_eq!(round_tripped, vec![vec![2, 2, 5]]);
   }
 
   /// Sanity: when the segment was written without positions, reading with


### PR DESCRIPTION
## Summary

Fixes BUG-004 (#142).

`PostingsWriter::write_term` delta-encodes each position with an unchecked `u32` subtraction (`pos - prev`). `PostingEntry` is a public type and its `positions` field is directly constructible by callers (including other workspace crates), so the monotonicity invariant is upheld only by convention. A caller that supplies non-monotonic positions hits:

- **Debug builds:** an arithmetic-overflow panic in the writer, crashing the indexer.
- **Release builds:** the subtraction wraps and a malformed delta is written to disk — the segment then decodes into garbage positions and surfaces the complementary BUG-003 overflow on the read path (now already guarded, but still produces a load error rather than accurate positional data).

Swap the unchecked subtraction for `checked_sub` with a descriptive error that identifies the offending `doc_id` and position pair so the writer fails loudly instead of producing a segment that cannot be round-tripped. The legitimate call path through `InvertedIndexBuilder::add_term` already appends positions in token order, so well-formed builds are unaffected.

## Changes

- `searchlite-core/src/index/postings.rs`
  - Replace `let delta = pos - prev;` in `PostingsWriter::write_term` with `pos.checked_sub(prev)` and return an `anyhow::Error` naming the offending `doc_id`, `pos`, and previous position.
  - Add regression tests:
    - `write_term_rejects_non_monotonic_positions` — `[5, 3]` is rejected with a `non-decreasing` error.
    - `write_term_rejects_backward_step_mid_list` — `[0, 10, 4]` is rejected (guards against an off-by-one that only checks the first pair).
    - `write_term_allows_equal_consecutive_positions` — `[2, 2, 5]` remains valid and round-trips through `PostingsReader` intact (delta == 0 must still be accepted).

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-core --lib index::postings` — 8 passed, including the three new tests
- [x] `cargo test --workspace --lib` — all existing tests still green (179 in `searchlite-core`, 44 in `searchlite-http`, 7 in `searchlite-ffi`)