### PR TITLE
fix(query): prevent regex_literal_prefix overshooting past optional atoms (BUG-202)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -4144,9 +4144,12 @@ mod tests {
 
   #[test]
   fn regex_flat_alternation_finds_all_branches() {
-    // BUG-202 regression: a flat top-level alternation has no literal
-    // prefix shared by every branch. Pre-fix, `regex_literal_prefix`
-    // returned "rust" and the term `ruby` was unreachable from the scan.
+    // BUG-202 regression: with a flat top-level alternation, the term
+    // scan must reach every branch. Pre-fix, `regex_literal_prefix`
+    // returned "rust" (only) and the term `ruby` was unreachable.
+    // Post-fix the extractor returns the longest literal prefix shared
+    // by every branch (`"ru"` for `rust|ruby`), which stays safe and
+    // still bounds the scan away from unrelated terms like `rope`.
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("idx-regex-flat-alt");
     let idx = Index::create(

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -4068,6 +4068,158 @@ mod tests {
   }
 
   #[test]
+  fn regex_with_optional_char_finds_shorter_term() {
+    // BUG-202 regression: a regex with an optional atom (here `u?`) must
+    // not have its literal-prefix scan overshoot past the optional char.
+    // Pre-fix, `regex_literal_prefix("colou?r")` returned "colou", and the
+    // term-dictionary iterator therefore skipped the term `color` even
+    // though the regex accepts it.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("idx-regex-optional");
+    let idx = Index::create(
+      &path,
+      Schema::default_text_body(),
+      IndexOptions {
+        path: path.clone(),
+        create_if_missing: true,
+        enable_positions: true,
+        bm25_k1: 0.9,
+        bm25_b: 0.4,
+        storage: StorageType::Filesystem,
+        #[cfg(feature = "vectors")]
+        vector_defaults: None,
+      },
+    )
+    .unwrap();
+    let mut writer = idx.writer().unwrap();
+    for (id, body) in [("1", "color"), ("2", "colour")] {
+      writer
+        .add_document(&Document {
+          fields: [
+            ("_id".into(), serde_json::json!(id)),
+            ("body".into(), serde_json::json!(body)),
+          ]
+          .into_iter()
+          .collect(),
+        })
+        .unwrap();
+    }
+    writer.commit().unwrap();
+    let reader = idx.reader().unwrap();
+    let default_fields: Vec<String> = reader
+      .manifest
+      .schema
+      .text_fields
+      .iter()
+      .map(|f| f.name.clone())
+      .collect();
+    let plan = build_query_plan(
+      &Query::Node(QueryNode::Regex {
+        field: "body".into(),
+        value: "colou?r".into(),
+        max_expansions: Some(16),
+        boost: None,
+      }),
+      &default_fields,
+    )
+    .unwrap();
+    let (_, groups) = expand_term_groups(
+      &reader.segments,
+      &plan.term_groups,
+      None,
+      &reader.analysis,
+      &reader.manifest.schema,
+    )
+    .unwrap();
+    let keys = groups[0].keys.to_vec();
+    assert!(
+      keys.contains(&"body:color".to_string()),
+      "missed `color`: got {keys:?}"
+    );
+    assert!(
+      keys.contains(&"body:colour".to_string()),
+      "missed `colour`: got {keys:?}"
+    );
+  }
+
+  #[test]
+  fn regex_flat_alternation_finds_all_branches() {
+    // BUG-202 regression: a flat top-level alternation has no literal
+    // prefix shared by every branch. Pre-fix, `regex_literal_prefix`
+    // returned "rust" and the term `ruby` was unreachable from the scan.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("idx-regex-flat-alt");
+    let idx = Index::create(
+      &path,
+      Schema::default_text_body(),
+      IndexOptions {
+        path: path.clone(),
+        create_if_missing: true,
+        enable_positions: true,
+        bm25_k1: 0.9,
+        bm25_b: 0.4,
+        storage: StorageType::Filesystem,
+        #[cfg(feature = "vectors")]
+        vector_defaults: None,
+      },
+    )
+    .unwrap();
+    let mut writer = idx.writer().unwrap();
+    for (id, body) in [("1", "rust"), ("2", "ruby"), ("3", "rope")] {
+      writer
+        .add_document(&Document {
+          fields: [
+            ("_id".into(), serde_json::json!(id)),
+            ("body".into(), serde_json::json!(body)),
+          ]
+          .into_iter()
+          .collect(),
+        })
+        .unwrap();
+    }
+    writer.commit().unwrap();
+    let reader = idx.reader().unwrap();
+    let default_fields: Vec<String> = reader
+      .manifest
+      .schema
+      .text_fields
+      .iter()
+      .map(|f| f.name.clone())
+      .collect();
+    let plan = build_query_plan(
+      &Query::Node(QueryNode::Regex {
+        field: "body".into(),
+        value: "rust|ruby".into(),
+        max_expansions: Some(16),
+        boost: None,
+      }),
+      &default_fields,
+    )
+    .unwrap();
+    let (_, groups) = expand_term_groups(
+      &reader.segments,
+      &plan.term_groups,
+      None,
+      &reader.analysis,
+      &reader.manifest.schema,
+    )
+    .unwrap();
+    let keys = groups[0].keys.to_vec();
+    assert!(
+      keys.contains(&"body:rust".to_string()),
+      "missed `rust`: got {keys:?}"
+    );
+    assert!(
+      keys.contains(&"body:ruby".to_string()),
+      "missed `ruby`: got {keys:?}"
+    );
+    assert!(
+      !keys.contains(&"body:rope".to_string()),
+      "`rope` must not be accepted by `rust|ruby`: got {keys:?}"
+    );
+  }
+
+  #[test]
   fn completion_suggest_prefers_higher_doc_freq() {
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("idx-suggest");

--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -436,22 +436,43 @@ fn expand_wildcard(
 /// `terms_with_prefix(field:<prefix>)` can be used to skip terms that
 /// could not possibly match without missing any that could.
 ///
-/// To preserve that invariant, the walker must account for two regex
-/// constructs that make the *last* accumulated character (or the whole
-/// accumulated branch) optional — and therefore not a guaranteed prefix of
-/// matching terms:
+/// To preserve that invariant, the pattern is split at top-level `|` into
+/// alternation branches, a per-branch safe prefix is extracted from each,
+/// and the greatest common prefix of those is returned. Cases handled:
 ///
 /// * Quantifiers that permit zero occurrences of the preceding atom
-///   (`*`, `?`, `{0,…}`, `{,…}`, `{0}`). The preceding literal must be
-///   dropped: e.g. `colou?r` requires prefix `colo`, not `colou`.
-/// * Top-level alternation (`|`). No single literal prefix is shared by
-///   every branch (e.g. `foo|bar` shares no common first character), so the
-///   prefix must be cleared entirely.
+///   (`*`, `?`, `{0,…}`, `{,…}`, `{0}`) drop the preceding literal inside
+///   a branch: e.g. `colou?r` yields branch prefix `colo`, not `colou`.
+/// * Top-level alternation returns the LCP across branches. Simple shared
+///   prefixes are preserved (e.g. `rust|ruby` → `ru`, `abc|ab` → `ab`),
+///   while branches with no shared first character collapse to `""`
+///   (e.g. `foo|bar` → `""`).
 ///
 /// Alternation, groups, and character classes *inside* `(`, `[`, or `{`
-/// never affect the running prefix because the walker already breaks at
+/// never affect a branch's running prefix because the walker breaks at
 /// those metacharacters. Only top-level constructs reach this logic.
 fn regex_literal_prefix(pattern: &str) -> String {
+  let mut branches = split_top_level_alternatives(pattern);
+  let first = match branches.next() {
+    Some(b) => b,
+    None => return String::new(),
+  };
+  let mut prefix = regex_branch_literal_prefix(first);
+  for branch in branches {
+    if prefix.is_empty() {
+      return prefix;
+    }
+    let next = regex_branch_literal_prefix(branch);
+    let lcp_len = longest_common_prefix_len(&prefix, &next);
+    prefix.truncate(lcp_len);
+  }
+  prefix
+}
+
+/// Extracts a safe literal prefix from a single alternation branch (i.e.
+/// a pattern with no top-level `|`). See [`regex_literal_prefix`] for the
+/// invariant the returned prefix upholds.
+fn regex_branch_literal_prefix(pattern: &str) -> String {
   let chars: Vec<(usize, char)> = pattern.char_indices().collect();
   let mut prefix = String::new();
   let mut escaped = false;
@@ -498,13 +519,9 @@ fn regex_literal_prefix(pattern: &str) -> String {
       '^' if prefix.is_empty() => {
         i += 1;
       }
-      '|' => {
-        // Top-level alternation: no literal prefix is guaranteed to appear
-        // across every branch, so invalidate anything accumulated so far.
-        prefix.clear();
-        break;
-      }
-      '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '$' => break,
+      // Any top-level `|` should have been consumed by the caller's
+      // splitter, but guard against it as a defensive break.
+      '|' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '$' => break,
       _ => {
         if quantifier_allows_zero(&chars, i + 1) {
           break;
@@ -518,9 +535,62 @@ fn regex_literal_prefix(pattern: &str) -> String {
   prefix
 }
 
+/// Splits `pattern` at every `|` that sits at the top level — i.e. not
+/// inside `(…)`, `[…]`, `{…}`, and not the target of a `\` escape. Returns
+/// an iterator that yields at least one branch (the empty pattern yields a
+/// single empty branch).
+fn split_top_level_alternatives(pattern: &str) -> impl Iterator<Item = &str> {
+  let mut out: SmallVec<[&str; 2]> = SmallVec::new();
+  let mut escaped = false;
+  let mut paren: i32 = 0;
+  let mut bracket: i32 = 0;
+  let mut brace: i32 = 0;
+  let mut start = 0usize;
+  for (i, ch) in pattern.char_indices() {
+    if escaped {
+      escaped = false;
+      continue;
+    }
+    match ch {
+      '\\' => escaped = true,
+      '(' => paren = paren.saturating_add(1),
+      ')' => paren = (paren - 1).max(0),
+      '[' => bracket = bracket.saturating_add(1),
+      ']' => bracket = (bracket - 1).max(0),
+      '{' => brace = brace.saturating_add(1),
+      '}' => brace = (brace - 1).max(0),
+      '|' if paren == 0 && bracket == 0 && brace == 0 => {
+        out.push(&pattern[start..i]);
+        start = i + ch.len_utf8();
+      }
+      _ => {}
+    }
+  }
+  out.push(&pattern[start..]);
+  out.into_iter()
+}
+
+/// Returns the byte length of the longest common prefix of `a` and `b`,
+/// measured at a UTF-8 character boundary. `a[..n]` and `b[..n]` are both
+/// valid UTF-8 substrings of their respective inputs.
+fn longest_common_prefix_len(a: &str, b: &str) -> usize {
+  let mut len = 0usize;
+  for (ac, bc) in a.char_indices().zip(b.chars()) {
+    if ac.1 == bc {
+      len = ac.0 + ac.1.len_utf8();
+    } else {
+      break;
+    }
+  }
+  len
+}
+
 /// Returns true when `chars[pos]` starts a quantifier that permits zero
 /// occurrences of the preceding atom (`*`, `?`, `{0,…}`, `{,…}`, `{0}`).
-/// Any other char, or a `{…}` whose lower bound is ≥ 1, returns false.
+///
+/// `{…}` forms must be properly terminated with `}`; unterminated cases
+/// like `{0,` or `{,5` return false. Non-zero lower bounds (`{1,3}`,
+/// `{5}`, …) also return false so the preceding literal is preserved.
 fn quantifier_allows_zero(chars: &[(usize, char)], pos: usize) -> bool {
   if pos >= chars.len() {
     return false;
@@ -528,8 +598,9 @@ fn quantifier_allows_zero(chars: &[(usize, char)], pos: usize) -> bool {
   match chars[pos].1 {
     '*' | '?' => true,
     '{' => {
-      // Parse the minimum-occurrences digits; anything that isn't a valid
-      // `{n…}` form is treated as "unknown" (conservative: return false).
+      // Parse the minimum-occurrences digits without allocating. An
+      // overflowing or non-digit body disqualifies the quantifier from
+      // being zero-permitting (conservative: return false).
       let digits_start = pos + 1;
       let mut j = digits_start;
       while j < chars.len() && chars[j].1.is_ascii_digit() {
@@ -538,19 +609,44 @@ fn quantifier_allows_zero(chars: &[(usize, char)], pos: usize) -> bool {
       if j >= chars.len() {
         return false;
       }
-      match chars[j].1 {
-        ',' | '}' => {
-          // Empty lower bound (e.g. `{,5}`) is treated as 0.
-          if digits_start == j {
-            return true;
+      let lower_is_zero = if digits_start == j {
+        // Empty lower bound (e.g. `{,5}`) is treated as 0.
+        true
+      } else {
+        let mut lower: u64 = 0;
+        let mut ok = true;
+        for (_, c) in &chars[digits_start..j] {
+          let digit = match c.to_digit(10) {
+            Some(d) => d as u64,
+            None => {
+              ok = false;
+              break;
+            }
+          };
+          match lower.checked_mul(10).and_then(|n| n.checked_add(digit)) {
+            Some(v) => lower = v,
+            None => {
+              ok = false;
+              break;
+            }
           }
-          let lower: u64 = chars[digits_start..j]
-            .iter()
-            .map(|(_, c)| *c)
-            .collect::<String>()
-            .parse()
-            .unwrap_or(u64::MAX);
-          lower == 0
+        }
+        ok && lower == 0
+      };
+      match chars[j].1 {
+        '}' => lower_is_zero,
+        ',' => {
+          // Skip optional upper-bound digits and require a closing `}`
+          // terminator; anything else is malformed and disqualifying.
+          let mut k = j + 1;
+          while k < chars.len() && chars[k].1.is_ascii_digit() {
+            k += 1;
+          }
+          if k < chars.len() && chars[k].1 == '}' {
+            lower_is_zero
+          } else {
+            false
+          }
         }
         _ => false,
       }
@@ -809,12 +905,38 @@ mod tests {
   }
 
   #[test]
-  fn top_level_alternation_clears_prefix() {
-    // BUG-202 repro: `foo|bar` shares no common first character.
+  fn top_level_alternation_returns_branch_lcp() {
+    // BUG-202 repro: branches with no shared first character collapse to
+    // an empty prefix.
     assert_eq!(regex_literal_prefix("foo|bar"), "");
     assert_prefix_is_safe("foo|bar", &["foo", "bar"]);
-    assert_eq!(regex_literal_prefix("rust|ruby"), "");
+    // Branches that *do* share a literal prefix keep that shared prefix,
+    // so the term-dictionary scan still benefits from a bound.
+    assert_eq!(regex_literal_prefix("rust|ruby"), "ru");
     assert_prefix_is_safe("rust|ruby", &["rust", "ruby"]);
+    assert_eq!(regex_literal_prefix("abc|ab"), "ab");
+    assert_prefix_is_safe("abc|ab", &["abc", "ab"]);
+    // More than two branches: LCP collapses to the shortest shared prefix.
+    assert_eq!(regex_literal_prefix("rust|ruby|rails"), "r");
+    assert_prefix_is_safe("rust|ruby|rails", &["rust", "ruby", "rails"]);
+    assert_eq!(regex_literal_prefix("alpha|beta|alp"), "");
+    assert_prefix_is_safe("alpha|beta|alp", &["alpha", "beta", "alp"]);
+  }
+
+  #[test]
+  fn alternation_respects_escaped_pipe() {
+    // An escaped `|` is a literal pipe character, not an alternation
+    // operator, so the whole pattern is a single branch.
+    assert_eq!(regex_literal_prefix("foo\\|bar"), "foo|bar");
+    assert_prefix_is_safe("foo\\|bar", &["foo|bar"]);
+  }
+
+  #[test]
+  fn alternation_ignores_pipe_inside_groups() {
+    // `|` inside `(`, `[`, or `{` is part of the group, not a top-level
+    // alternation, so the outer branch prefix is preserved.
+    assert_eq!(regex_literal_prefix("foo(ab|cd)"), "foo");
+    assert_eq!(regex_literal_prefix("foo[a|b]"), "foo");
   }
 
   #[test]
@@ -886,9 +1008,18 @@ mod tests {
     assert!(!quantifier_allows_zero(&chars("{1,3}"), 0));
     assert!(!quantifier_allows_zero(&chars("{2,}"), 0));
     assert!(!quantifier_allows_zero(&chars("foo"), 0));
-    // Unterminated / malformed `{…` — conservatively false.
+    // Overflowing lower bound disqualifies.
+    assert!(!quantifier_allows_zero(&chars("{99999999999999999999}"), 0));
+    // Unterminated / malformed `{…` — conservatively false. All of these
+    // are missing a closing `}`.
     assert!(!quantifier_allows_zero(&chars("{"), 0));
     assert!(!quantifier_allows_zero(&chars("{0"), 0));
+    assert!(!quantifier_allows_zero(&chars("{0,"), 0));
+    assert!(!quantifier_allows_zero(&chars("{0,3"), 0));
+    assert!(!quantifier_allows_zero(&chars("{,5"), 0));
+    assert!(!quantifier_allows_zero(&chars("{,"), 0));
+    // Non-digit body disqualifies.
+    assert!(!quantifier_allows_zero(&chars("{abc}"), 0));
     // Position past the end is false.
     assert!(!quantifier_allows_zero(&chars("?"), 1));
   }

--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -524,6 +524,18 @@ fn regex_branch_literal_prefix(pattern: &str) -> String {
       '|' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '$' => break,
       _ => {
         if quantifier_allows_zero(&chars, i + 1) {
+          // The preceding literal `ch` is optional, so it cannot extend
+          // the prefix on its own. But if the next required atom is the
+          // same literal `ch` (e.g. `ab?b`, `a*a`, `a{0,3}a`), then that
+          // character is guaranteed at the current position regardless
+          // of whether the optional was taken, so we can commit one
+          // copy before stopping. We must stop here because the two
+          // branches diverge in position after this, so subsequent
+          // pattern chars no longer line up across both cases.
+          if let Some(commit) = collapsed_literal_after_optional(&chars, i) {
+            let end = commit + ch.len_utf8();
+            prefix.push_str(&pattern[commit..end]);
+          }
           break;
         }
         let end = pos + ch.len_utf8();
@@ -533,6 +545,65 @@ fn regex_branch_literal_prefix(pattern: &str) -> String {
     }
   }
   prefix
+}
+
+/// When `chars[i]` is a literal `x` followed by a zero-permitting
+/// quantifier, checks whether the atom immediately after the quantifier
+/// is also a required literal `x`. If so, returns the byte offset of
+/// that second `x` (so the caller can commit it to the prefix). Returns
+/// `None` otherwise.
+///
+/// The required-literal check:
+///
+/// * Must be a plain literal char (no backslash-escape, no metachar),
+///   because anything else (wildcards, classes, groups, alternation)
+///   doesn't guarantee a single specific byte at that position.
+/// * Must not itself be followed by a zero-permitting quantifier — if
+///   the second `x` is also optional, it isn't guaranteed to appear.
+fn collapsed_literal_after_optional(chars: &[(usize, char)], i: usize) -> Option<usize> {
+  let ch = chars.get(i)?.1;
+  let q_end = quantifier_end(chars, i + 1)?;
+  let (pos, next) = *chars.get(q_end)?;
+  if !is_plain_literal(next) || next != ch {
+    return None;
+  }
+  if quantifier_allows_zero(chars, q_end + 1) {
+    return None;
+  }
+  Some(pos)
+}
+
+/// Returns the index in `chars` immediately after the quantifier that
+/// starts at `pos`, or `None` if there is no quantifier at `pos`.
+fn quantifier_end(chars: &[(usize, char)], pos: usize) -> Option<usize> {
+  match chars.get(pos)?.1 {
+    '*' | '?' | '+' => Some(pos + 1),
+    '{' => {
+      // Scan for the matching `}`; quantifier bodies contain only
+      // digits and at most one `,`, but we stay tolerant and just look
+      // for the terminator.
+      let mut k = pos + 1;
+      while k < chars.len() && chars[k].1 != '}' {
+        k += 1;
+      }
+      if k < chars.len() {
+        Some(k + 1)
+      } else {
+        None
+      }
+    }
+    _ => None,
+  }
+}
+
+/// Returns true when `c` can safely be compared as a literal byte for
+/// the `x?x`-style prefix extension — i.e. not a regex metacharacter,
+/// escape prefix, or anchor.
+fn is_plain_literal(c: char) -> bool {
+  !matches!(
+    c,
+    '\\' | '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '$' | '^'
+  )
 }
 
 /// Splits `pattern` at every `|` that sits at the top level — i.e. not
@@ -902,6 +973,51 @@ mod tests {
     assert_prefix_is_safe("foo{1,3}", &["foo", "fooo"]);
     assert_eq!(regex_literal_prefix("foo{5}"), "foo");
     assert_prefix_is_safe("foo{5}", &["foooooo"]);
+  }
+
+  #[test]
+  fn optional_followed_by_matching_required_keeps_one_copy() {
+    // When an optional atom is followed by the same required literal
+    // (e.g. `ab?b`, `a*a`, `a{0,3}a`), the position after the earlier
+    // literals is guaranteed to be that char regardless of whether the
+    // optional was taken. We commit one copy and stop.
+    assert_eq!(regex_literal_prefix("ab?b"), "ab");
+    assert_prefix_is_safe("ab?b", &["ab", "abb"]);
+    assert_eq!(regex_literal_prefix("a*a"), "a");
+    assert_prefix_is_safe("a*a", &["a", "aa", "aaa"]);
+    assert_eq!(regex_literal_prefix("a?a"), "a");
+    assert_prefix_is_safe("a?a", &["a", "aa"]);
+    assert_eq!(regex_literal_prefix("ab{0,3}b"), "ab");
+    assert_prefix_is_safe("ab{0,3}b", &["ab", "abb", "abbb", "abbbb"]);
+  }
+
+  #[test]
+  fn optional_followed_by_different_required_stops() {
+    // `ab?c` diverges at position 1 (`c` vs `b`), so the prefix is just
+    // `a`. `a*b` shares nothing, so prefix is empty.
+    assert_eq!(regex_literal_prefix("ab?c"), "a");
+    assert_prefix_is_safe("ab?c", &["ac", "abc"]);
+    assert_eq!(regex_literal_prefix("a*b"), "");
+    assert_prefix_is_safe("a*b", &["b", "ab", "aab"]);
+  }
+
+  #[test]
+  fn optional_followed_by_optional_does_not_collapse() {
+    // The required-literal check must reject the case where the char
+    // after the first quantifier is itself optional (`ab?b?c`). The
+    // second `b` isn't guaranteed to appear, so we can't commit it.
+    assert_eq!(regex_literal_prefix("ab?b?c"), "a");
+    assert_prefix_is_safe("ab?b?c", &["ac", "abc", "abbc"]);
+  }
+
+  #[test]
+  fn optional_followed_by_metachar_stops() {
+    // `.`, `\`, `[`, `(` etc. after the quantifier don't represent a
+    // concrete literal, so no collapse can be applied.
+    assert_eq!(regex_literal_prefix("ab?."), "a");
+    assert_prefix_is_safe("ab?.", &["ax", "abx"]);
+    assert_eq!(regex_literal_prefix("ab?\\."), "a");
+    assert_prefix_is_safe("ab?\\.", &["a.", "ab."]);
   }
 
   #[test]

--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -428,41 +428,135 @@ fn expand_wildcard(
   Ok((qualified, keys))
 }
 
+/// Extracts a safe literal prefix from a regex pattern for use as a
+/// term-dictionary scan bound.
+///
+/// The returned prefix is guaranteed to be a prefix of every string the
+/// compiled regex can match (anchored via [`anchored_regex`]), so
+/// `terms_with_prefix(field:<prefix>)` can be used to skip terms that
+/// could not possibly match without missing any that could.
+///
+/// To preserve that invariant, the walker must account for two regex
+/// constructs that make the *last* accumulated character (or the whole
+/// accumulated branch) optional — and therefore not a guaranteed prefix of
+/// matching terms:
+///
+/// * Quantifiers that permit zero occurrences of the preceding atom
+///   (`*`, `?`, `{0,…}`, `{,…}`, `{0}`). The preceding literal must be
+///   dropped: e.g. `colou?r` requires prefix `colo`, not `colou`.
+/// * Top-level alternation (`|`). No single literal prefix is shared by
+///   every branch (e.g. `foo|bar` shares no common first character), so the
+///   prefix must be cleared entirely.
+///
+/// Alternation, groups, and character classes *inside* `(`, `[`, or `{`
+/// never affect the running prefix because the walker already breaks at
+/// those metacharacters. Only top-level constructs reach this logic.
 fn regex_literal_prefix(pattern: &str) -> String {
+  let chars: Vec<(usize, char)> = pattern.char_indices().collect();
   let mut prefix = String::new();
   let mut escaped = false;
-  for (i, ch) in pattern.char_indices() {
+  let mut i = 0usize;
+  while i < chars.len() {
+    let (pos, ch) = chars[i];
     if escaped {
       match ch {
         '\\' => {
-          // Escaped backslash is a literal backslash in the prefix.
-          let end = i + ch.len_utf8();
-          prefix.push_str(&pattern[i..end]);
+          // Escaped backslash is a literal backslash. If a zero-permitting
+          // quantifier follows, the backslash is optional and must not be
+          // committed to the prefix.
+          if quantifier_allows_zero(&chars, i + 1) {
+            break;
+          }
+          let end = pos + ch.len_utf8();
+          prefix.push_str(&pattern[pos..end]);
           escaped = false;
+          i += 1;
           continue;
         }
         // Escape classes/boundaries mean we cannot keep extending the literal prefix.
         'd' | 'D' | 'w' | 'W' | 's' | 'S' | 'b' | 'B' => break,
         'p' | 'P' => break,
         _ => {
-          let end = i + ch.len_utf8();
-          prefix.push_str(&pattern[i..end]);
+          // Escaped literal (e.g. `\.`, `\+`, `\?`). The same
+          // quantifier-lookahead rule applies.
+          if quantifier_allows_zero(&chars, i + 1) {
+            break;
+          }
+          let end = pos + ch.len_utf8();
+          prefix.push_str(&pattern[pos..end]);
           escaped = false;
+          i += 1;
           continue;
         }
       }
     }
     match ch {
-      '\\' => escaped = true,
-      '^' if prefix.is_empty() => continue,
-      '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '|' | '$' => break,
+      '\\' => {
+        escaped = true;
+        i += 1;
+      }
+      '^' if prefix.is_empty() => {
+        i += 1;
+      }
+      '|' => {
+        // Top-level alternation: no literal prefix is guaranteed to appear
+        // across every branch, so invalidate anything accumulated so far.
+        prefix.clear();
+        break;
+      }
+      '.' | '*' | '+' | '?' | '(' | ')' | '[' | ']' | '{' | '}' | '$' => break,
       _ => {
-        let end = i + ch.len_utf8();
-        prefix.push_str(&pattern[i..end]);
+        if quantifier_allows_zero(&chars, i + 1) {
+          break;
+        }
+        let end = pos + ch.len_utf8();
+        prefix.push_str(&pattern[pos..end]);
+        i += 1;
       }
     }
   }
   prefix
+}
+
+/// Returns true when `chars[pos]` starts a quantifier that permits zero
+/// occurrences of the preceding atom (`*`, `?`, `{0,…}`, `{,…}`, `{0}`).
+/// Any other char, or a `{…}` whose lower bound is ≥ 1, returns false.
+fn quantifier_allows_zero(chars: &[(usize, char)], pos: usize) -> bool {
+  if pos >= chars.len() {
+    return false;
+  }
+  match chars[pos].1 {
+    '*' | '?' => true,
+    '{' => {
+      // Parse the minimum-occurrences digits; anything that isn't a valid
+      // `{n…}` form is treated as "unknown" (conservative: return false).
+      let digits_start = pos + 1;
+      let mut j = digits_start;
+      while j < chars.len() && chars[j].1.is_ascii_digit() {
+        j += 1;
+      }
+      if j >= chars.len() {
+        return false;
+      }
+      match chars[j].1 {
+        ',' | '}' => {
+          // Empty lower bound (e.g. `{,5}`) is treated as 0.
+          if digits_start == j {
+            return true;
+          }
+          let lower: u64 = chars[digits_start..j]
+            .iter()
+            .map(|(_, c)| *c)
+            .collect::<String>()
+            .parse()
+            .unwrap_or(u64::MAX);
+          lower == 0
+        }
+        _ => false,
+      }
+    }
+    _ => false,
+  }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -616,4 +710,186 @@ fn expand_term_fuzzy(
     }
   }
   (qualified, keys)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{quantifier_allows_zero, regex_literal_prefix};
+  use crate::util::regex::anchored_regex;
+
+  /// Pins the invariant the whole helper exists to uphold: every term the
+  /// anchored regex could match must start with the returned prefix. If this
+  /// property regresses, `expand_regex` silently drops matching terms.
+  fn assert_prefix_is_safe(pattern: &str, matching: &[&str]) {
+    let regex = anchored_regex(pattern).expect("valid regex");
+    let prefix = regex_literal_prefix(pattern);
+    for term in matching {
+      assert!(
+        regex.is_match(term),
+        "test bug: pattern `{pattern}` must match `{term}`"
+      );
+      assert!(
+        term.starts_with(&prefix),
+        "prefix `{prefix}` is not a prefix of matching term `{term}` (pattern `{pattern}`)"
+      );
+    }
+  }
+
+  #[test]
+  fn plain_literal_is_kept() {
+    assert_eq!(regex_literal_prefix("color"), "color");
+    assert_prefix_is_safe("color", &["color"]);
+  }
+
+  #[test]
+  fn caret_anchor_is_stripped_from_prefix() {
+    assert_eq!(regex_literal_prefix("^color"), "color");
+    assert_prefix_is_safe("^color", &["color"]);
+  }
+
+  #[test]
+  fn optional_char_is_not_committed() {
+    // BUG-202 repro: `colou?r` must match both `color` and `colour`, so the
+    // literal prefix cannot extend past `colo`.
+    assert_eq!(regex_literal_prefix("colou?r"), "colo");
+    assert_prefix_is_safe("colou?r", &["color", "colour"]);
+  }
+
+  #[test]
+  fn question_at_end_trims_last_char() {
+    assert_eq!(regex_literal_prefix("ab?"), "a");
+    assert_prefix_is_safe("ab?", &["a", "ab"]);
+  }
+
+  #[test]
+  fn star_quantifier_trims_last_char() {
+    // `foo*` matches `fo`, `foo`, `fooo`, ... — common prefix is `fo`.
+    assert_eq!(regex_literal_prefix("foo*"), "fo");
+    assert_prefix_is_safe("foo*", &["fo", "foo", "fooo"]);
+  }
+
+  #[test]
+  fn plus_quantifier_keeps_last_char() {
+    // `+` requires at least one occurrence, so `foo+` still implies `foo`.
+    assert_eq!(regex_literal_prefix("foo+"), "foo");
+    assert_prefix_is_safe("foo+", &["foo", "fooo"]);
+  }
+
+  #[test]
+  fn bounded_quantifier_with_zero_lower_trims_last_char() {
+    assert_eq!(regex_literal_prefix("foo{0,3}"), "fo");
+    assert_prefix_is_safe("foo{0,3}", &["fo", "foo", "fooo"]);
+  }
+
+  #[test]
+  fn bounded_quantifier_with_empty_lower_trims_last_char() {
+    // `{,n}` isn't accepted by the regex crate, but treating it as
+    // zero-permitting is still the correct conservative choice: if a future
+    // parser accepts it, the returned prefix must stay safe. So just assert
+    // the computed prefix directly (no compilation through `anchored_regex`).
+    assert_eq!(regex_literal_prefix("foo{,3}"), "fo");
+  }
+
+  #[test]
+  fn bounded_quantifier_with_zero_exact_trims_last_char() {
+    // `{0}` means "zero occurrences of the preceding atom" — the last char
+    // is effectively removed. We still stop there to stay safe.
+    assert_eq!(regex_literal_prefix("foo{0}"), "fo");
+    assert_prefix_is_safe("foo{0}", &["fo"]);
+  }
+
+  #[test]
+  fn bounded_quantifier_with_nonzero_lower_keeps_last_char() {
+    // `{1,3}` and `{5}` both require at least one occurrence, so the last
+    // literal char is still guaranteed to appear.
+    assert_eq!(regex_literal_prefix("foo{1,3}"), "foo");
+    assert_prefix_is_safe("foo{1,3}", &["foo", "fooo"]);
+    assert_eq!(regex_literal_prefix("foo{5}"), "foo");
+    assert_prefix_is_safe("foo{5}", &["foooooo"]);
+  }
+
+  #[test]
+  fn top_level_alternation_clears_prefix() {
+    // BUG-202 repro: `foo|bar` shares no common first character.
+    assert_eq!(regex_literal_prefix("foo|bar"), "");
+    assert_prefix_is_safe("foo|bar", &["foo", "bar"]);
+    assert_eq!(regex_literal_prefix("rust|ruby"), "");
+    assert_prefix_is_safe("rust|ruby", &["rust", "ruby"]);
+  }
+
+  #[test]
+  fn grouped_alternation_keeps_outer_literal_prefix() {
+    // `(` terminates the walk, so everything before it is preserved. The
+    // existing `r(ust|uby)` expansion test relies on this.
+    assert_eq!(regex_literal_prefix("r(ust|uby)"), "r");
+    assert_prefix_is_safe("r(ust|uby)", &["rust", "ruby"]);
+  }
+
+  #[test]
+  fn character_class_terminates_walk() {
+    assert_eq!(regex_literal_prefix("fo[ou]"), "fo");
+    assert_prefix_is_safe("fo[ou]", &["foo", "fou"]);
+  }
+
+  #[test]
+  fn escaped_literal_followed_by_optional_is_dropped() {
+    // `colou\??` is `colou` + literal `?` + optional-quantifier on that `?`.
+    // The literal `?` is therefore optional, so it cannot extend the prefix.
+    assert_eq!(regex_literal_prefix("colou\\??"), "colou");
+    assert_prefix_is_safe("colou\\??", &["colou", "colou?"]);
+  }
+
+  #[test]
+  fn escaped_literal_without_quantifier_is_kept() {
+    assert_eq!(regex_literal_prefix("foo\\.bar"), "foo.bar");
+    assert_prefix_is_safe("foo\\.bar", &["foo.bar"]);
+  }
+
+  #[test]
+  fn escape_class_terminates_walk() {
+    assert_eq!(regex_literal_prefix("foo\\d"), "foo");
+    assert_prefix_is_safe("foo\\d", &["foo0", "foo9"]);
+  }
+
+  #[test]
+  fn dollar_anchor_terminates_walk() {
+    assert_eq!(regex_literal_prefix("foo$"), "foo");
+    assert_prefix_is_safe("foo$", &["foo"]);
+  }
+
+  #[test]
+  fn dot_terminates_walk() {
+    assert_eq!(regex_literal_prefix("foo.bar"), "foo");
+    assert_prefix_is_safe("foo.bar", &["fooxbar", "foo!bar"]);
+  }
+
+  #[test]
+  fn unicode_literal_is_preserved() {
+    assert_eq!(regex_literal_prefix("café"), "café");
+    assert_prefix_is_safe("café", &["café"]);
+  }
+
+  #[test]
+  fn quantifier_allows_zero_covers_bounded_forms() {
+    fn chars(pattern: &str) -> Vec<(usize, char)> {
+      pattern.char_indices().collect()
+    }
+    // Position is the *quantifier* char (or `{`), not the preceding atom.
+    assert!(quantifier_allows_zero(&chars("?"), 0));
+    assert!(quantifier_allows_zero(&chars("*"), 0));
+    assert!(!quantifier_allows_zero(&chars("+"), 0));
+    assert!(quantifier_allows_zero(&chars("{0}"), 0));
+    assert!(quantifier_allows_zero(&chars("{0,3}"), 0));
+    assert!(quantifier_allows_zero(&chars("{0,}"), 0));
+    assert!(quantifier_allows_zero(&chars("{,5}"), 0));
+    assert!(!quantifier_allows_zero(&chars("{1}"), 0));
+    assert!(!quantifier_allows_zero(&chars("{1,3}"), 0));
+    assert!(!quantifier_allows_zero(&chars("{2,}"), 0));
+    assert!(!quantifier_allows_zero(&chars("foo"), 0));
+    // Unterminated / malformed `{…` — conservatively false.
+    assert!(!quantifier_allows_zero(&chars("{"), 0));
+    assert!(!quantifier_allows_zero(&chars("{0"), 0));
+    // Position past the end is false.
+    assert!(!quantifier_allows_zero(&chars("?"), 1));
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #202.

`regex_literal_prefix` in `searchlite-core/src/api/term_expansion.rs` previously accumulated every literal character before knowing what followed it. When the next character turned out to be a zero-permitting quantifier (`*`, `?`, `{0,…}`, `{,…}`, `{0}`), the last accumulated character was no longer guaranteed to appear in matching terms. Likewise, a top-level `|` made the whole accumulated branch optional. The returned prefix was therefore strictly longer than the greatest common prefix of the regex's matches, and `expand_regex` silently skipped matching terms when it scanned the term dictionary through `terms_with_prefix(field:<prefix>)`.

Concrete symptoms (all previously present against `4f3d6b7`):

| Pattern | Prefix (old) | Prefix (new) | Missed term the old prefix blocked |
| --- | --- | --- | --- |
| `colou?r` | `colou` | `colo` | `color` |
| `foo*` | `foo` | `fo` | `fo` |
| `ab?` | `ab` | `a` | `a` |
| `rust\|ruby` | `rust` | `` (empty) | `ruby` |
| `foo{0,3}` | `foo` | `fo` | `fo` |

The `r(ust|uby)` case the existing `regex_expansion_applies_cap` test relies on still works because `(` already terminated the walk — only top-level constructs needed handling.

## Changes

- `searchlite-core/src/api/term_expansion.rs`
  - `regex_literal_prefix`: rewrite the walk with a `Vec<(usize, char)>` so it can look ahead cheaply, and consult a new `quantifier_allows_zero` helper before pushing each literal char. Top-level `|` now clears the accumulated prefix entirely and breaks. Documented the invariant the helper must uphold.
  - `quantifier_allows_zero`: new private helper. Recognises `*`, `?`, and `{n,…}` forms whose lower bound parses to `0` (including the tolerant `{,n}` form). Malformed or non-zero-lower `{…}` bodies return false, so unknown constructs are handled conservatively.

No on-disk format change, no caller-visible API change, no change to `expand_regex`, `anchored_regex`, or any other call site. The existing `regex_expansion_applies_cap` test against `r(ust|uby)` continues to pass unchanged.

## Regression tests

- `searchlite-core/src/api/term_expansion.rs`: new `mod tests` with 20 unit tests. An `assert_prefix_is_safe(pattern, terms)` helper compiles the pattern via `anchored_regex` and asserts every matching term still starts with the returned prefix — the invariant `expand_regex` relies on. Coverage includes every regex construct the walker handles (`*`, `+`, `?`, `{0}`, `{0,n}`, `{,n}`, `{1,3}`, `{5}`, top-level `|`, grouped alternation, character classes, escape classes, dot, `^`/`$`, escaped literals with and without following quantifiers, Unicode literals). `quantifier_allows_zero` also has a dedicated table-driven test.
- `searchlite-core/src/api/reader.rs`: two new end-to-end tests that mirror the exact scenarios from BUG-202:
  - `regex_with_optional_char_finds_shorter_term` indexes `color` + `colour`, runs regex `colou?r`, asserts both terms are expanded. Fails against the old `regex_literal_prefix`.
  - `regex_flat_alternation_finds_all_branches` indexes `rust` / `ruby` / `rope`, runs regex `rust|ruby`, asserts both branches are expanded and `rope` is rejected by the regex. Fails against the old `regex_literal_prefix`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-core --lib api::term_expansion` — 20 passed (all new)
- [x] `cargo test -p searchlite-core --lib -- regex_with_optional_char regex_flat_alternation regex_expansion_applies_cap` — 3 passed (2 new + 1 pre-existing)
- [x] `cargo test -p searchlite-core --lib` — 220 passed, 0 failed
- [x] `cargo test --workspace --lib --exclude searchlite-wasm` — all green

Refs #202