### PR TITLE
fix(http): drop path from /indexes response (BUG-219)

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -318,7 +318,7 @@ curl -s http://localhost:8080/healthz
 curl -s http://localhost:8080/indexes
 # -> {
 #      "indexes": [
-#        { "name": "products", "path": "/data/products", "exists": true,
+#        { "name": "products", "exists": true,
 #          "doc_count": 1042, "committed_at": "2025-01-03T12:01:04Z",
 #          "auto_commit_secs": 0, "auto_refresh_secs": 0,
 #          "refresh_on_commit": false }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -25,7 +25,7 @@ paths:
       summary: List configured indexes and aliases
       responses:
         "200":
-          description: Names and on-disk paths for mounted indexes
+          description: Names and runtime metadata for mounted indexes
           content:
             application/json:
               schema:
@@ -449,8 +449,6 @@ components:
       properties:
         name:
           type: string
-        path:
-          type: string
         exists:
           type: boolean
         committed_at:
@@ -471,7 +469,6 @@ components:
       required:
         [
           name,
-          path,
           exists,
           auto_commit_secs,
           auto_refresh_secs,

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -370,7 +370,6 @@ impl ManagedIndex {
 
     Ok(IndexDescriptor {
       name: self.name.clone(),
-      path: self.path.display().to_string(),
       exists,
       committed_at,
       doc_count,
@@ -838,10 +837,13 @@ struct HealthResponse {
   status: String,
 }
 
+// Note: `path` was removed from this descriptor as a Security fix (BUG-219),
+// mirroring the BUG-015 fix to `StatsResponse`. The on-disk filesystem path of
+// an index is an operator-side implementation detail and must not be exposed
+// to unauthenticated callers of `/indexes`.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct IndexDescriptor {
   name: String,
-  path: String,
   exists: bool,
   committed_at: Option<String>,
   doc_count: Option<u64>,
@@ -2720,6 +2722,107 @@ mod tests {
     assert_eq!(stats["index_name"], INDEX_NAME);
     assert!(stats["index_uuid"].as_str().is_some());
     assert_eq!(stats["documents"], 1);
+
+    handle.abort();
+    let _ = handle.await;
+  }
+
+  // Regression test for BUG-219: the public `/indexes` endpoint must not leak
+  // the on-disk filesystem path of any mounted index. This mirrors BUG-015,
+  // which removed the same field from `/stats`. Read-side endpoints are
+  // unauthenticated by design, so the response surface is restricted to
+  // operator-chosen logical identifiers and aggregate counts.
+  #[tokio::test]
+  async fn list_indexes_response_does_not_expose_filesystem_path() {
+    init_tracing();
+    let dir = tempdir().unwrap();
+    let index_path = dir.path().join("idx-list-no-path");
+    let (client, base, index_base, handle, _state, _args) = setup_server(index_path.clone()).await;
+
+    // Walk the parsed JSON and check string values directly so we are not
+    // tricked by JSON escaping (e.g. Windows backslashes are doubled in the
+    // raw serialized form, which would let a regression slip past a naive
+    // substring check on the wire bytes).
+    fn json_contains_string_value(value: &serde_json::Value, target: &str) -> bool {
+      match value {
+        serde_json::Value::String(s) => s == target,
+        serde_json::Value::Array(values) => values
+          .iter()
+          .any(|value| json_contains_string_value(value, target)),
+        serde_json::Value::Object(map) => map
+          .values()
+          .any(|value| json_contains_string_value(value, target)),
+        _ => false,
+      }
+    }
+
+    let fs_path_str = index_path.display().to_string();
+
+    // Pre-init: descriptor still must not carry the path.
+    let before: serde_json::Value = client
+      .get(format!("{base}/indexes"))
+      .send()
+      .await
+      .unwrap()
+      .json()
+      .await
+      .unwrap();
+    let first_before = before["indexes"][0]
+      .as_object()
+      .expect("descriptor is a JSON object");
+    assert!(
+      !first_before.contains_key("path"),
+      "indexes response must not include `path` (leaks FS layout): {first_before:?}"
+    );
+    assert!(
+      !json_contains_string_value(&before, fs_path_str.as_str()),
+      "indexes response must not contain the raw index filesystem path: {before:?}"
+    );
+
+    // Post-init/commit: descriptor still must not carry the path even after
+    // the on-disk index has materialized.
+    client
+      .post(format!("{index_base}/init"))
+      .json(&Schema::default_text_body())
+      .send()
+      .await
+      .unwrap();
+    client
+      .post(format!("{index_base}/add"))
+      .body("{\"_id\":\"1\",\"body\":\"doc\"}\n")
+      .send()
+      .await
+      .unwrap();
+    client
+      .post(format!("{index_base}/commit"))
+      .send()
+      .await
+      .unwrap();
+
+    let after: serde_json::Value = client
+      .get(format!("{base}/indexes"))
+      .send()
+      .await
+      .unwrap()
+      .json()
+      .await
+      .unwrap();
+    let first_after = after["indexes"][0]
+      .as_object()
+      .expect("descriptor is a JSON object");
+    assert!(
+      !first_after.contains_key("path"),
+      "indexes response must not include `path` (leaks FS layout): {first_after:?}"
+    );
+    assert!(
+      !json_contains_string_value(&after, fs_path_str.as_str()),
+      "indexes response must not contain the raw index filesystem path: {after:?}"
+    );
+
+    // Sanity: the public fields are still present.
+    assert_eq!(first_after["name"], INDEX_NAME);
+    assert_eq!(first_after["exists"], true);
+    assert_eq!(first_after["doc_count"], 1);
 
     handle.abort();
     let _ = handle.await;


### PR DESCRIPTION
## Summary

Fixes #219.

The public `/indexes` handler (`searchlite-http/src/lib.rs:1076-1082`) serialized `self.path.display().to_string()` into every response as `IndexDescriptor.path`. `/indexes` is a read-side endpoint and does not require the `x-write-key` header, so a read-only caller — including an unauthenticated one in deployments that gate only writes — could retrieve the absolute on-disk filesystem path of every named index.

This is the same information-disclosure pattern that BUG-015 / PR #178 removed from `/stats`. The sibling `/indexes` endpoint was missed at the time, and the OpenAPI schema continued to advertise the leak. In multi-tenant hosts where the operator namespaces indexes by customer in the path, the leaked string is enough to enumerate tenant directories and confirm mount-point / container topology. Public responses should only surface operator-chosen logical identifiers (`name`) and aggregate counts — the filesystem layout belongs in operator tooling and logs.

## Changes

- `searchlite-http/src/lib.rs`
  - Remove `path` from the `IndexDescriptor` struct and stop populating it in `ManagedIndex::describe()`. Add a note explaining why the field cannot return.
  - Add `list_indexes_response_does_not_expose_filesystem_path` — a regression test that asserts the `/indexes` body contains neither the `path` key nor the raw temp-dir path string, both before init and after the index has materialized on disk. The check walks the parsed JSON value-by-value to avoid being fooled by escaping quirks (e.g. doubled backslashes on Windows).
- `openapi.yaml` — drop `path` from the `IndexDescriptor` schema and from the `required` list, and reword the response description so it no longer claims to return on-disk paths.
- `docs/http.md` — drop `path` from the `/indexes` example response so the documented shape matches what the server actually returns.

The existing test `list_indexes_exposes_runtime_metadata` already only asserts on the public fields, so it required no changes. No other consumers (CLI, integration harness, WASM bindings) read `IndexDescriptor.path`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`
- [x] `cargo test -p searchlite-http --lib` — 48 passed, including the new `list_indexes_response_does_not_expose_filesystem_path`
- [x] Integration test crate compiles cleanly
- [x] Visual diff review against `openapi.yaml` ensures `required` stays consistent and the `IndexDescriptor` schema matches the wire format