### PR TITLE
fix(varint): guard read_u32_var against final-byte shift overflow (BUG-198)

### DIFF
--- a/searchlite-core/src/util/varint.rs
+++ b/searchlite-core/src/util/varint.rs
@@ -47,7 +47,16 @@ pub fn read_u32_var<R: Read>(r: &mut R) -> Result<u32> {
       return Err(anyhow!(e));
     }
     let b = byte[0];
-    value |= ((b & 0x7F) as u32) << shift;
+    let part = (b & 0x7F) as u32;
+    // On the final possible byte (shift == 28) only the low 4 bits of
+    // `part` fit in a u32; any higher bit would be silently truncated by
+    // the shift. Reject such inputs as overflowing u32 rather than
+    // decoding to a lossy value (mirrors the shift == 63 guard in
+    // read_u64; see BUG-002 / #140).
+    if shift == 28 && part > 0x0F {
+      return Err(anyhow!("varint overflows u32"));
+    }
+    value |= part << shift;
     if b & 0x80 == 0 {
       return Ok(value);
     }
@@ -119,6 +128,66 @@ mod tests {
     let (decoded, len) = read_u64(&buf).unwrap();
     assert_eq!(decoded, u64::MAX);
     assert_eq!(len, 10);
+  }
+
+  #[test]
+  fn read_u32_var_roundtrip_boundary_values() {
+    // u32::MAX encodes to exactly 5 LEB128 bytes — the boundary case that
+    // must round-trip through the stricter overflow guard without error.
+    use std::io::Cursor;
+    for val in [0u32, 1, 127, 128, 16383, 16384, u32::MAX - 1, u32::MAX] {
+      let mut buf = Vec::new();
+      write_u32_var(val, &mut buf);
+      let mut cur = Cursor::new(&buf);
+      let decoded = read_u32_var(&mut cur).unwrap();
+      assert_eq!(decoded, val, "round-trip failed for {val}");
+    }
+  }
+
+  #[test]
+  fn read_u32_var_rejects_final_byte_overflow() {
+    // 5-byte varint: four continuation bytes (value bits all zero) + final
+    // byte 0x10. The final byte's bit 4 sits at position 32 once shifted,
+    // i.e. one bit above u32::MAX. The decoded value is exactly 2^32 and
+    // does NOT fit in a u32. read_u32_var must error rather than silently
+    // dropping the high bit through the u32 left shift.
+    use std::io::Cursor;
+    let buf = vec![0x80u8, 0x80, 0x80, 0x80, 0x10];
+    let mut cur = Cursor::new(&buf);
+    let err = read_u32_var(&mut cur).expect_err("u32-overflowing varint must be rejected");
+    assert_eq!(err.to_string(), "varint overflows u32");
+
+    // Same shape, even more value bits set in the final byte (bits 4..6).
+    let buf = vec![0x80u8, 0x80, 0x80, 0x80, 0x70];
+    let mut cur = Cursor::new(&buf);
+    let err = read_u32_var(&mut cur).expect_err("u32-overflowing varint must be rejected");
+    assert_eq!(err.to_string(), "varint overflows u32");
+  }
+
+  #[test]
+  fn read_u32_var_rejects_overlong_varint() {
+    // A stream of continuation-only bytes (no value bits set) would shift
+    // past 28 bits of a u32 without ever terminating. Must return an
+    // error instead of panicking or silently corrupting the value.
+    use std::io::Cursor;
+    let buf = vec![0x80u8; 10];
+    let mut cur = Cursor::new(&buf);
+    let err = read_u32_var(&mut cur).expect_err("overlong varint must be rejected");
+    assert_eq!(err.to_string(), "varint too long");
+  }
+
+  #[test]
+  fn read_u32_var_accepts_max_length_valid_varint() {
+    // u32::MAX encodes to exactly 5 LEB128 bytes whose final byte is 0x0F —
+    // the boundary the new guard must accept.
+    use std::io::Cursor;
+    let mut buf = Vec::new();
+    write_u32_var(u32::MAX, &mut buf);
+    assert_eq!(buf.len(), 5);
+    assert_eq!(buf[4], 0x0F);
+    let mut cur = Cursor::new(&buf);
+    let decoded = read_u32_var(&mut cur).unwrap();
+    assert_eq!(decoded, u32::MAX);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Fixes #198.

`read_u32_var` in `searchlite-core/src/util/varint.rs` did not guard against shift overflow at the final possible byte (`shift == 28`). A varint whose 5th byte had any bit above bit 3 set (`part > 0x0F`) silently decoded to an arbitrary truncated `u32` value instead of being rejected as overflow. This is the same class of bug as BUG-002 (#140), which was fixed for `read_u64` but the sibling `read_u32_var` in the same file was overlooked.

Honest writers encode values in `0..=u32::MAX`, whose 5th byte is always `<= 0x0F`, so the bug is unreachable for well-formed input. Corrupt or maliciously-crafted segment data, however, could previously smuggle truncated `doc_id` / `term_freq` / position-count / position-delta values past the varint layer. Callers reached through `searchlite-core/src/index/postings.rs:223-232` had no way to detect the corruption at this layer.

## Changes

- `searchlite-core/src/util/varint.rs`
  - `read_u32_var`: add the `shift == 28 && part > 0x0F` guard, returning `"varint overflows u32"`. Directly mirrors the `shift == 63 && part > 1` guard `read_u64` got in BUG-002.
  - Inline comment pointing at BUG-002 / #140 so the parallel with `read_u64` stays obvious the next time someone audits this file.

No on-disk format change, no caller-visible API change, no change to `write_u32_var` / `write_u64` / `read_u64`.

## Regression tests

Four new tests under the existing `#[cfg(test)] mod tests`:

- `read_u32_var_roundtrip_boundary_values` — round-trips `0`, `1`, `127`, `128`, `16383`, `16384`, `u32::MAX - 1`, `u32::MAX` through `write_u32_var` + `read_u32_var` end-to-end. Pins that the stricter guard does not regress honest inputs, including the boundary case where the final byte is exactly `0x0F`.
- `read_u32_var_rejects_final_byte_overflow` — the exact two repro buffers from the issue (`[0x80, 0x80, 0x80, 0x80, 0x10]` → decodes to `2^32` pre-fix, and `[0x80, 0x80, 0x80, 0x80, 0x70]` → decodes to `~30 billion` pre-fix, both truncated to `0` under a `u32` shift). Asserts both now error with exactly `"varint overflows u32"`.
- `read_u32_var_rejects_overlong_varint` — 10 continuation-only bytes must return `"varint too long"`, pinning the pre-existing `shift > 28` overlong guard so the new check doesn't accidentally change that error shape.
- `read_u32_var_accepts_max_length_valid_varint` — asserts `u32::MAX` still encodes to exactly 5 bytes with `0x0F` in the final byte and round-trips unchanged, so the new guard's lower bound (`> 0x0F`) is correct rather than over-aggressive.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-core --lib util::varint` — 11 passed (4 new + 7 pre-existing)
- [x] `cargo test -p searchlite-core --lib` — 202 passed, 0 failed
- [x] `cargo test --workspace --lib --exclude searchlite-wasm` — all green

Refs #198