### PR TITLE
fix(aggs): apply top_hits from skip after cross-segment merge (BUG-215)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -2132,8 +2132,8 @@ impl<'a> TopHitsCollector<'a> {
     // segment-local rank is `< from` but whose global rank is within the
     // requested `[from, from + size)` page — see BUG-215 for details.
     let mut hits = Vec::with_capacity(ranked.len());
+    let need_doc = self.fields.is_some() || self.highlight_field.is_some();
     for doc in ranked.into_iter() {
-      let need_doc = self.fields.is_some() || self.highlight_field.is_some();
       let fetched = if need_doc {
         self.ctx.segment.get_doc(doc.doc_id).ok()
       } else {

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -2126,10 +2126,13 @@ impl<'a> TopHitsCollector<'a> {
   fn finish(mut self) -> TopHitsState {
     let mut ranked: Vec<RankedDoc> = self.heap.drain().collect();
     ranked.sort_by(|a, b| a.key.cmp(&b.key));
-    let start = self.from.min(ranked.len());
-    let end = (start + self.size).min(ranked.len());
-    let mut hits = Vec::with_capacity(end.saturating_sub(start));
-    for doc in ranked.into_iter().skip(start).take(self.size) {
+    // Keep all top `(from + size)` ranked items for this segment; the final
+    // `from` skip is applied once globally after segments are merged in
+    // `finalize_response`. Applying the skip here would discard items whose
+    // segment-local rank is `< from` but whose global rank is within the
+    // requested `[from, from + size)` page — see BUG-215 for details.
+    let mut hits = Vec::with_capacity(ranked.len());
+    for doc in ranked.into_iter() {
       let need_doc = self.fields.is_some() || self.highlight_field.is_some();
       let fetched = if need_doc {
         self.ctx.segment.get_doc(doc.doc_id).ok()
@@ -2687,8 +2690,11 @@ fn merge_top_hits(target: &mut TopHitsState, incoming: TopHitsState) {
   }
   let mut hits: Vec<_> = heap.into_iter().collect();
   hits.sort_by(|a, b| a.key.cmp(&b.key));
-  let start = target.from.min(hits.len());
-  target.hits = hits.into_iter().skip(start).take(target.size).collect();
+  // Keep the full merged top `(from + size)` window; the `from` skip is
+  // applied once in `finalize_response` so that per-segment items at ranks
+  // `[0, from)` are not discarded before the merge can compare them against
+  // other segments (BUG-215).
+  target.hits = hits;
 }
 
 fn bucket_key_string(key: &serde_json::Value) -> String {
@@ -2933,10 +2939,24 @@ fn finalize_response(intermediate: AggregationIntermediate) -> AggregationRespon
         values: compute_percentile_ranks_from_state(state),
       })
     }
-    AggregationIntermediate::TopHits(state) => AggregationResponse::TopHits(TopHitsResponse {
-      total: state.total,
-      hits: state.hits.into_iter().map(|h| h.hit).collect(),
-    }),
+    AggregationIntermediate::TopHits(state) => {
+      // `state.hits` holds the top `(from + size)` merged hits; apply the
+      // final `from` skip and truncate to `size` to produce the response
+      // page. Doing the skip here (instead of per-segment) ensures items at
+      // segment-local ranks `[0, from)` can still win the global `[from,
+      // from + size)` window after cross-segment merging.
+      let start = state.from.min(state.hits.len());
+      AggregationResponse::TopHits(TopHitsResponse {
+        total: state.total,
+        hits: state
+          .hits
+          .into_iter()
+          .skip(start)
+          .take(state.size)
+          .map(|h| h.hit)
+          .collect(),
+      })
+    }
     AggregationIntermediate::Filter {
       bucket,
       pipeline,

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -1896,3 +1896,213 @@ mod bug_200 {
     );
   }
 }
+
+/// Regression coverage for BUG-215: `top_hits` with `from > 0` on a
+/// multi-segment index must return the globally `from`-th through
+/// `(from + size - 1)`-th best documents.
+///
+/// Before the fix, `TopHitsCollector::finish` dropped items at per-segment
+/// ranks `[0, from)` *before* `merge_top_hits` could compare them across
+/// segments. On a two-segment index that produced an answer drawn from the
+/// per-segment `[from, from + size)` window of each segment, which is not
+/// the same as the global top `(from + size)` window.
+mod bug_215 {
+  use super::*;
+
+  #[test]
+  fn top_hits_from_offset_is_global_across_segments() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_path_buf();
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "score".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      // Segment A: scores 10, 8, 6, 4, 2.
+      for (id, s) in [(1_i64, 10_i64), (2, 8), (3, 6), (4, 4), (5, 2)] {
+        writer
+          .add_document(&doc(
+            &format!("a-{id}"),
+            vec![("body", json!("rust")), ("score", json!(s))],
+          ))
+          .unwrap();
+      }
+      writer.commit().unwrap();
+      // Segment B: scores 9, 7, 5, 3, 1. Separate commit creates a second
+      // segment, which is the precondition for the bug.
+      for (id, s) in [(6_i64, 9_i64), (7, 7), (8, 5), (9, 3), (10, 1)] {
+        writer
+          .add_document(&doc(
+            &format!("b-{id}"),
+            vec![("body", json!("rust")), ("score", json!(s))],
+          ))
+          .unwrap();
+      }
+      writer.commit().unwrap();
+    }
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hits".into(),
+      Aggregation::TopHits(TopHitsAggregation {
+        size: 2,
+        from: 1,
+        fields: Some(vec!["score".into()]),
+        sort: vec![SortSpec {
+          field: "score".into(),
+          order: Some(SortOrder::Desc),
+        }],
+        highlight_field: None,
+      }),
+    );
+
+    let resp = idx
+      .reader()
+      .unwrap()
+      .search(&SearchRequest {
+        query: "rust".into(),
+        fields: None,
+        filter: None,
+        limit: 1,
+        from: 0,
+        return_hits: true,
+        candidate_size: None,
+        #[cfg(feature = "vectors")]
+        max_global_vector_candidates: None,
+        sort: Vec::new(),
+        cursor: None,
+        search_after: None,
+        execution: ExecutionStrategy::Wand,
+        bmw_block_size: None,
+        fuzzy: None,
+        track_total_hits: None,
+        #[cfg(feature = "vectors")]
+        vector_query: None,
+        #[cfg(feature = "vectors")]
+        vector_filter: None,
+        return_stored: false,
+        highlight_field: None,
+        highlight: None,
+        collapse: None,
+        aggs,
+        suggest: BTreeMap::new(),
+        rescore: None,
+        explain: false,
+        profile: false,
+      })
+      .unwrap();
+
+    let agg = resp.aggregations.get("hits").unwrap();
+    if let searchlite_core::api::types::AggregationResponse::TopHits(top_hits) = agg {
+      assert_eq!(top_hits.total, 10);
+      let scores: Vec<_> = top_hits
+        .hits
+        .iter()
+        .map(|h| {
+          h.fields
+            .as_ref()
+            .and_then(|f| f.get("score"))
+            .and_then(|v| v.as_i64())
+            .unwrap()
+        })
+        .collect();
+      // Global sorted order is [10, 9, 8, 7, 6, 5, 4, 3, 2, 1]; skipping
+      // `from = 1` and taking `size = 2` yields [9, 8]. The pre-fix
+      // behaviour returned [7, 6] because segment B's top-ranked doc
+      // (score 9) was discarded by the per-segment `from` skip before the
+      // cross-segment merge ever saw it.
+      assert_eq!(scores, vec![9, 8]);
+    } else {
+      panic!("expected top hits response");
+    }
+  }
+
+  /// Deep `from` (larger than any single segment's per-segment `from`
+  /// window alone) still returns globally-correct results.
+  #[test]
+  fn top_hits_deep_from_across_segments() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_path_buf();
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "score".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      // Segment A: odd scores 1, 3, ..., 19.
+      let odd: Vec<i64> = (1..=19).filter(|s| s % 2 == 1).collect();
+      for s in &odd {
+        writer
+          .add_document(&doc(
+            &format!("a-{s}"),
+            vec![("body", json!("rust")), ("score", json!(*s))],
+          ))
+          .unwrap();
+      }
+      writer.commit().unwrap();
+      // Segment B: even scores 2, 4, ..., 20.
+      let even: Vec<i64> = (2..=20).filter(|s| s % 2 == 0).collect();
+      for s in &even {
+        writer
+          .add_document(&doc(
+            &format!("b-{s}"),
+            vec![("body", json!("rust")), ("score", json!(*s))],
+          ))
+          .unwrap();
+      }
+      writer.commit().unwrap();
+    }
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hits".into(),
+      Aggregation::TopHits(TopHitsAggregation {
+        size: 3,
+        from: 4,
+        fields: Some(vec!["score".into()]),
+        sort: vec![SortSpec {
+          field: "score".into(),
+          order: Some(SortOrder::Desc),
+        }],
+        highlight_field: None,
+      }),
+    );
+
+    let mut req = SearchRequest::new("rust");
+    req.limit = 1;
+    req.aggs = aggs;
+    let resp = idx.reader().unwrap().search(&req).unwrap();
+
+    let agg = resp.aggregations.get("hits").unwrap();
+    if let searchlite_core::api::types::AggregationResponse::TopHits(top_hits) = agg {
+      assert_eq!(top_hits.total, 20);
+      let scores: Vec<_> = top_hits
+        .hits
+        .iter()
+        .map(|h| {
+          h.fields
+            .as_ref()
+            .and_then(|f| f.get("score"))
+            .and_then(|v| v.as_i64())
+            .unwrap()
+        })
+        .collect();
+      // Global descending order is 20, 19, ..., 1. Skipping `from = 4`
+      // and taking `size = 3` yields [16, 15, 14].
+      assert_eq!(scores, vec![16, 15, 14]);
+    } else {
+      panic!("expected top hits response");
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #215.

`top_hits` with `from > 0` on a multi-segment index returned the wrong page. `TopHitsCollector::finish` skipped items at per-segment ranks `[0, from)` **before** `merge_top_hits` could compare them across segments, so items whose segment-local rank was `< from` but whose global rank was within `[from, from + size)` were discarded up front. The merge step then applied the same `from` skip a second time, which could not recover those items even in principle.

Trace of the bug (two segments, `size = 2`, `from = 1`):

- Segment A scores `[10, 8, 6, 4, 2]` → per-segment heap top-3 `[10, 8, 6]` → `finish` skips 1, takes 2 → `[8, 6]`
- Segment B scores `[9, 7, 5, 3, 1]` → per-segment heap top-3 `[9, 7, 5]` → `finish` skips 1, takes 2 → `[7, 5]`
- `merge_top_hits` combines `[8, 6, 7, 5]` into heap top-3 `[8, 7, 6]`, skips 1, takes 2 → **`[7, 6]`**
- Correct global answer (score-desc, skip 1, take 2) is **`[9, 8]`** — but `9` was already gone.

## Fix

Move the `from` skip out of both `TopHitsCollector::finish` and `merge_top_hits`. Both now keep the full top `(from + size)` window. `finalize_response` applies the `from` skip exactly once when converting `TopHitsState` to the public `TopHitsResponse`. The per-segment heap capacity was already `size + from`, so no capacity changes are needed — the only cost is materializing (doc fetch / highlight / field projection) at most `from` extra docs per segment.

Single-segment behaviour is unchanged: `finish` still returns up to `size + from` items, and `finalize_response` trims to the requested page.

## Test plan

- [x] `cargo test -p searchlite-core --tests` — 400+ tests pass, including existing `top_hits_returns_requested_docs` and `top_hits_applies_sort_spec`
- [x] `cargo test -p searchlite-core --lib` — 265 unit tests pass
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New regression tests in `tests/aggregation_bounds.rs::bug_215`:
  - `top_hits_from_offset_is_global_across_segments` — the exact issue repro (two segments, `size=2, from=1`, asserts `[9, 8]`)
  - `top_hits_deep_from_across_segments` — interleaved scores across two segments with deeper `from=4, size=3`, asserts `[16, 15, 14]`