### PR TITLE
fix(fastfields): reject non-UTF-8 field names and dict entries (BUG-217)

### DIFF
--- a/searchlite-core/src/index/fastfields.rs
+++ b/searchlite-core/src/index/fastfields.rs
@@ -3,7 +3,7 @@ use std::io::{BufWriter, Write};
 use std::mem;
 use std::path::Path;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 
 use crate::storage::Storage;
 use crate::DocId;
@@ -1238,7 +1238,16 @@ fn read_fields(data: &[u8]) -> Result<HashMap<String, Column>> {
     if cursor + name_len > data.len() {
       return Err(anyhow!("invalid fast field name length"));
     }
-    let name = String::from_utf8_lossy(&data[cursor..cursor + name_len]).into_owned();
+    // Fast-field names are written from `&str` by `write_field`, so they are
+    // valid UTF-8 by construction. Any non-UTF-8 bytes on disk are therefore
+    // a corruption signal — surface them as a structured error instead of
+    // silently mapping to U+FFFD via `from_utf8_lossy`. Mirrors BUG-010's
+    // fix in `terms.rs::read_terms`; see BUG-217.
+    let name = std::str::from_utf8(&data[cursor..cursor + name_len])
+      .with_context(|| {
+        format!("fast-field file contains non-UTF-8 bytes at offset {cursor} (field name)")
+      })?
+      .to_string();
     cursor += name_len;
     let ty = FieldType::from_u8(read_u8(&mut cursor, data)?)
       .ok_or_else(|| anyhow!("invalid fast field type"))?;
@@ -1420,7 +1429,13 @@ fn read_fields(data: &[u8]) -> Result<HashMap<String, Column>> {
           if cursor + slen > data.len() {
             return Err(anyhow!("unexpected end of fast field dict"));
           }
-          let s = String::from_utf8_lossy(&data[cursor..cursor + slen]).into_owned();
+          let s = std::str::from_utf8(&data[cursor..cursor + slen])
+            .with_context(|| {
+              format!(
+                "fast-field file contains non-UTF-8 bytes at offset {cursor} (Str dict entry)"
+              )
+            })?
+            .to_string();
           cursor += slen;
           dict.push(s);
         }
@@ -1451,7 +1466,13 @@ fn read_fields(data: &[u8]) -> Result<HashMap<String, Column>> {
           if cursor + slen > data.len() {
             return Err(anyhow!("unexpected end of fast field dict"));
           }
-          let s = String::from_utf8_lossy(&data[cursor..cursor + slen]).into_owned();
+          let s = std::str::from_utf8(&data[cursor..cursor + slen])
+            .with_context(|| {
+              format!(
+                "fast-field file contains non-UTF-8 bytes at offset {cursor} (StrList dict entry)"
+              )
+            })?
+            .to_string();
           cursor += slen;
           dict.push(s);
         }
@@ -1491,7 +1512,13 @@ fn read_fields(data: &[u8]) -> Result<HashMap<String, Column>> {
           if cursor + slen > data.len() {
             return Err(anyhow!("unexpected end of fast field dict"));
           }
-          let s = String::from_utf8_lossy(&data[cursor..cursor + slen]).into_owned();
+          let s = std::str::from_utf8(&data[cursor..cursor + slen])
+            .with_context(|| {
+              format!(
+                "fast-field file contains non-UTF-8 bytes at offset {cursor} (StrNested dict entry)"
+              )
+            })?
+            .to_string();
           cursor += slen;
           dict.push(s);
         }
@@ -1888,6 +1915,121 @@ mod tests {
     field_prefix(&mut buf, FieldType::NestedParent, 0);
     buf.extend_from_slice(&u32::MAX.to_le_bytes()); // offsets[0]
     assert_capacity_rejected(read_fields(&buf).unwrap_err());
+  }
+
+  // --- Non-UTF-8 corruption regression tests (BUG-217) ---
+  //
+  // `write_field` always emits field names and string-dictionary entries from
+  // Rust `&str` values, which are valid UTF-8 by construction. Any non-UTF-8
+  // bytes observed by `read_fields` are therefore a corruption signal. Each
+  // test below hand-crafts a minimal `FFV1` buffer whose only corruption is
+  // an ill-formed UTF-8 sequence at one of the four affected sites and
+  // asserts that `read_fields` surfaces a structured error (preserving the
+  // underlying `Utf8Error`) rather than silently mapping to `U+FFFD`. The
+  // sequence `[0xC3, 0x28, 0xA0]` is rejected by strict UTF-8 decoding
+  // because `0xC3` is a 2-byte lead that requires a continuation byte in
+  // `0x80..=0xBF`, and `0x28` falls outside that range.
+  const INVALID_UTF8: [u8; 3] = [0xC3, 0x28, 0xA0];
+
+  fn assert_non_utf8_rejected(err: anyhow::Error, label: &str) {
+    let msg = format!("{err:#}");
+    assert!(
+      msg.contains("non-UTF-8 bytes"),
+      "expected non-UTF-8 error for {label}, got: {msg}"
+    );
+    assert!(
+      msg.contains(label),
+      "expected error for {label} to mention the label, got: {msg}"
+    );
+    // Preserve the underlying `Utf8Error` in the chain so operators can
+    // identify the low-level cause without relying on message text.
+    assert!(
+      err.chain().any(|cause| cause.is::<std::str::Utf8Error>()),
+      "expected Utf8Error in error chain for {label}, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn read_fields_rejects_non_utf8_field_name() {
+    let mut buf = header_with(1);
+    buf.extend_from_slice(&(INVALID_UTF8.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&INVALID_UTF8);
+    // The `checked_count` guard at the top of the field loop enforces a
+    // 9-byte minimum stride per field (4-byte name length + 0 bytes name
+    // + 1-byte type tag + 4-byte doc_len), so append a type byte and a
+    // `doc_len` of zero to satisfy it. The buffer still reaches the UTF-8
+    // check before any of those trailing bytes are consumed.
+    buf.push(FieldType::I64.as_u8());
+    buf.extend_from_slice(&0u32.to_le_bytes());
+    assert_non_utf8_rejected(read_fields(&buf).unwrap_err(), "field name");
+  }
+
+  /// Push an empty-name `Str`/`StrList`/`StrNested` field header whose
+  /// dictionary contains a single entry with non-UTF-8 bytes. The loop
+  /// rejects the entry before any `doc_len`-sized allocation matters, so
+  /// `doc_len = 0` keeps the buffer minimal.
+  fn push_str_field_with_invalid_dict_entry(buf: &mut Vec<u8>, ty: FieldType) {
+    field_prefix(buf, ty, 0);
+    buf.extend_from_slice(&1u32.to_le_bytes()); // dict_len = 1
+    buf.extend_from_slice(&(INVALID_UTF8.len() as u32).to_le_bytes());
+    buf.extend_from_slice(&INVALID_UTF8);
+  }
+
+  #[test]
+  fn read_fields_rejects_non_utf8_str_dict_entry() {
+    let mut buf = header_with(1);
+    push_str_field_with_invalid_dict_entry(&mut buf, FieldType::Str);
+    assert_non_utf8_rejected(read_fields(&buf).unwrap_err(), "Str dict entry");
+  }
+
+  #[test]
+  fn read_fields_rejects_non_utf8_str_list_dict_entry() {
+    let mut buf = header_with(1);
+    push_str_field_with_invalid_dict_entry(&mut buf, FieldType::StrList);
+    assert_non_utf8_rejected(read_fields(&buf).unwrap_err(), "StrList dict entry");
+  }
+
+  #[test]
+  fn read_fields_rejects_non_utf8_str_nested_dict_entry() {
+    let mut buf = header_with(1);
+    push_str_field_with_invalid_dict_entry(&mut buf, FieldType::StrNested);
+    assert_non_utf8_rejected(read_fields(&buf).unwrap_err(), "StrNested dict entry");
+  }
+
+  /// End-to-end variant: round-trip a valid `Str` column through
+  /// `FastFieldsWriter` + `FastFieldsReader::open`, mutate the on-disk
+  /// dictionary entry to be ill-formed UTF-8, and confirm the reader
+  /// surfaces the corruption instead of returning a `U+FFFD`-substituted
+  /// column. Mirrors `terms::tests::invalid_utf8_term_errors`.
+  #[test]
+  fn open_rejects_non_utf8_str_dict_entry_on_disk() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("fast.ff");
+    let storage = crate::storage::FsStorage::new(dir.path().to_path_buf());
+
+    let mut writer = FastFieldsWriter::new();
+    writer.set("tag", 0, FastValue::Str("valid".into()));
+    writer.write_to(&storage, &path).unwrap();
+
+    // The writer emits the ASCII `valid` byte sequence verbatim into the
+    // dictionary; find and overwrite its leading byte with the start of a
+    // 2-byte UTF-8 sequence so the entry is no longer valid UTF-8.
+    let mut bytes = std::fs::read(&path).unwrap();
+    let needle = b"valid";
+    let idx = bytes
+      .windows(needle.len())
+      .position(|w| w == needle)
+      .expect("expected ASCII dict entry in on-disk buffer");
+    bytes[idx] = 0xC3;
+    std::fs::write(&path, bytes).unwrap();
+
+    // `FastFieldsReader` does not implement `Debug`, so `.unwrap_err()` is
+    // not available here — match the `Result` explicitly.
+    let err = match FastFieldsReader::open(&storage, &path) {
+      Ok(_) => panic!("expected non-UTF-8 error, got Ok"),
+      Err(e) => e,
+    };
+    assert_non_utf8_rejected(err, "Str dict entry");
   }
 
   #[test]


### PR DESCRIPTION
## Summary

`searchlite-core/src/index/fastfields.rs::read_fields` decoded four distinct UTF-8 payloads with `String::from_utf8_lossy(...).into_owned()`: the fast-field name in the `FFV1` header (`fastfields.rs:1241`), and the dictionary entries for `Str` (`:1423`), `StrList` (`:1454`), and `StrNested` (`:1494`) columns. Ill-formed bytes were silently replaced with `U+FFFD` rather than surfaced as an error. Because `write_field` always emits those payloads from Rust `&str` values, non-UTF-8 bytes on disk are — by the `String` invariant — a corruption signal. The lossy decode would quietly produce wrong keys in the in-memory column, so filters, aggregations, and collapses keyed by the real (valid) value would silently miss documents with no error reported.

This is the same reasoning BUG-010 used for `read_terms` (terms.rs); the fastfields call sites were simply not updated at the time.

Fixes #217.

## Changes

- Replace each of the four `from_utf8_lossy` sites with strict `std::str::from_utf8(...).with_context(...)?.to_string()`, mirroring the BUG-010 fix. Error messages name the byte offset and which payload failed (`field name`, `Str dict entry`, `StrList dict entry`, `StrNested dict entry`).
- Import `anyhow::Context` alongside the existing `anyhow` / `Result` imports.

## Tests

Added five regression tests:

- `read_fields_rejects_non_utf8_field_name` — hand-crafted `FFV1` buffer with an invalid UTF-8 sequence in the field name.
- `read_fields_rejects_non_utf8_str_dict_entry` / `_str_list_dict_entry` / `_str_nested_dict_entry` — dictionary entry at each of the three column sites.
- `open_rejects_non_utf8_str_dict_entry_on_disk` — end-to-end: round-trip a valid `Str` column through `FastFieldsWriter` + `FastFieldsReader::open`, overwrite the leading byte of the on-disk dict entry with `0xC3` (a 2-byte UTF-8 lead with no valid continuation), and confirm `open` errors instead of returning a `U+FFFD`-substituted column.

Each assertion checks both the structured error message and that a `std::str::Utf8Error` is preserved in the error chain.

## Test plan

- [x] `cargo test -p searchlite-core --lib index::fastfields` — 25/25 pass locally.
- [x] `cargo test --all --all-features` — full workspace green.
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.