### PR TITLE
fix(aggs): bound top_hits size and from against unbounded allocation (BUG-222)

### DIFF
--- a/search-request.schema.json
+++ b/search-request.schema.json
@@ -338,8 +338,8 @@
       "additionalProperties": false,
       "properties": {
         "type": { "const": "top_hits" },
-        "size": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Per-segment hits to retain. Capped server-side to bound the per-segment heap; `size + from` must also stay within the cap." },
-        "from": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Offset into the merged hit list. Capped server-side to bound the per-segment heap; `size + from` must also stay within the cap." },
+        "size": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Per-segment hits to retain. Must be <= 10000; requests exceeding this limit are rejected server-side. `size + from` must also stay within the cap." },
+        "from": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Offset into the merged hit list. Must be <= 10000; requests exceeding this limit are rejected server-side. `size + from` must also stay within the cap." },
         "fields": { "type": "array", "items": { "type": "string" } },
         "sort": { "type": "array", "items": { "$ref": "#/$defs/sort_spec" }, "default": [] },
         "highlight_field": { "type": "string" }

--- a/search-request.schema.json
+++ b/search-request.schema.json
@@ -338,8 +338,8 @@
       "additionalProperties": false,
       "properties": {
         "type": { "const": "top_hits" },
-        "size": { "type": "integer", "minimum": 0 },
-        "from": { "type": "integer", "minimum": 0 },
+        "size": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Per-segment hits to retain. Capped server-side to bound the per-segment heap; `size + from` must also stay within the cap." },
+        "from": { "type": "integer", "minimum": 0, "maximum": 10000, "description": "Offset into the merged hit list. Capped server-side to bound the per-segment heap; `size + from` must also stay within the cap." },
         "fields": { "type": "array", "items": { "type": "string" } },
         "sort": { "type": "array", "items": { "$ref": "#/$defs/sort_spec" }, "default": [] },
         "highlight_field": { "type": "string" }

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use crate::api::types::{
   Aggregation, AggregationResponse, AggregationSampling, DateHistogramAggregation, Filter,
   HistogramAggregation, IndexOptions, MgetDoc, MovingAvgAggregation, Query, RescoreMode,
-  RescoreRequest, SearchRequest, SortOrder, SuggestResult,
+  RescoreRequest, SearchRequest, SortOrder, SuggestResult, TopHitsAggregation,
 };
 #[cfg(feature = "vectors")]
 use crate::api::types::{LegacyVectorQuery, VectorQuery, VectorQuerySpec};
@@ -2383,10 +2383,7 @@ fn validate_aggregations_in_scope(
       | Aggregation::Derivative(_)
       | Aggregation::BucketScript(_) => {}
       Aggregation::MovingAvg(m) => validate_moving_avg_config(name, m)?,
-      Aggregation::TopHits(t) => {
-        SortPlan::from_request(schema, &t.sort)
-          .with_context(|| format!("invalid top_hits sort in aggregation `{name}`"))?;
-      }
+      Aggregation::TopHits(t) => validate_top_hits_config(schema, name, t)?,
     }
   }
   Ok(())
@@ -2891,6 +2888,59 @@ fn validate_moving_avg_config(name: &str, agg: &MovingAvgAggregation) -> Result<
         .into(),
       );
     }
+  }
+  Ok(())
+}
+
+/// Reject `top_hits` requests that would let untrusted input drive an unbounded
+/// `BinaryHeap<RankedDoc>` allocation in the per-segment collector (BUG-222).
+///
+/// `size` and `from` are forwarded directly into `TopHitsCollector::new` and used
+/// to size the per-segment heap (`size + from`). Without a request-time gate, a
+/// tiny request body can ask for `size = 10_000_000_000` and OOM the process as
+/// the heap grows during collection. We reject `size`, `from`, and the saturating
+/// sum independently so the error message names the offending dimension and so
+/// the additive case (`size = cap`, `from = cap`) cannot bypass either single
+/// bound. The existing sort-plan validation is preserved so a malformed sort
+/// surfaces at request-parse time rather than a collector panic.
+fn validate_top_hits_config(schema: &Schema, name: &str, agg: &TopHitsAggregation) -> Result<()> {
+  SortPlan::from_request(schema, &agg.sort)
+    .with_context(|| format!("invalid top_hits sort in aggregation `{name}`"))?;
+  if agg.size > crate::query::aggs::MAX_TOP_HITS {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!(
+          "top_hits `{name}` size {} exceeds limit {}",
+          agg.size,
+          crate::query::aggs::MAX_TOP_HITS
+        ),
+      }
+      .into(),
+    );
+  }
+  if agg.from > crate::query::aggs::MAX_TOP_HITS {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!(
+          "top_hits `{name}` from {} exceeds limit {}",
+          agg.from,
+          crate::query::aggs::MAX_TOP_HITS
+        ),
+      }
+      .into(),
+    );
+  }
+  let combined = agg.size.saturating_add(agg.from);
+  if combined > crate::query::aggs::MAX_TOP_HITS {
+    return Err(
+      AggregationError::InvalidConfig {
+        reason: format!(
+          "top_hits `{name}` size + from = {combined} exceeds limit {}",
+          crate::query::aggs::MAX_TOP_HITS
+        ),
+      }
+      .into(),
+    );
   }
   Ok(())
 }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -50,6 +50,14 @@ pub(crate) const MAX_BUCKETS: usize = 10_000;
 /// so the forecast horizon never grows past the materialization budget for any other bucketing
 /// aggregation in the same request.
 pub(crate) const MAX_PREDICTIONS: usize = MAX_BUCKETS;
