### PR TITLE
fix(wal): fsync in append_commit to guarantee durability (BUG-006)

### DIFF
--- a/searchlite-core/src/api/writer.rs
+++ b/searchlite-core/src/api/writer.rs
@@ -358,8 +358,9 @@ impl IndexWriter {
     let wal_len = self.wal.len()?;
     if let Err(e) = (|| -> Result<()> {
       new_manifest.store(self.inner.storage.as_ref(), &manifest_path)?;
+      // `append_commit` fsyncs before returning, so no separate `sync` call
+      // is needed to guarantee the commit record is durable on disk.
       self.wal.append_commit()?;
-      self.wal.sync()?;
       Ok(())
     })() {
       // Roll back manifest to the previous snapshot and restore WAL to its

--- a/searchlite-core/src/index/wal.rs
+++ b/searchlite-core/src/index/wal.rs
@@ -40,8 +40,20 @@ impl Wal {
     self.append_entry(1, &payload)
   }
 
+  /// Append a commit record and fsync the file to disk.
+  ///
+  /// The commit record is the WAL's durability boundary: once `append_commit`
+  /// returns `Ok`, every preceding `AddDoc` / `DeleteDocId` entry is guaranteed
+  /// to have been forced out of the kernel page cache, so a subsequent crash
+  /// cannot resurrect "committed" state as pending ops on replay.
+  ///
+  /// `append_add_doc` and `append_delete_doc_id` deliberately defer fsync so
+  /// that a burst of writes under a single commit stays fast; callers do not
+  /// need to call [`Wal::sync`] separately after `append_commit`.
   pub fn append_commit(&mut self) -> Result<()> {
-    self.append_entry(2, &[])
+    self.append_entry(2, &[])?;
+    self.file.sync_all()?;
+    Ok(())
   }
 
   pub fn append_delete_doc_id(&mut self, doc_id: &str) -> Result<()> {
@@ -298,11 +310,140 @@ mod tests {
     wal.append_add_doc(&doc).unwrap();
     let len_after_add = wal.len().unwrap();
     wal.append_commit().unwrap();
-    wal.sync().unwrap();
     let len_after_commit = wal.len().unwrap();
     assert!(len_after_commit > len_after_add);
     wal.truncate_to(len_after_add).unwrap();
     let len_restored = wal.len().unwrap();
     assert_eq!(len_restored, len_after_add);
+  }
+
+  /// A [`StorageFile`] that proxies to an inner file and records each
+  /// `sync_all` call so tests can assert on durability behaviour without
+  /// inspecting the host kernel's page cache.
+  struct SyncCountingFile {
+    inner: crate::storage::DynFile,
+    sync_count: Arc<std::sync::atomic::AtomicUsize>,
+  }
+
+  impl std::io::Read for SyncCountingFile {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+      self.inner.read(buf)
+    }
+  }
+
+  impl std::io::Write for SyncCountingFile {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+      self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+      self.inner.flush()
+    }
+  }
+
+  impl std::io::Seek for SyncCountingFile {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+      self.inner.seek(pos)
+    }
+  }
+
+  impl crate::storage::StorageFile for SyncCountingFile {
+    fn set_len(&mut self, len: u64) -> Result<()> {
+      self.inner.set_len(len)
+    }
+
+    fn sync_all(&mut self) -> Result<()> {
+      self
+        .sync_count
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+      self.inner.sync_all()
+    }
+  }
+
+  struct SyncCountingStorage {
+    inner: crate::storage::FsStorage,
+    sync_count: Arc<std::sync::atomic::AtomicUsize>,
+  }
+
+  impl crate::storage::Storage for SyncCountingStorage {
+    fn root(&self) -> &Path {
+      self.inner.root()
+    }
+
+    fn ensure_dir(&self, path: &Path) -> Result<()> {
+      self.inner.ensure_dir(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+      self.inner.exists(path)
+    }
+
+    fn open_read(&self, path: &Path) -> Result<crate::storage::DynFile> {
+      self.inner.open_read(path)
+    }
+
+    fn open_write(&self, path: &Path) -> Result<crate::storage::DynFile> {
+      let file = self.inner.open_write(path)?;
+      Ok(Box::new(SyncCountingFile {
+        inner: file,
+        sync_count: Arc::clone(&self.sync_count),
+      }))
+    }
+
+    fn open_append(&self, path: &Path) -> Result<crate::storage::DynFile> {
+      let file = self.inner.open_append(path)?;
+      Ok(Box::new(SyncCountingFile {
+        inner: file,
+        sync_count: Arc::clone(&self.sync_count),
+      }))
+    }
+
+    fn read_to_end(&self, path: &Path) -> Result<Vec<u8>> {
+      self.inner.read_to_end(path)
+    }
+
+    fn write_all(&self, path: &Path, data: &[u8]) -> Result<()> {
+      self.inner.write_all(path, data)
+    }
+
+    fn atomic_write(&self, path: &Path, data: &[u8]) -> Result<()> {
+      self.inner.atomic_write(path, data)
+    }
+
+    fn remove(&self, path: &Path) -> Result<()> {
+      self.inner.remove(path)
+    }
+
+    fn remove_dir_all(&self, path: &Path) -> Result<()> {
+      self.inner.remove_dir_all(path)
+    }
+  }
+
+  #[test]
+  fn append_commit_fsyncs_before_returning() {
+    use std::sync::atomic::Ordering;
+
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("wal.log");
+    let sync_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let storage = Arc::new(SyncCountingStorage {
+      inner: crate::storage::FsStorage::new(dir.path().to_path_buf()),
+      sync_count: Arc::clone(&sync_count),
+    });
+    let mut wal = Wal::open(storage, &path).unwrap();
+    let doc = Document {
+      fields: [("body".into(), serde_json::json!("durable"))]
+        .into_iter()
+        .collect(),
+    };
+
+    // Plain appends must not fsync so that batching stays cheap.
+    wal.append_add_doc(&doc).unwrap();
+    assert_eq!(sync_count.load(Ordering::SeqCst), 0);
+
+    // `append_commit` is the durability boundary: it must fsync before
+    // returning `Ok`, without requiring the caller to also invoke `sync`.
+    wal.append_commit().unwrap();
+    assert_eq!(sync_count.load(Ordering::SeqCst), 1);
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-006 (#144).

`Wal::append_commit` (`searchlite-core/src/index/wal.rs:43-45`) previously delegated to `append_entry`, which only calls `self.file.flush()`. `flush()` drains user-space buffers into the kernel page cache but does not force the bytes to stable storage — the kernel is free to keep them in cache indefinitely. A crash or power loss between `append_commit` returning `Ok` and the next explicit `sync()` call can therefore leave the WAL without a durable commit record on recovery, so `Wal::last_pending_ops` re-applies writes the caller was told had succeeded. Callers that had already reported success to their user (HTTP client, CLI, etc.) then see silent double-applies on restart — the opposite of the at-most-once contract that a commit record is supposed to promise.

A public `Wal::sync` exists, but requiring every caller to remember to call it after every commit makes the durability boundary a convention rather than an invariant. The only production call site (`Writer::commit` at `searchlite-core/src/api/writer.rs:361-362`) did in fact pair `append_commit` with `self.wal.sync()`, but that's exactly the pattern the issue flags as fragile.

Move the durability contract inside the WAL so `append_commit` is self-sufficient.

## Changes

- `searchlite-core/src/index/wal.rs`
  - `Wal::append_commit` now calls `self.file.sync_all()?` after writing the commit record, and carries a doc comment describing the invariant: plain `append_add_doc` / `append_delete_doc_id` deliberately defer fsync so that batching under a single commit stays fast; `append_commit` is the durability boundary.
  - Add `append_commit_fsyncs_before_returning` — a regression test that wraps `FsStorage` in a counting mock `StorageFile` and asserts `append_add_doc` performs zero `sync_all` calls while `append_commit` triggers exactly one, without the caller invoking `sync()` separately.
  - Drop the now-redundant `wal.sync()` from `truncate_to_restores_previous_length` so the test exercises the new contract directly.
- `searchlite-core/src/api/writer.rs`
  - Remove the now-redundant `self.wal.sync()?` call that followed `append_commit` inside `Writer::commit`; the commit record is already durable when `append_commit` returns. Leave a short note so future readers don't re-introduce the double fsync.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-core --lib index::wal` — 7 passed, including the new `append_commit_fsyncs_before_returning`
- [x] `cargo test -p searchlite-core --lib` — 195 passed
- [x] `cargo test --workspace --lib` — all existing tests green

Refs #144
