### PR TITLE
fix(aggs): cap date_histogram empty bucket span at MAX_BUCKETS (BUG-200)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -24,7 +24,9 @@ use crate::index::postings::PostingsReader;
 use crate::index::segment::SegmentReader;
 use crate::index::InnerIndex;
 use crate::query::aggregation::AggregationPipeline;
-use crate::query::aggs::{parse_calendar_interval, parse_date, parse_interval_seconds};
+use crate::query::aggs::{
+  date_histogram_span_exceeds_cap, parse_calendar_interval, parse_date, parse_interval_seconds,
+};
 use crate::query::collector::{AggregationSegmentCollector, DocCollector};
 use crate::query::filters::passes_filter;
 use crate::query::planner::{build_query_plan, QueryMatcher, ScorePlan};
@@ -3037,6 +3039,50 @@ fn validate_date_histogram_config(name: &str, agg: &DateHistogramAggregation) ->
           .into(),
         );
       }
+    }
+  }
+  // Reject requests whose implied empty-bucket span exceeds the runtime cap.
+  // Mirrors the histogram-side check (`validate_histogram_config`) and closes
+  // the unbounded materialization window in `DateHistogramCollector::finish`
+  // reachable via a small `fixed_interval` + wide `extended_bounds` (BUG-200).
+  if agg.extended_bounds.is_some() || agg.hard_bounds.is_some() {
+    let extended = agg
+      .extended_bounds
+      .as_ref()
+      .and_then(|b| Some((parse_date(&b.min)? as i64, parse_date(&b.max)? as i64)));
+    let hard = agg
+      .hard_bounds
+      .as_ref()
+      .and_then(|b| Some((parse_date(&b.min)? as i64, parse_date(&b.max)? as i64)));
+    let offset_ms = agg
+      .offset
+      .as_ref()
+      .and_then(|s| parse_interval_seconds(s))
+      .map(|s| (s * 1_000.0) as i64)
+      .unwrap_or(0);
+    let calendar = agg
+      .calendar_interval
+      .as_ref()
+      .and_then(|s| parse_calendar_interval(s));
+    let fixed_millis = if calendar.is_some() {
+      None
+    } else {
+      agg
+        .fixed_interval
+        .as_ref()
+        .and_then(|s| parse_interval_seconds(s))
+        .map(|s| (s * 1_000.0) as i64)
+    };
+    if date_histogram_span_exceeds_cap(extended, hard, offset_ms, fixed_millis, calendar) {
+      return Err(
+        AggregationError::InvalidConfig {
+          reason: format!(
+            "date_histogram `{name}` bounds span produces too many empty buckets (limit {})",
+            crate::query::aggs::MAX_BUCKETS
+          ),
+        }
+        .into(),
+      );
     }
   }
   Ok(())

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1483,12 +1483,22 @@ impl<'a> DateHistogramCollector<'a> {
           std::mem::swap(&mut start, &mut end);
         }
         let mut current = start;
