### PR TITLE
fix(core): unify keyword case-folding across postings and filter paths

### DIFF
--- a/searchlite-core/src/api/phrase.rs
+++ b/searchlite-core/src/api/phrase.rs
@@ -9,6 +9,7 @@ use crate::index::manifest::{FieldKind, Schema, SchemaAnalyzers};
 use crate::index::postings::PostingEntry;
 use crate::index::segment::SegmentReader;
 use crate::query::planner::PhraseSpec;
+use crate::util::case_fold::fold_keyword;
 use crate::DocId;
 
 #[derive(Clone, Debug)]
@@ -64,7 +65,7 @@ pub(crate) fn expand_phrase_fields(
             Some((field.clone(), positions))
           }),
           FieldKind::Keyword => {
-            let joined = phrase.terms.join(" ").to_ascii_lowercase();
+            let joined = fold_keyword(&phrase.terms.join(" ")).into_owned();
             if joined.is_empty() {
               None
             } else {

--- a/searchlite-core/src/api/suggestion.rs
+++ b/searchlite-core/src/api/suggestion.rs
@@ -12,6 +12,7 @@ use crate::api::reader::IndexReader;
 use crate::api::types::{FuzzyOptions, SuggestOption, SuggestRequest, SuggestResult};
 use crate::index::manifest::FieldKind;
 use crate::index::segment::SegmentReader;
+use crate::util::case_fold::fold_keyword;
 
 #[derive(Default)]
 struct SuggestCandidate {
@@ -133,7 +134,7 @@ impl IndexReader {
         inputs.dedup();
         Ok(inputs)
       }
-      FieldKind::Keyword => Ok(vec![prefix.to_ascii_lowercase()]),
+      FieldKind::Keyword => Ok(vec![fold_keyword(prefix).into_owned()]),
       FieldKind::Numeric | FieldKind::Unknown => {
         bail!("completion suggest is only supported on text/keyword fields")
       }

--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -10,6 +10,7 @@ use crate::api::types::{FuzzyOptions, MultiMatchFuzziness};
 use crate::index::manifest::{FieldKind, Schema, SchemaAnalyzers};
 use crate::index::segment::SegmentReader;
 use crate::query::planner::{TermExpansion, TermGroupMode, TermGroupSpec};
+use crate::util::case_fold::fold_keyword;
 use crate::util::regex::anchored_regex;
 
 use super::phrase::TermMatchGroup;
@@ -183,7 +184,7 @@ pub(crate) fn expand_term_groups(
           }
         }
         FieldKind::Keyword => {
-          let term = group.term.to_ascii_lowercase();
+          let term = fold_keyword(&group.term).into_owned();
           let term_fuzzy =
             resolve_multi_match_fuzzy_options(group.fuzziness.as_ref(), request_fuzzy, &term);
           let (scored, mut expanded_keys) = expand_term_for_group(

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -721,13 +721,18 @@ impl<'a> SegmentWriter<'a> {
         let is_nested_field = field.contains('.');
         for value in values.iter() {
           if indexed {
+            // `fold_keyword` returns a borrowed `Cow` for already-lowercase
+            // ASCII input, so we probe `seen_terms` before allocating and
+            // only materialize an owned `String` on the insert path. This
+            // preserves the ASCII fast path for the common duplicate case.
             let lower = fold_keyword(value);
-            if seen_terms.insert(lower.clone().into_owned()) {
+            if !seen_terms.contains(lower.as_ref()) {
               let mut term_key = String::with_capacity(field.len() + lower.len() + 1);
               term_key.push_str(field);
               term_key.push(':');
               term_key.push_str(&lower);
               postings_builder.add_term(&term_key, doc_ord, 0, false);
+              seen_terms.insert(lower.into_owned());
             }
           }
         }

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -30,6 +30,7 @@ use crate::index::manifest::{
 use crate::index::postings::{read_doc_freq, InvertedIndexBuilder, PostingsReader, PostingsWriter};
 use crate::index::terms::{read_terms, write_terms};
 use crate::storage::{Storage, StorageFile};
+use crate::util::case_fold::fold_keyword;
 use crate::util::checksum::checksum;
 #[cfg(feature = "vectors")]
 use crate::vectors::hnsw::HnswParams;
@@ -720,8 +721,8 @@ impl<'a> SegmentWriter<'a> {
         let is_nested_field = field.contains('.');
         for value in values.iter() {
           if indexed {
-            let lower = value.to_ascii_lowercase();
-            if seen_terms.insert(lower.clone()) {
+            let lower = fold_keyword(value);
+            if seen_terms.insert(lower.clone().into_owned()) {
               let mut term_key = String::with_capacity(field.len() + lower.len() + 1);
               term_key.push_str(field);
               term_key.push(':');

--- a/searchlite-core/src/util/case_fold.rs
+++ b/searchlite-core/src/util/case_fold.rs
@@ -1,0 +1,89 @@
+use std::borrow::Cow;
+
+/// Case-fold a keyword/term value for indexing and searching.
+///
+/// This is the single source of truth for how keyword values are folded. Both
+/// the postings path (indexing and `match` queries over keyword fields) and
+/// the fast-field equality path (`case_insensitive_equals`) must agree on the
+/// folded form so their results line up for ASCII and non-ASCII alike.
+///
+/// Previously the postings path used `str::to_ascii_lowercase`, which only
+/// rewrites the 26 uppercase ASCII letters and leaves every other byte
+/// untouched. That diverged from `case_insensitive_equals`, which does real
+/// Unicode folding via `char::to_lowercase`, so a keyword value whose
+/// uppercase form contained non-ASCII code points (e.g. `RÉSUMÉ`) was
+/// matched by `Filter::KeywordEq` but silently missed by a `match` query on
+/// the same field.
+///
+/// The helper keeps the ASCII fast path for the common case: inputs that are
+/// pure ASCII and already lowercase are returned borrowed, without
+/// allocating.
+pub fn fold_keyword(value: &str) -> Cow<'_, str> {
+  if value.is_ascii() {
+    if value.bytes().any(|b| b.is_ascii_uppercase()) {
+      Cow::Owned(value.to_ascii_lowercase())
+    } else {
+      Cow::Borrowed(value)
+    }
+  } else {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+      for lc in ch.to_lowercase() {
+        out.push(lc);
+      }
+    }
+    Cow::Owned(out)
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn ascii_lowercase_borrows() {
+    let folded = fold_keyword("tag");
+    assert_eq!(folded, "tag");
+    assert!(matches!(folded, Cow::Borrowed(_)));
+  }
+
+  #[test]
+  fn ascii_uppercase_lowercases() {
+    let folded = fold_keyword("TAG");
+    assert_eq!(folded, "tag");
+    assert!(matches!(folded, Cow::Owned(_)));
+  }
+
+  #[test]
+  fn ascii_mixed_case_lowercases() {
+    assert_eq!(fold_keyword("Tag"), "tag");
+  }
+
+  #[test]
+  fn non_ascii_uppercase_lowercases() {
+    assert_eq!(fold_keyword("RÉSUMÉ"), "résumé");
+    assert_eq!(fold_keyword("Résumé"), "résumé");
+    assert_eq!(fold_keyword("résumé"), "résumé");
+  }
+
+  #[test]
+  fn non_ascii_cyrillic_and_greek() {
+    // Cyrillic capital Ж -> lowercase ж
+    assert_eq!(fold_keyword("ЖУК"), "жук");
+    // Greek capital Σ folds to lowercase σ in non-final positions.
+    assert_eq!(fold_keyword("ΣΟΦΙΑ"), "σοφια");
+  }
+
+  #[test]
+  fn non_ascii_one_to_many_folding() {
+    // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE lowercases to two code points.
+    assert_eq!(fold_keyword("İ"), "i\u{0307}");
+  }
+
+  #[test]
+  fn empty_input_is_borrowed() {
+    let folded = fold_keyword("");
+    assert_eq!(folded, "");
+    assert!(matches!(folded, Cow::Borrowed(_)));
+  }
+}

--- a/searchlite-core/src/util/mod.rs
+++ b/searchlite-core/src/util/mod.rs
@@ -1,4 +1,5 @@
 pub mod bitpack;
+pub mod case_fold;
 pub mod checksum;
 pub mod doc_id;
 pub mod fst;

--- a/searchlite-core/tests/regressions.rs
+++ b/searchlite-core/tests/regressions.rs
@@ -3,8 +3,8 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use searchlite_core::api::types::{
-  CollapseRequest, Document, ExecutionStrategy, IndexOptions, KeywordField, Schema, SearchRequest,
-  StorageType, TextField,
+  CollapseRequest, Document, ExecutionStrategy, IndexOptions, KeywordField, Query, QueryNode,
+  Schema, SearchRequest, StorageType, TextField,
 };
 use searchlite_core::api::{Filter, Index};
 use searchlite_core::storage::Storage;
@@ -332,4 +332,149 @@ fn concurrent_writers_refresh_manifest_before_commit() {
   let hits_updated = reader.search(&req_updated).unwrap().hits.len();
   assert_eq!(hits_first, 0, "stale writer should tombstone old doc");
   assert_eq!(hits_updated, 1, "new version must be visible");
+}
+
+/// Regression test for the keyword case-folding divergence reported in
+/// davidkelley/searchlite#212.
+///
+/// Before the fix, keyword indexing and `match`/`term` queries lowercased
+/// with `str::to_ascii_lowercase`, which only rewrites the 26 ASCII
+/// uppercase letters and leaves every other byte untouched. The fast-field
+/// filter path (`Filter::KeywordEq`) already used Unicode-aware folding, so
+/// documents whose keyword uppercase form contained non-ASCII code points
+/// (e.g. `RÉSUMÉ`) were matched by the filter but silently missed by the
+/// equivalent `term` query. After the fix both paths go through the shared
+/// `fold_keyword` helper and agree for ASCII and non-ASCII input alike.
+#[test]
+fn keyword_match_and_filter_agree_on_non_ascii_case() {
+  let dir = tempdir().unwrap();
+  let path = dir.path().to_path_buf();
+  let schema = Schema {
+    doc_id_field: "_id".into(),
+    analyzers: Vec::new(),
+    text_fields: vec![TextField {
+      name: "body".into(),
+      analyzer: "default".into(),
+      search_analyzer: None,
+      stored: true,
+      indexed: true,
+      nullable: false,
+      search_as_you_type: None,
+    }],
+    keyword_fields: vec![KeywordField {
+      name: "tag".into(),
+      stored: true,
+      indexed: true,
+      fast: true,
+      nullable: false,
+    }],
+    numeric_fields: Vec::new(),
+    nested_fields: Vec::new(),
+    #[cfg(feature = "vectors")]
+    vector_fields: Vec::new(),
+  };
+  let idx = Index::create(&path, schema, opts(&path)).unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // doc_a's tag lowercases to "résumé" under either ASCII or Unicode folding.
+    writer
+      .add_document(&doc(
+        "doc_a",
+        vec![("body", json!("alpha")), ("tag", json!("Résumé"))],
+      ))
+      .unwrap();
+    // doc_b's tag only lowercases to "résumé" under Unicode folding; ASCII
+    // folding would leave it as "rÉsumÉ". This is the document that the
+    // pre-fix postings path silently missed.
+    writer
+      .add_document(&doc(
+        "doc_b",
+        vec![("body", json!("beta")), ("tag", json!("RÉSUMÉ"))],
+      ))
+      .unwrap();
+    // A Cyrillic control: uppercase ЖУК should match lowercase жук under
+    // Unicode folding and miss under ASCII folding.
+    writer
+      .add_document(&doc(
+        "doc_c",
+        vec![("body", json!("gamma")), ("tag", json!("ЖУК"))],
+      ))
+      .unwrap();
+    writer.commit().unwrap();
+  }
+  let reader = idx.reader().unwrap();
+
+  // Filter path (fast field): both résumé docs match, the beetle does not.
+  let filter_req = SearchRequest {
+    query: Query::Node(QueryNode::MatchAll { boost: None }),
+    filter: Some(Filter::KeywordEq {
+      field: "tag".into(),
+      value: "résumé".into(),
+    }),
+    ..base_request("", None)
+  };
+  let mut filter_ids: Vec<String> = reader
+    .search(&filter_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  filter_ids.sort();
+  assert_eq!(filter_ids, vec!["doc_a".to_string(), "doc_b".to_string()]);
+
+  // Query/postings path (term query over the keyword field): same docs as
+  // the filter path. Before the fix, doc_b was missing from this result set.
+  let term_req = SearchRequest {
+    query: Query::Node(QueryNode::Term {
+      field: "tag".into(),
+      value: "résumé".into(),
+      boost: None,
+    }),
+    ..base_request("", None)
+  };
+  let mut term_ids: Vec<String> = reader
+    .search(&term_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  term_ids.sort();
+  assert_eq!(term_ids, filter_ids);
+
+  // Cyrillic spot-check. Filter and query agree here too.
+  let cyrillic_filter = SearchRequest {
+    query: Query::Node(QueryNode::MatchAll { boost: None }),
+    filter: Some(Filter::KeywordEq {
+      field: "tag".into(),
+      value: "жук".into(),
+    }),
+    ..base_request("", None)
+  };
+  let cyrillic_filter_ids: Vec<String> = reader
+    .search(&cyrillic_filter)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_eq!(cyrillic_filter_ids, vec!["doc_c".to_string()]);
+
+  let cyrillic_query = SearchRequest {
+    query: Query::Node(QueryNode::Term {
+      field: "tag".into(),
+      value: "жук".into(),
+      boost: None,
+    }),
+    ..base_request("", None)
+  };
+  let cyrillic_query_ids: Vec<String> = reader
+    .search(&cyrillic_query)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_eq!(cyrillic_query_ids, cyrillic_filter_ids);
 }


### PR DESCRIPTION
## Summary

Fixes #212.

Keyword indexing and `match`/`term` queries on keyword fields lowercased values with `str::to_ascii_lowercase`, which only rewrites the 26 ASCII uppercase letters and leaves every other byte untouched. The fast-field filter path (`Filter::KeywordEq` / `KeywordIn`) already used Unicode-aware folding via `char::to_lowercase`, so a keyword value whose uppercase form contains non-ASCII code points (e.g. `RÉSUMÉ`, Cyrillic `ЖУК`) was matched by the filter path but silently missed by an equivalent `match`/`term` query on the same field and the same query string.

## Fix

- Introduce `util::case_fold::fold_keyword(&str) -> Cow<'_, str>`, the single source of truth for how keyword values are folded. It keeps the ASCII fast path for the common case (borrowing when the input is already lowercase) and falls through to full Unicode folding via `char::to_lowercase` for non-ASCII input.
- Route all four call sites that previously used `to_ascii_lowercase` for keyword values through the helper:
  - `searchlite-core/src/index/segment.rs` — keyword postings indexing
  - `searchlite-core/src/api/term_expansion.rs` — keyword `match`/term-expansion queries
  - `searchlite-core/src/api/phrase.rs` — keyword phrase terms
  - `searchlite-core/src/api/suggestion.rs` — completion-suggest prefix normalization
- `case_insensitive_equals` in `fastfields.rs` keeps its existing iterator-based Unicode folding — it already agreed with `fold_keyword`'s semantics; both rely on `char::to_lowercase`. Both code paths now produce identical results for ASCII and non-ASCII input alike.

## Test plan

- [x] `cargo test -p searchlite-core --lib --tests` — 429/429 pass, including the new regression test `keyword_match_and_filter_agree_on_non_ascii_case` which indexes `Résumé`, `RÉSUMÉ`, and Cyrillic `ЖУК` and asserts that the fast-field filter and the postings-backed `term` query return the same document sets for lowercase Unicode queries.
- [x] Confirmed the regression test fails (`left: ["doc_a"]`, `right: ["doc_a", "doc_b"]`) if the indexing site is reverted to `to_ascii_lowercase`, so the test demonstrably catches the bug.
- [x] `cargo test --all --all-features` — full workspace green.
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Unit tests on the helper itself cover ASCII borrow, ASCII uppercase lowercasing, Latin-with-diacritics, Cyrillic, Greek (including one-to-many folding for `İ`), and empty input.