### PR TITLE
fix(aggs): bound moving_avg predict against unbounded allocation (BUG-221)

### DIFF
--- a/search-request.schema.json
+++ b/search-request.schema.json
@@ -426,8 +426,8 @@
       "properties": {
         "type": { "const": "moving_avg" },
         "buckets_path": { "type": "string", "description": "Metric path to average." },
-        "window": { "type": "integer", "minimum": 1 },
-        "predict": { "type": "integer", "minimum": 0 },
+        "window": { "type": "integer", "minimum": 1, "maximum": 10000 },
+        "predict": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Forecast horizon in buckets. Capped server-side to bound response memory." },
         "gap_policy": { "type": "string", "enum": ["skip", "insert_zeros"] }
       }
     },

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::api::types::{
   Aggregation, AggregationResponse, AggregationSampling, DateHistogramAggregation, Filter,
-  HistogramAggregation, IndexOptions, MgetDoc, Query, RescoreMode, RescoreRequest, SearchRequest,
-  SortOrder, SuggestResult,
+  HistogramAggregation, IndexOptions, MgetDoc, MovingAvgAggregation, Query, RescoreMode,
+  RescoreRequest, SearchRequest, SortOrder, SuggestResult,
 };
 #[cfg(feature = "vectors")]
 use crate::api::types::{LegacyVectorQuery, VectorQuery, VectorQuerySpec};