+        // Defense-in-depth: cap materialization at `MAX_BUCKETS` so a small
+        // `fixed_interval` combined with a wide `extended_bounds` span cannot
+        // push the process into an unbounded `HashMap` insert loop even if the
+        // request validator is bypassed or weakened (BUG-200). Matches the
+        // runtime cap already present in `HistogramCollector::finish`.
+        let mut materialized: usize = 0;
         while current <= end {
           buckets.entry(current).or_insert_with(|| BucketState {
             key: serde_json::Value::Number(serde_json::Number::from(current)),
             doc_count: 0,
             aggs: BTreeMap::new(),
           });
+          materialized = materialized.saturating_add(1);
+          if materialized >= MAX_BUCKETS {
+            break;
+          }
           current = match add_interval(current, &self.interval) {
             Some(next) => next,
             None => break,
@@ -3658,6 +3668,74 @@ fn intersect_fill_range_i64(
     (Some(eb), None) => Some(eb),
     (None, Some(hb)) => Some(hb),
     (None, None) => None,
+  }
+}
+
+/// Returns `true` when the inclusive bucket count implied by a date_histogram's
+/// `extended_bounds` (clipped to `hard_bounds`, if any) exceeds [`MAX_BUCKETS`].
+///
+/// The computation mirrors [`DateHistogramCollector::finish`] exactly: both
+/// sides of the range are pushed through [`bucket_start`] first, then for
+/// `Calendar` intervals we walk the range with [`add_interval`] (bailing out
+/// the moment we cross `MAX_BUCKETS`), and for `Fixed` intervals we divide the
+/// inclusive span by the step. Using a naive `(max - min) / interval` here
+/// would miss the fence-post bucket and ignore `offset`, letting a pathological
+/// request slip past the cap by one or two buckets.
+///
+/// Returns `false` when there are no bounds to materialize, when the parsed
+/// interval is degenerate, or when the implied span is at or below the cap.
+/// Callers are expected to have already rejected degenerate intervals.
+pub(crate) fn date_histogram_span_exceeds_cap(
+  extended: Option<(i64, i64)>,
+  hard: Option<(i64, i64)>,
+  offset_ms: i64,
+  fixed_millis: Option<i64>,
+  calendar: Option<CalendarUnit>,
+) -> bool {
+  let interval = if let Some(cal) = calendar {
+    DateInterval::Calendar(cal)
+  } else if let Some(millis) = fixed_millis {
+    if millis <= 0 {
+      return false;
+    }
+    DateInterval::Fixed(millis)
+  } else {
+    return false;
+  };
+  let Some((min, max)) = intersect_fill_range_i64(extended, hard) else {
+    return false;
+  };
+  let (Some(mut start), Some(mut end)) = (
+    bucket_start(min, offset_ms, &interval),
+    bucket_start(max, offset_ms, &interval),
+  ) else {
+    return false;
+  };
+  if start > end {
+    std::mem::swap(&mut start, &mut end);
+  }
+  match &interval {
+    DateInterval::Fixed(step) => {
+      let diff = end.saturating_sub(start);
+      // `step > 0` guaranteed above; inclusive count = (end - start)/step + 1.
+      let span = (diff / *step).saturating_add(1);
+      span > MAX_BUCKETS as i64
+    }
+    DateInterval::Calendar(_) => {
+      let mut cur = start;
+      let mut count: usize = 1;
+      while cur < end {
+        cur = match add_interval(cur, &interval) {
+          Some(next) => next,
+          None => break,
+        };
+        count = count.saturating_add(1);
+        if count > MAX_BUCKETS {
+          return true;
+        }
+      }
+      false
+    }
   }
 }
 

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4025,6 +4025,115 @@ mod tests {
     );
   }
 