+/// Upper bound on the number of hits a single `top_hits` sub-aggregation may track per segment.
+///
+/// `size` and `from` control the per-segment `BinaryHeap<RankedDoc>` allocation in
+/// [`TopHitsCollector`]; without a cap, a tiny request body can size the heap from untrusted user
+/// input and drive an unbounded heap growth during collection (BUG-222). We share the same
+/// `10_000` ceiling as `MAX_BUCKETS` so the materialized hit set never grows past the
+/// materialization budget for any other bucketing aggregation in the same request.
+pub(crate) const MAX_TOP_HITS: usize = MAX_BUCKETS;
 const TDIGEST_MAX_SIZE: usize = 200;
 const PERCENTILE_EXACT_LIMIT: usize = 256;
 
@@ -2098,10 +2106,21 @@ impl<'a> TopHitsCollector<'a> {
   fn new(ctx: AggregationContext<'a>, agg: &TopHitsAggregation) -> Self {
     let plan = SortPlan::from_request(ctx.schema, &agg.sort)
       .expect("top_hits sort validated during request planning");
+    // Defense-in-depth: clamp `size` and `from` to `MAX_TOP_HITS` so an internal caller that
+    // bypasses `validate_aggregations_in_scope` cannot drive an unbounded `BinaryHeap` here
+    // (BUG-222). The request validator rejects values past the cap up-front; the `min` calls are
+    // a hard ceiling on the per-segment heap. `.max(1)` preserves the legacy invariant that the
+    // collector retains the best hit even when callers ask for `size = 0` so the merge step has
+    // a candidate to pick from.
+    let bounded_size = agg.size.min(MAX_TOP_HITS);
+    let bounded_from = agg.from.min(MAX_TOP_HITS);
+    let limit = bounded_size
+      .saturating_add(bounded_from)
+      .clamp(1, MAX_TOP_HITS);
     Self {
       size: agg.size,
       from: agg.from,
-      limit: agg.size.saturating_add(agg.from).max(agg.size).max(1),
+      limit,
       heap: BinaryHeap::new(),
       total: 0,
       fields: agg.fields.clone(),

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -2109,17 +2109,19 @@ impl<'a> TopHitsCollector<'a> {
     // Defense-in-depth: clamp `size` and `from` to `MAX_TOP_HITS` so an internal caller that
     // bypasses `validate_aggregations_in_scope` cannot drive an unbounded `BinaryHeap` here
     // (BUG-222). The request validator rejects values past the cap up-front; the `min` calls are
-    // a hard ceiling on the per-segment heap. `.max(1)` preserves the legacy invariant that the
-    // collector retains the best hit even when callers ask for `size = 0` so the merge step has
-    // a candidate to pick from.
+    // a hard ceiling on the per-segment heap. We persist the bounded values into the struct so
+    // every downstream use (heap sizing, `finish`'s `start + size` arithmetic, the
+    // `Vec::with_capacity` for hits) stays within the cap and consistent with `limit`. `.max(1)`
+    // on `limit` preserves the legacy invariant that the collector retains the best hit even
+    // when callers ask for `size = 0` so the merge step has a candidate to pick from.
     let bounded_size = agg.size.min(MAX_TOP_HITS);
     let bounded_from = agg.from.min(MAX_TOP_HITS);
     let limit = bounded_size
       .saturating_add(bounded_from)
       .clamp(1, MAX_TOP_HITS);
     Self {
-      size: agg.size,
-      from: agg.from,
+      size: bounded_size,
+      from: bounded_from,
       limit,
       heap: BinaryHeap::new(),
       total: 0,

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2350,30 +2350,22 @@ mod bug_222 {
   }
 
   #[test]
-  fn huge_size_is_rejected_without_allocation() {
-    use std::time::{Duration, Instant};
-
+  fn huge_size_is_rejected() {
     let tmp = tempfile::tempdir().unwrap();
     let idx = corpus_index(tmp.path());
 
-    // The bug report uses `size = 10^10`, which would size the heap to billions
-    // of `RankedDoc` entries (≥100 bytes each) if the validator did not gate it.
-    let aggs = top_hits_request(10_000_000_000, 0);
-
-    let start = Instant::now();
+    // `usize::MAX` is the largest possible value the deserializer can hand us;
+    // it is also portable across 32- and 64-bit targets, where a literal like
+    // `10_000_000_000` would overflow on 32-bit. The validator must reject it
+    // outright — without the bound, the per-segment heap would grow until the
+    // segment is exhausted or the process OOMs.
+    let aggs = top_hits_request(usize::MAX, 0);
     let err = search_with_agg(&idx, aggs)
       .expect_err("top_hits with size above MAX_TOP_HITS must be rejected");
-    let elapsed = start.elapsed();
     let msg = err.to_string();
     assert!(
       msg.contains("size") && msg.contains("exceeds limit"),
       "expected size-bound error, got: {msg}"
-    );
-    // The validator runs before any allocation; rejection must be effectively
-    // instantaneous, never paying the cost of growing the per-segment heap.
-    assert!(
-      elapsed < Duration::from_secs(2),
-      "top_hits validation must reject quickly without allocating: took {elapsed:?}"
     );
   }
 
@@ -2382,7 +2374,8 @@ mod bug_222 {
     let tmp = tempfile::tempdir().unwrap();
     let idx = corpus_index(tmp.path());
 
-    let aggs = top_hits_request(1, 10_000_000_000);
+    // See `huge_size_is_rejected` — `usize::MAX` keeps the test 32-bit safe.
+    let aggs = top_hits_request(1, usize::MAX);
     let err = search_with_agg(&idx, aggs)
       .expect_err("top_hits with from above MAX_TOP_HITS must be rejected");
     let msg = err.to_string();

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2282,3 +2282,191 @@ mod bug_215 {
     }
   }
 }
+
+/// Regression tests for BUG-222 — `TopHitsAggregation::size` and `from` are
+/// forwarded straight into `TopHitsCollector::new`, which uses them to size a
+/// per-segment `BinaryHeap<RankedDoc>`. Without a request-time bound, a tiny
+/// request body (well under the HTTP 50 MiB cap) could ask for `size = 10^10`
+/// and grow the heap until the segment is exhausted or the process OOMs.
+mod bug_222 {
+  use super::*;
+
+  fn corpus_index(path: &std::path::Path) -> searchlite_core::api::Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "n".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = IndexBuilder::create(path, schema, build_base_options(path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      // Two docs is enough to exercise the heap-growth branch in `collect`;
+      // the bug is about how the heap is *sized*, not about the number of
+      // matching docs.
+      writer
+        .add_document(&doc(
+          "a",
+          vec![("body", json!("rust")), ("n", json!(1_i64))],
+        ))
+        .unwrap();
+      writer
+        .add_document(&doc(
+          "b",
+          vec![("body", json!("rust")), ("n", json!(2_i64))],
+        ))
+        .unwrap();
+      writer.commit().unwrap();
+    }
+    idx
+  }
+
+  fn top_hits_request(size: usize, from: usize) -> BTreeMap<String, Aggregation> {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hits".into(),
+      Aggregation::TopHits(TopHitsAggregation {
+        size,
+        from,
+        fields: None,
+        sort: Vec::new(),
+        highlight_field: None,
+      }),
+    );
+    aggs
+  }
+
+  fn search_with_agg(
+    idx: &searchlite_core::api::Index,
+    aggs: BTreeMap<String, Aggregation>,
+  ) -> anyhow::Result<()> {
+    let mut req = SearchRequest::new("rust");
+    req.limit = 1;
+    req.aggs = aggs;
+    idx.reader().unwrap().search(&req)?;
+    Ok(())
+  }
+
+  #[test]
+  fn huge_size_is_rejected_without_allocation() {
+    use std::time::{Duration, Instant};
+
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    // The bug report uses `size = 10^10`, which would size the heap to billions
+    // of `RankedDoc` entries (≥100 bytes each) if the validator did not gate it.
+    let aggs = top_hits_request(10_000_000_000, 0);
+
+    let start = Instant::now();
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("top_hits with size above MAX_TOP_HITS must be rejected");
+    let elapsed = start.elapsed();
+    let msg = err.to_string();
+    assert!(
+      msg.contains("size") && msg.contains("exceeds limit"),
+      "expected size-bound error, got: {msg}"
+    );
+    // The validator runs before any allocation; rejection must be effectively
+    // instantaneous, never paying the cost of growing the per-segment heap.
+    assert!(
+      elapsed < Duration::from_secs(2),
+      "top_hits validation must reject quickly without allocating: took {elapsed:?}"
+    );
+  }
+
+  #[test]
+  fn huge_from_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    let aggs = top_hits_request(1, 10_000_000_000);
+    let err = search_with_agg(&idx, aggs)
+      .expect_err("top_hits with from above MAX_TOP_HITS must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("from") && msg.contains("exceeds limit"),
+      "expected from-bound error, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn size_just_above_cap_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    // `MAX_TOP_HITS` is 10_000; exercise the strict `>` boundary on `size`.
+    let aggs = top_hits_request(10_001, 0);
+    let err = search_with_agg(&idx, aggs).expect_err("size = MAX_TOP_HITS + 1 must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("size") && msg.contains("10001"),
+      "expected size bound error mentioning the offending value, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn from_just_above_cap_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    let aggs = top_hits_request(0, 10_001);
+    let err = search_with_agg(&idx, aggs).expect_err("from = MAX_TOP_HITS + 1 must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("from") && msg.contains("10001"),
+      "expected from bound error mentioning the offending value, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn size_plus_from_above_cap_is_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    // Each value is below the cap, but the sum exceeds it. Without the
+    // additive check, an attacker could pick `size = cap` and `from = cap`
+    // to size the heap at `2 * cap` and bypass the per-dimension bound.
+    let aggs = top_hits_request(10_000, 1);
+    let err =
+      search_with_agg(&idx, aggs).expect_err("size + from above MAX_TOP_HITS must be rejected");
+    let msg = err.to_string();
+    assert!(
+      msg.contains("size + from") && msg.contains("exceeds limit"),
+      "expected combined bound error, got: {msg}"
+    );
+  }
+
+  #[test]
+  fn size_at_cap_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    // 10_000 hits is intentionally accepted so legitimate clients keep working.
+    let aggs = top_hits_request(10_000, 0);
+    search_with_agg(&idx, aggs).expect("size at the cap must be accepted");
+  }
+
+  #[test]
+  fn size_plus_from_at_cap_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    // The combined bound is `<= MAX_TOP_HITS`, not `<`. Exercise the boundary
+    // so a future tightening of the check does not silently break clients
+    // that already rely on `size + from = cap`.
+    let aggs = top_hits_request(9_000, 1_000);
+    search_with_agg(&idx, aggs).expect("size + from at the cap must be accepted");
+  }
+
+  #[test]
+  fn small_top_hits_request_is_accepted() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = corpus_index(tmp.path());
+
+    let aggs = top_hits_request(2, 1);
+    search_with_agg(&idx, aggs).expect("typical top_hits values must be accepted");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes BUG-222: `TopHitsCollector` sized its per-segment `BinaryHeap<RankedDoc>` directly from `top_hits.size + top_hits.from`, both arriving as untrusted `usize` values from the request JSON with no upper bound. A tiny request body could ask for `size = 10^10` and grow the heap until the process OOMed; the existing HTTP page-size cap only guarded the top-level pagination, not aggregation-internal sizes.

- Add `MAX_TOP_HITS = 10_000` (shared ceiling with `MAX_BUCKETS` / `MAX_PREDICTIONS`).
- Reject `size`, `from`, and the saturating sum in `validate_aggregations_in_scope` so the error message names the offending dimension and the additive case (`size = cap`, `from = cap`) cannot bypass either single bound.
- Defense-in-depth: clamp the per-segment heap `limit` in `TopHitsCollector::new` so an internal caller that bypasses the request validator still cannot drive an unbounded allocation.
- Publish the new ceilings in `search-request.schema.json`.

Mirrors the pattern PR #223 used for BUG-221 (`moving_avg.predict`).

Closes #222

## Test plan

- [x] `cargo test -p searchlite-core --test aggregation_bounds` — 46 tests pass, including 8 new `bug_222` cases covering `size > cap`, `from > cap`, `size + from > cap`, the boundary at `cap` and `cap + 1`, and small/legitimate values.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.
- [x] `cargo fmt --check -p searchlite-core` clean.
- [x] `cargo test --workspace` — full suite passes locally.