@@ -2381,8 +2381,8 @@ fn validate_aggregations_in_scope(
       | Aggregation::AvgBucket(_)
       | Aggregation::SumBucket(_)
       | Aggregation::Derivative(_)
-      | Aggregation::MovingAvg(_)
       | Aggregation::BucketScript(_) => {}
+      Aggregation::MovingAvg(m) => validate_moving_avg_config(name, m)?,
       Aggregation::TopHits(t) => {
         SortPlan::from_request(schema, &t.sort)
           .with_context(|| format!("invalid top_hits sort in aggregation `{name}`"))?;
@@ -2840,6 +2840,52 @@ fn validate_sampling(name: &str, sampling: &Option<AggregationSampling>) -> Resu
         AggregationError::InvalidConfig {
           reason: format!(
             "aggregation `{name}` sampling seed requires size or probability to be set"
+          ),
+        }
+        .into(),
+      );
+    }
+  }
+  Ok(())
+}
+
+/// Reject `moving_avg` requests that would let untrusted input drive an unbounded
+/// `Vec<f64>` allocation in the response finalization step (BUG-221).
+///
+/// `predict` is fed straight into `vec![last_avg; predict]` inside
+/// `apply_moving_avg_pipeline`; without this gate a tiny request body (well under
+/// the HTTP body cap) can request multi-gigabyte allocations and OOM the process.
+/// We also bound `window` to the same ceiling so a runaway value cannot mask
+/// other validation failures or surprise future maintainers, even though `window`
+/// is not itself a direct allocation source today.
+fn validate_moving_avg_config(name: &str, agg: &MovingAvgAggregation) -> Result<()> {
+  if agg.window == 0 {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!("moving_avg `{name}` requires window >= 1 (got 0)"),
+      }
+      .into(),
+    );
+  }
+  if agg.window > crate::query::aggs::MAX_BUCKETS {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!(
+          "moving_avg `{name}` window {} exceeds limit {}",
+          agg.window,
+          crate::query::aggs::MAX_BUCKETS
+        ),
+      }
+      .into(),
+    );
+  }
+  if let Some(predict) = agg.predict {
+    if predict > crate::query::aggs::MAX_PREDICTIONS {
+      return Err(
+        AggregationError::InvalidConfig {
+          reason: format!(
+            "moving_avg `{name}` predict {predict} exceeds limit {}",
+            crate::query::aggs::MAX_PREDICTIONS
           ),
         }
         .into(),

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -42,6 +42,14 @@ pub struct AggregationContext<'a> {
 /// still allowing thousands of buckets. Deployments that need a different limit can adjust this
 /// constant at compile time.
 pub(crate) const MAX_BUCKETS: usize = 10_000;
+/// Upper bound on the number of forecast points a single `moving_avg` pipeline may emit.
+///
+/// `predict` controls a `Vec<f64>` allocation in [`apply_moving_avg_pipeline`] sized directly by
+/// untrusted user input (BUG-221). Without a cap, a tiny request body can drive an unbounded heap
+/// allocation during response finalization. We share the same `10_000` ceiling as `MAX_BUCKETS`
+/// so the forecast horizon never grows past the materialization budget for any other bucketing
+/// aggregation in the same request.
+pub(crate) const MAX_PREDICTIONS: usize = MAX_BUCKETS;
 const TDIGEST_MAX_SIZE: usize = 200;
 const PERCENTILE_EXACT_LIMIT: usize = 256;
 
@@ -3163,6 +3171,11 @@ fn apply_moving_avg_pipeline(
   let mut predictions = Vec::new();
   if let Some(predict) = cfg.predict {
     if let Some(last_avg) = avgs.last().and_then(|v| *v) {
+      // Defense-in-depth: clamp `predict` to `MAX_PREDICTIONS` so an internal caller
+      // that bypasses `validate_aggregations_in_scope` cannot drive an unbounded
+      // allocation here (BUG-221). The request validator rejects values past the cap
+      // up-front; this `min` is just a hard ceiling on the materialization step.
+      let predict = predict.min(MAX_PREDICTIONS);
       // Simple forecast that repeats the last observed average to avoid feedback loops.
       predictions = vec![last_avg; predict];
     }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3140,6 +3140,15 @@ fn apply_moving_avg_pipeline(
   let series = bucket_metric_series(buckets, &cfg.buckets_path);
   let policy = cfg.gap_policy.unwrap_or(GapPolicy::Skip);
   let mut window_values: VecDeque<f64> = VecDeque::new();
+  // The request validator rejects `window = 0` (BUG-221) so this is the documented
+  // precondition; assert it loudly in dev/test builds. The `.max(1)` survives as a
+  // production safety net so an internal caller that bypasses validation still gets
+  // a windowed average rather than the deque growing unboundedly to `buckets.len()`.
+  debug_assert!(
+    cfg.window >= 1,
+    "moving_avg window must be >= 1; got {}",
+    cfg.window
+  );
   let window = cfg.window.max(1);
   let mut avgs = Vec::with_capacity(buckets.len());
   for (idx, bucket) in buckets.iter_mut().enumerate() {

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -5,8 +5,8 @@ use searchlite_core::api::builder::IndexBuilder;
 use searchlite_core::api::types::{
   Aggregation, CompositeAggregation, CompositeSource, DateHistogramAggregation,
   DateHistogramBounds, Document, ExecutionStrategy, HistogramAggregation, HistogramBounds,
-  IndexOptions, KeywordField, MetricAggregation, NumericField, Schema, SearchRequest, SortOrder,
-  SortSpec, StorageType, TermsAggregation, TopHitsAggregation,
+  IndexOptions, KeywordField, MetricAggregation, MovingAvgAggregation, NumericField, Schema,
+  SearchRequest, SortOrder, SortSpec, StorageType, TermsAggregation, TopHitsAggregation,
 };
 use searchlite_core::api::Index;
 use serde_json::json;
@@ -1893,6 +1893,182 @@ mod bug_200 {
     assert!(
       elapsed < Duration::from_secs(5),
       "pathological date_histogram must not loop: took {elapsed:?}"
+    );
+  }
+}
+
+/// Regression tests for BUG-221 — `MovingAvgAggregation::predict` is fed
+/// straight into `vec![last_avg; predict]` inside `apply_moving_avg_pipeline`.
+/// Without a request-time bound, a tiny request body (well under the HTTP
+/// 50 MiB cap) could request multi-gigabyte allocations during response
+/// finalization and OOM the server.
+mod bug_221 {
+  use super::*;
+  use searchlite_core::api::types::GapPolicy;
+
+  fn views_index(path: &std::path::Path) -> searchlite_core::api::Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "n".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = Index::create(path, schema, build_base_options(path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      // Two docs in distinct histogram buckets so the bucketing agg has at
+      // least one non-empty bucket — the precondition for the `predict`
+      // branch in `apply_moving_avg_pipeline` to allocate.
+      writer
+        .add_document(&doc(
+          "a",
+          vec![("body", json!("rust")), ("n", json!(1_i64))],
+        ))
+        .unwrap();
+      writer
+        .add_document(&doc(
+          "b",
+          vec![("body", json!("rust")), ("n", json!(2_i64))],
+        ))
+        .unwrap();
+      writer.commit().unwrap();
+    }
+    idx
+  }
+
+  fn moving_avg_request(predict: Option<usize>, window: usize) -> BTreeMap<String, Aggregation> {
+    let mut hist_aggs = BTreeMap::new();
+    hist_aggs.insert(
+      "mov".into(),
+      Aggregation::MovingAvg(MovingAvgAggregation {
+        buckets_path: "_count".into(),
+        window,
+        predict,
+        gap_policy: Some(GapPolicy::Skip),
+      }),
+    );
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "n".into(),
+        interval: 1.0,
+        offset: None,
+        min_doc_count: Some(0),
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: hist_aggs,
+      })),
+    );
+    aggs
+  }
+
+  fn search_with_agg(
+    idx: &searchlite_core::api::Index,
+    aggs: BTreeMap<String, Aggregation>,
+  ) -> anyhow::Result<()> {
+    let mut req = SearchRequest::new("rust");
+    req.aggs = aggs;
+    idx.reader().unwrap().search(&req)?;
+    Ok(())
+  }
+
+  #[test]
+  fn huge_predict_is_rejected_without_allocation() {
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = views_index(tmp.path());
+
+    // ~8 GiB of `f64` if it ever reached `vec![..; predict]`.
+    let aggs = moving_avg_request(Some(1_073_741_824), 1);
+
+    let start = Instant::now();
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("moving_avg with predict above MAX_PREDICTIONS must be rejected");
+    let elapsed = start.elapsed();
+    let msg = err.to_string();
+    assert!(
+      msg.contains("predict") && msg.contains("exceeds limit"),
+      "expected predict-bound error, got: {msg}"
+    );
+    // The validator runs before any allocation; rejection must be effectively
+    // instantaneous, never paying the cost of `vec![..; predict]`.
+    assert!(
+      elapsed < Duration::from_secs(2),
+      "moving_avg validation must reject quickly without allocating: took {elapsed:?}"
+    );
+  }
+
+  #[test]
+  fn predict_just_above_cap_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = views_index(tmp.path());
+
+    // `MAX_PREDICTIONS` is 10_000; exercise the strict `>` boundary.
+    let aggs = moving_avg_request(Some(10_001), 1);
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("predict = MAX_PREDICTIONS + 1 must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("predict") && msg.contains("10001"),
+      "expected predict bound error mentioning the offending value, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn predict_at_cap_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = views_index(tmp.path());
+
+    // 10_000 forecast points of an `f64` is ~80 KiB — well within budget and
+    // intentionally accepted so legitimate clients keep working.
+    let aggs = moving_avg_request(Some(10_000), 1);
+    search_with_agg(&idx, aggs).expect("predict at the cap must be accepted");
+  }
+
+  #[test]
+  fn small_predict_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = views_index(tmp.path());
+
+    let aggs = moving_avg_request(Some(3), 2);
+    search_with_agg(&idx, aggs).expect("typical predict values must be accepted");
+  }
+
+  #[test]
+  fn huge_window_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = views_index(tmp.path());
+
+    // `window` is not itself an unbounded allocation today, but a runaway
+    // value is meaningless and must be rejected so future maintainers cannot
+    // accidentally turn it into one.
+    let aggs = moving_avg_request(None, 1_000_000);
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("moving_avg window above MAX_BUCKETS must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("window") && msg.contains("exceeds limit"),
+      "expected window-bound error, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn zero_window_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = views_index(tmp.path());
+
+    let aggs = moving_avg_request(None, 0);
+    let err = search_with_agg(&idx, aggs).expect_err("window = 0 must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("window") && msg.contains(">= 1"),
+      "expected zero-window error, got: {msg}"
     );
   }
 }

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2011,8 +2011,8 @@ mod bug_221 {
 
     // `MAX_PREDICTIONS` is 10_000; exercise the strict `>` boundary.
     let aggs = moving_avg_request(Some(10_001), 1);
-    let err = search_with_agg(&idx, aggs)
-      .expect_err("predict = MAX_PREDICTIONS + 1 must be rejected");
+    let err =
+      search_with_agg(&idx, aggs).expect_err("predict = MAX_PREDICTIONS + 1 must be rejected");
     let msg = err.to_string();
     assert!(
       msg.contains("predict") && msg.contains("10001"),


### PR DESCRIPTION
## Summary

`apply_moving_avg_pipeline` allocated `vec![last_avg; predict]` directly from request input. A request body well under the 50 MiB HTTP cap, with `predict: 1_073_741_824`, would request ~8 GiB of contiguous heap during response finalization and OOM the server. The validator arm for pipeline aggregations was a no-op, so nothing between request parse and response finalization bounded the allocation.

This closes BUG-221 (#221).

## What changed

- **Reject** `moving_avg` configs whose `predict` exceeds `MAX_PREDICTIONS` (10_000, the same ceiling as `MAX_BUCKETS`) up-front in `validate_aggregations_in_scope` — fail fast with a clear error message rather than allocating.
- **Defense-in-depth**: clamp `predict` inside `apply_moving_avg_pipeline` so an internal caller that bypasses validation cannot drive an unbounded allocation either.
- **Bound `window`** at the same gate. Not currently a direct allocation source (the deque tops out at `buckets.len()` regardless), but runaway values are meaningless and easy to bound here so a future maintainer cannot accidentally turn it into one.
- **Reject `window = 0`** — surfaces the prior `.max(1)` silent coercion as an error so requests don't get a quietly-different result than they asked for.
- Update `search-request.schema.json` to publish the new ceilings (`maximum: 10000` on both `predict` and `window`).

## Test plan

- [x] New `bug_221` module in `searchlite-core/tests/aggregation_bounds.rs` covering:
  - `huge_predict_is_rejected_without_allocation` — the original PoC payload (`predict = 1_073_741_824`); also asserts elapsed time < 2s so an accidental reintroduction of `vec![..; predict]` is caught.
  - `predict_just_above_cap_is_rejected` — strict `>` boundary at `MAX_PREDICTIONS + 1`.
  - `predict_at_cap_is_accepted` — the cap itself is allowed (legitimate clients keep working).
  - `small_predict_is_accepted` — typical small values still work.
  - `huge_window_is_rejected` — runaway `window` is caught.
  - `zero_window_is_rejected` — `window = 0` now surfaces an error instead of being silently coerced to 1.
- [x] `cargo test -p searchlite-core --test aggregation_bounds` — 38/38 pass (was 32/32 before)
- [x] `cargo test -p searchlite-core --test aggregations` — 38/38 pass
- [x] `cargo test -p searchlite-core --lib` — 277/277 pass
- [x] `cargo build --workspace` — clean
- [x] `cargo clippy -p searchlite-core --tests` — clean