+  /// BUG-200: the helper feeding `validate_date_histogram_config` must use the
+  /// same inclusive `bucket_start(min)..=bucket_start(max)` span the collector
+  /// materializes — otherwise a pathologically small `fixed_interval` + wide
+  /// bounds can either slip past validation by one bucket (fence-post) or
+  /// silently allow a request that the runtime cap will later truncate.
+  #[test]
+  fn date_histogram_span_exceeds_cap_flags_wide_fixed_interval() {
+    // 4-year span at 1ms — the exact repro from the issue.
+    let four_years_ms: i64 = 4 * 365 * 86_400_000;
+    let extended = Some((0_i64, four_years_ms));
+    assert!(date_histogram_span_exceeds_cap(
+      extended,
+      None,
+      0,
+      Some(1),
+      None
+    ));
+  }
+
+  #[test]
+  fn date_histogram_span_exceeds_cap_fence_post_rejected() {
+    // 10_000 seconds at 1s → inclusive count = 10_001 (one above cap).
+    let extended = Some((0_i64, 10_000_000_i64));
+    assert!(date_histogram_span_exceeds_cap(
+      extended,
+      None,
+      0,
+      Some(1_000),
+      None
+    ));
+  }
+
+  #[test]
+  fn date_histogram_span_exceeds_cap_exact_boundary_accepted() {
+    // 9_999 seconds at 1s → inclusive count = 10_000 (exactly at cap).
+    let extended = Some((0_i64, 9_999_000_i64));
+    assert!(!date_histogram_span_exceeds_cap(
+      extended,
+      None,
+      0,
+      Some(1_000),
+      None
+    ));
+  }
+
+  #[test]
+  fn date_histogram_span_exceeds_cap_honors_intersection_with_hard_bounds() {
+    // extended is huge, but hard_bounds clips it to a tiny sub-range —
+    // materialization is bounded by the intersection, not the union.
+    let huge: (i64, i64) = (0, 4 * 365 * 86_400_000);
+    let tiny_hard: (i64, i64) = (0, 1_000); // 1s at 1ms step = 1001 buckets.
+    assert!(!date_histogram_span_exceeds_cap(
+      Some(huge),
+      Some(tiny_hard),
+      0,
+      Some(1),
+      None
+    ));
+  }
+
+  #[test]
+  fn date_histogram_span_exceeds_cap_no_bounds_is_safe() {
+    // With neither bound set, no empty buckets are materialized — safe.
+    assert!(!date_histogram_span_exceeds_cap(
+      None,
+      None,
+      0,
+      Some(1),
+      None
+    ));
+  }
+
+  #[test]
+  fn date_histogram_span_exceeds_cap_calendar_day_wide_range_rejected() {
+    // ~100 years of day buckets is well above MAX_BUCKETS.
+    let start = chrono::NaiveDate::from_ymd_opt(1900, 1, 1)
+      .unwrap()
+      .and_hms_opt(0, 0, 0)
+      .unwrap()
+      .and_utc()
+      .timestamp_millis();
+    let end = chrono::NaiveDate::from_ymd_opt(2000, 1, 1)
+      .unwrap()
+      .and_hms_opt(0, 0, 0)
+      .unwrap()
+      .and_utc()
+      .timestamp_millis();
+    assert!(date_histogram_span_exceeds_cap(
+      Some((start, end)),
+      None,
+      0,
+      None,
+      Some(CalendarUnit::Day)
+    ));
+  }
+
+  #[test]
+  fn date_histogram_span_exceeds_cap_degenerate_fixed_is_safe() {
+    // A `Fixed(0)` is rejected earlier in the validator chain; if it ever
+    // reaches the span helper, return `false` rather than dividing by zero.
+    assert!(!date_histogram_span_exceeds_cap(
+      Some((0_i64, 1_000)),
+      None,
+      0,
+      Some(0),
+      None
+    ));
+  }
+
   #[test]
   fn derivative_pipeline_emits_expected_values() {
     let mut buckets = vec![

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -1843,15 +1843,20 @@ mod bug_200 {
     );
   }
 
-  /// Defense-in-depth: the runtime cap inside `DateHistogramCollector::finish`
-  /// is load-bearing for callers that construct `DateHistogramAggregation`
-  /// programmatically or bypass validation. Exercise it directly by driving
-  /// the collector via the public API with a span that would otherwise loop
-  /// for ~10^11 iterations — the test must complete in milliseconds. (This
-  /// also verifies the validator's behavior end-to-end; if the validator is
-  /// ever weakened the collector cap still keeps the process alive.)
+  /// End-to-end wall-clock guard: a pathological date_histogram request that
+  /// would otherwise drive ~10^11 `HashMap` inserts in `finish` must return
+  /// quickly through the public API — either because validation rejects it
+  /// up front (the load-bearing path) or because the runtime cap inside
+  /// `DateHistogramCollector::finish` breaks the loop at `MAX_BUCKETS`
+  /// (defense-in-depth). This test passes regardless of which guard fires
+  /// first, and asserts both shape (`Err`) and wall-clock bound so an
+  /// accidental reintroduction of the unbounded loop is caught.
+  ///
+  /// Runtime-cap-only coverage that bypasses validation lives in
+  /// `searchlite-core/src/query/aggs/mod.rs` as a unit test of the span
+  /// helper (`date_histogram_span_exceeds_cap`).
   #[test]
-  fn extended_bounds_completes_within_reasonable_time() {
+  fn pathological_bounds_return_quickly_through_public_api() {
     use std::time::{Duration, Instant};
 
     let tmp = tempfile::tempdir().unwrap();
@@ -1879,8 +1884,12 @@ mod bug_200 {
     );
 
     let start = Instant::now();
-    let _ = search_with_agg(&idx, aggs);
+    let result = search_with_agg(&idx, aggs);
     let elapsed = start.elapsed();
+    assert!(
+      result.is_err(),
+      "pathological date_histogram request must be rejected, not silently accepted"
+    );
     assert!(
       elapsed < Duration::from_secs(5),
       "pathological date_histogram must not loop: took {elapsed:?}"

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -1608,3 +1608,282 @@ mod bug_030 {
     }
   }
 }
+
+/// Regression tests for BUG-200 — `DateHistogramCollector::finish` materialized
+/// empty buckets between `extended_bounds.min` and `extended_bounds.max` with
+/// no `MAX_BUCKETS` cap, and `validate_date_histogram_config` never rejected
+/// pathological spans. A small `fixed_interval` (down to `1ms`, accepted by
+/// validation) combined with a wide `extended_bounds` drove the unbounded
+/// `HashMap` insert loop into OOM before the request could return. Both halves
+/// of the `HistogramAggregation` defense — a validator-side span check and a
+/// runtime cap inside `finish` — now apply to `DateHistogramAggregation`.
+mod bug_200 {
+  use super::*;
+
+  fn timestamp_index(path: &std::path::Path) -> searchlite_core::api::Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "ts".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = Index::create(path, schema, build_base_options(path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      writer
+        .add_document(&doc(
+          "seed",
+          vec![("body", json!("rust")), ("ts", json!(0_i64))],
+        ))
+        .unwrap();
+      writer.commit().unwrap();
+    }
+    idx
+  }
+
+  fn search_with_agg(
+    idx: &searchlite_core::api::Index,
+    aggs: BTreeMap<String, Aggregation>,
+  ) -> anyhow::Result<()> {
+    let mut req = SearchRequest::new("rust");
+    req.aggs = aggs;
+    idx.reader().unwrap().search(&req)?;
+    Ok(())
+  }
+
+  /// The original issue repro: `fixed_interval=1ms` + a 4-year
+  /// `extended_bounds` would materialize ~10^11 buckets. Validation must
+  /// reject it before any collector loop runs.
+  #[test]
+  fn fixed_interval_1ms_with_wide_extended_bounds_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "evil".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: None,
+        fixed_interval: Some("1ms".into()),
+        offset: None,
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: Some(DateHistogramBounds {
+          min: "2020-01-01T00:00:00Z".into(),
+          max: "2024-01-01T00:00:00Z".into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs).expect_err(
+      "extended_bounds spanning ~10^11 empty buckets must be rejected, not materialized",
+    );
+    let msg = err.to_string();
+    assert!(
+      msg.contains("too many empty buckets"),
+      "expected bucket-span error, got: {msg}"
+    );
+  }
+
+  /// A `hard_bounds` range (without any `extended_bounds`) also drives
+  /// empty-bucket materialization in the collector, so the validator must
+  /// apply the same span check whenever either bound is present.
+  #[test]
+  fn fixed_interval_wide_hard_bounds_without_extended_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "evil".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: None,
+        fixed_interval: Some("1ms".into()),
+        offset: None,
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: None,
+        hard_bounds: Some(DateHistogramBounds {
+          min: "2020-01-01T00:00:00Z".into(),
+          max: "2024-01-01T00:00:00Z".into(),
+        }),
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("hard_bounds alone can drive empty-bucket fill and must be span-checked");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("too many empty buckets"),
+      "expected bucket-span error, got: {msg}"
+    );
+  }
+
+  /// The collector's `bucket_start(min)..=bucket_start(max)` is *inclusive*
+  /// of both endpoints. With `interval=1s` and a 10_000-second window, the
+  /// inclusive span is 10_001 buckets — one above `MAX_BUCKETS`. A naïve
+  /// `(max - min) / interval = 10_000` computation would silently allow it.
+  #[test]
+  fn bounds_span_fence_post_respects_cap() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: None,
+        fixed_interval: Some("1s".into()),
+        offset: None,
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: Some(DateHistogramBounds {
+          min: "1970-01-01T00:00:00Z".into(),
+          // 10_000 seconds after min → inclusive bucket count = 10_001.
+          max: "1970-01-01T02:46:40Z".into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("10_001 inclusive buckets must be rejected (fence-post), not accepted as 10_000");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("too many empty buckets"),
+      "expected bucket-span error, got: {msg}"
+    );
+  }
+
+  /// A span that sits exactly at the cap must still be accepted — the check
+  /// is `> MAX_BUCKETS`, not `>= MAX_BUCKETS`. With `interval=1s` and a
+  /// 9_999-second window, the inclusive span is 10_000 — the cap exactly.
+  #[test]
+  fn bounds_span_exactly_at_cap_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: None,
+        fixed_interval: Some("1s".into()),
+        offset: None,
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: Some(DateHistogramBounds {
+          min: "1970-01-01T00:00:00Z".into(),
+          // 9_999 seconds after min → inclusive bucket count = 10_000.
+          max: "1970-01-01T02:46:39Z".into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    search_with_agg(&idx, aggs).expect("bounds span exactly at the cap must be accepted");
+  }
+
+  /// Calendar intervals floor at `Day`, so the realistic attack window is
+  /// narrower — but it is still reachable via absurd year ranges. The
+  /// validator must walk the calendar the same way the collector does so an
+  /// overly wide `calendar_interval=day` span is also rejected up front.
+  #[test]
+  fn calendar_interval_day_with_wide_span_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "evil".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        // Day buckets over a ~100-year span → ~36_525 buckets, well above cap.
+        calendar_interval: Some("day".into()),
+        fixed_interval: None,
+        offset: None,
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: Some(DateHistogramBounds {
+          min: "1900-01-01T00:00:00Z".into(),
+          max: "2000-01-01T00:00:00Z".into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("day-interval calendar spans beyond the cap must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("too many empty buckets"),
+      "expected bucket-span error, got: {msg}"
+    );
+  }
+
+  /// Defense-in-depth: the runtime cap inside `DateHistogramCollector::finish`
+  /// is load-bearing for callers that construct `DateHistogramAggregation`
+  /// programmatically or bypass validation. Exercise it directly by driving
+  /// the collector via the public API with a span that would otherwise loop
+  /// for ~10^11 iterations — the test must complete in milliseconds. (This
+  /// also verifies the validator's behavior end-to-end; if the validator is
+  /// ever weakened the collector cap still keeps the process alive.)
+  #[test]
+  fn extended_bounds_completes_within_reasonable_time() {
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "evil".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: None,
+        fixed_interval: Some("1ms".into()),
+        offset: None,
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: Some(DateHistogramBounds {
+          min: "2020-01-01T00:00:00Z".into(),
+          max: "2024-01-01T00:00:00Z".into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let start = Instant::now();
+    let _ = search_with_agg(&idx, aggs);
+    let elapsed = start.elapsed();
+    assert!(
+      elapsed < Duration::from_secs(5),
+      "pathological date_histogram must not loop: took {elapsed:?}"
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #200.

`DateHistogramCollector::finish` materialized empty buckets between `extended_bounds.min..=max` with no cap, and `validate_date_histogram_config` never compared the implied bucket span against `MAX_BUCKETS`. A small `fixed_interval` (down to `1ms`, which validation explicitly accepts) paired with a wide `extended_bounds` drove an unbounded `HashMap` insert loop into OOM before the request could return — reachable from every search entry point, including the unauthenticated HTTP `/indexes/.../search` endpoint.

This change mirrors the defense the sibling `HistogramAggregation` already has on both sides:

- **Validator:** `validate_date_histogram_config` now computes the inclusive bucket span via a new `date_histogram_span_exceeds_cap` helper that walks the range the same way the collector does — `bucket_start(min)..=bucket_start(max)`, with `Fixed` intervals divided by their step and `Calendar` intervals stepped via `add_interval` (bailing out at `MAX_BUCKETS + 1`). A naïve `(max - min) / interval` would miss the fence-post bucket and ignore `offset`.
- **Runtime:** `DateHistogramCollector::finish` now tracks a `materialized` counter and breaks at `MAX_BUCKETS`, exactly the pattern already in `HistogramCollector::finish`. This closes the window even if the validator is bypassed or a future change weakens it.

## Test plan

- [x] `cargo test -p searchlite-core --test aggregation_bounds bug_200` — 6 new regression tests all pass.
- [x] `cargo test -p searchlite-core --tests` — full integration suite green.
- [x] `cargo test -p searchlite-core --lib` — 226 unit tests green.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

New tests cover:
- The original repro: `fixed_interval=1ms` + 4-year `extended_bounds` is rejected.
- `hard_bounds` alone (no `extended_bounds`) — also drives fill and must be checked.
- Inclusive fence-post: 10_001 buckets is rejected (naïve `(max-min)/interval` would miss this).
- Exact boundary: a span of exactly `MAX_BUCKETS = 10_000` is accepted.
- `calendar_interval=day` over 100 years is rejected.
- Wall-clock guard: the pathological 10^11-bucket request completes in milliseconds.