### PR TITLE
fix(postings): bound Vec capacity against untrusted u32 counts (BUG-205)

### DIFF
--- a/searchlite-core/src/index/postings.rs
+++ b/searchlite-core/src/index/postings.rs
@@ -1,7 +1,7 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use hashbrown::HashMap;
 use smallvec::SmallVec;
 
@@ -11,6 +11,30 @@ use crate::DocId;
 
 pub const DEFAULT_BLOCK_SIZE: usize = 128;
 const BLOCK_META_FLAG: u32 = 1u32 << 31;
+
+/// Reject element counts that cannot possibly be backed by the bytes still
+/// available in the segment file. The `count` is read from an untrusted
+/// header field and would otherwise drive a `Vec::with_capacity` /
+/// `Vec::reserve` of arbitrary size, allowing a tampered or corrupt segment
+/// to commit a multi-gigabyte allocation before the per-entry read loop
+/// surfaces the truncation. Mirrors the helper introduced by BUG-012 for
+/// `fastfields::read_fields`, adapted for the `Read + Seek` byte budget.
+fn checked_count(count: usize, min_stride: usize, remaining: u64) -> Result<usize> {
+  let needed = (count as u64)
+    .checked_mul(min_stride as u64)
+    .ok_or_else(|| anyhow!("postings count {count} * stride {min_stride} overflows u64"))?;
+  if needed > remaining {
+    return Err(anyhow!(
+      "postings count {count} would need {needed} bytes but only {remaining} remain in segment"
+    ));
+  }
+  Ok(count)
+}
+
+fn stream_remaining<R: Seek>(file: &mut R, end: u64) -> Result<u64> {
+  let cur = file.stream_position()?;
+  Ok(end.saturating_sub(cur))
+}
 
 #[derive(Debug, Clone)]
 pub struct PostingEntry {
@@ -186,6 +210,13 @@ impl PostingsReader {
 impl PostingsReader {
   pub fn read_at<R: Read + Seek>(file: &mut R, offset: u64, keep_positions: bool) -> Result<Self> {
     file.seek(SeekFrom::Start(offset))?;
+    // Capture the segment file length once so subsequent untrusted counts can
+    // be validated against the remaining byte budget before being passed to
+    // `Vec::with_capacity` / `Vec::reserve`. Otherwise a single 4-byte
+    // `doc_freq` field could drive a 171 GiB allocation (BUG-205, mirrors
+    // BUG-012 for `fastfields::read_fields`).
+    let end = file.seek(SeekFrom::End(0))?;
+    file.seek(SeekFrom::Start(offset))?;
     let doc_freq = read_u32(file)? as usize;
     // Track the on-disk flag independently of the caller's preference so that
     // we always consume the bytes that are actually present in the file.
@@ -209,15 +240,29 @@ impl PostingsReader {
     let mut block_max_tfs = Vec::new();
     if has_block_meta && block_count > 0 {
       block_size = read_u32(file)? as usize;
-      block_max_doc_ids.reserve(block_count);
-      block_max_tfs.reserve(block_count);
-      for _ in 0..block_count {
+      // Each block-meta entry is 4 B (u32 max_doc_id) + 4 B (f32 max_tf),
+      // read in two sequential loops. Validate the count against the
+      // remaining byte budget so a crafted `block_count` near `2^31 - 1`
+      // cannot reserve ~16 GiB before the read loop runs.
+      let remaining = stream_remaining(file, end)?;
+      let validated_block_count = checked_count(block_count, 8, remaining)?;
+      block_max_doc_ids.reserve(validated_block_count);
+      block_max_tfs.reserve(validated_block_count);
+      for _ in 0..validated_block_count {
         block_max_doc_ids.push(read_u32(file)?);
       }
-      for _ in 0..block_count {
+      for _ in 0..validated_block_count {
         block_max_tfs.push(read_f32(file)?);
       }
     }
+    // Each posting entry encodes at minimum a 1-byte varint for `doc_id`
+    // and a 1-byte varint for `term_freq` (plus a 1-byte varint for the
+    // position count when `stored_positions`). Validate `doc_freq` against
+    // the remaining byte budget before reserving capacity for a
+    // 40-byte-element vector.
+    let min_entry_stride = if stored_positions { 3 } else { 2 };
+    let remaining = stream_remaining(file, end)?;
+    let doc_freq = checked_count(doc_freq, min_entry_stride, remaining)?;
     let mut data = Vec::with_capacity(doc_freq);
     for _ in 0..doc_freq {
       let doc_id = read_u32_var(file)?;
@@ -529,6 +574,77 @@ mod tests {
       .map(|p| p.positions.iter().copied().collect::<Vec<_>>())
       .collect();
     assert_eq!(round_tripped, vec![vec![2, 2, 5]]);
+  }
+
+  /// Regression for BUG-205: a tampered or corrupt segment header that
+  /// claims `u32::MAX` postings entries on a near-empty file must be
+  /// rejected before `Vec::with_capacity` commits a multi-gigabyte
+  /// reservation. The check happens *before* the per-entry read loop
+  /// would otherwise surface the truncation as `failed to fill whole
+  /// buffer`, so the assertion targets the bounds-check error string
+  /// rather than an I/O error.
+  #[test]
+  fn read_at_rejects_oversized_doc_freq_on_short_file() {
+    use std::io::Cursor;
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&u32::MAX.to_le_bytes()); // doc_freq
+    buf.push(0); // stored_positions
+    buf.extend_from_slice(&0u32.to_le_bytes()); // raw_block (no block meta)
+    buf.extend_from_slice(&0u32.to_le_bytes()); // max_doc_id
+    buf.extend_from_slice(&0f32.to_le_bytes()); // max_tf
+    let mut cur = Cursor::new(buf);
+    let err =
+      PostingsReader::read_at(&mut cur, 0, false).expect_err("oversized doc_freq must be rejected");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+      msg.contains("postings count") && msg.contains("remain"),
+      "unexpected error: {err}"
+    );
+  }
+
+  /// Same as above, with `stored_positions = 1` so the minimum entry stride
+  /// becomes 3 bytes. The crafted file is still far too small to satisfy a
+  /// `u32::MAX` claim.
+  #[test]
+  fn read_at_rejects_oversized_doc_freq_with_positions_on_short_file() {
+    use std::io::Cursor;
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&u32::MAX.to_le_bytes()); // doc_freq
+    buf.push(1); // stored_positions
+    buf.extend_from_slice(&0u32.to_le_bytes()); // raw_block (no block meta)
+    buf.extend_from_slice(&0u32.to_le_bytes()); // max_doc_id
+    buf.extend_from_slice(&0f32.to_le_bytes()); // max_tf
+    let mut cur = Cursor::new(buf);
+    let err =
+      PostingsReader::read_at(&mut cur, 0, false).expect_err("oversized doc_freq must be rejected");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+      msg.contains("postings count") && msg.contains("remain"),
+      "unexpected error: {err}"
+    );
+  }
+
+  /// Regression for BUG-205: an oversized `block_count` (bottom 31 bits of
+  /// the block header) must be rejected before the two block-meta `reserve`
+  /// calls can commit ~16 GiB of capacity.
+  #[test]
+  fn read_at_rejects_oversized_block_count_on_short_file() {
+    use std::io::Cursor;
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&0u32.to_le_bytes()); // doc_freq = 0
+    buf.push(0); // stored_positions
+    buf.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // flag set + block_count = 2^31 - 1
+    buf.extend_from_slice(&0u32.to_le_bytes()); // max_doc_id
+    buf.extend_from_slice(&0f32.to_le_bytes()); // max_tf
+    buf.extend_from_slice(&128u32.to_le_bytes()); // block_size
+    let mut cur = Cursor::new(buf);
+    let err = PostingsReader::read_at(&mut cur, 0, false)
+      .expect_err("oversized block_count must be rejected");
+    let msg = err.to_string().to_lowercase();
+    assert!(
+      msg.contains("postings count") && msg.contains("remain"),
+      "unexpected error: {err}"
+    );
   }
 
   /// Sanity: when the segment was written without positions, reading with


### PR DESCRIPTION
## Summary

Fixes #205. `PostingsReader::read_at` previously sized two block-meta `Vec::reserve` calls and the per-entry `Vec::with_capacity` directly from `u32` header fields with no validation. A crafted or silently-corrupted segment with `doc_freq = u32::MAX` could drive a ~171 GiB allocation (40-byte `PostingEntry`) before the per-entry varint loop ever discovered the file was too short; an oversized `block_count` could commit ~16 GiB across the two block-meta arrays. On a host with overcommit off this aborts the process through `handle_alloc_error`; on an overcommitted host it dies later to OOM-kill — either way, a DoS on every query that touches the affected term.

This mirrors the BUG-012 / #150 fix in `fastfields::read_fields`, adapted for the `Read + Seek` interface used by `postings.rs`:

- Capture the segment file length once at function entry via `seek(SeekFrom::End(0))` and seek back.
- Pass each untrusted count through a `checked_count(count, min_stride, remaining)` helper that rejects claims exceeding the bytes still available, before the count reaches `Vec::with_capacity` / `Vec::reserve`.
- Minimum per-entry strides: **8 B** for block-meta entries (`u32` max_doc + `f32` max_tf), **2 B** for postings without stored positions (1-byte varints for `doc_id` + `term_freq`), **3 B** when `stored_positions` adds the position-count varint.

## Test plan

- [x] `cargo test -p searchlite-core --lib index::postings::` — 11 tests pass (3 new + 8 pre-existing)
- [x] `cargo test --workspace --lib` — 318 tests pass
- [x] `cargo fmt --all -- --check`
- [x] New regression tests:
  - `read_at_rejects_oversized_doc_freq_on_short_file`
  - `read_at_rejects_oversized_doc_freq_with_positions_on_short_file`
  - `read_at_rejects_oversized_block_count_on_short_file`