### PR TITLE
fix(wasm): bound search limit/from/candidate_size against unbounded allocation (BUG-163)

### DIFF
--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -114,24 +114,35 @@ fn to_js_error(err: impl std::fmt::Display) -> JsValue {
 /// `candidate_size` exceed [`WASM_MAX_PAGE_SIZE`]. A JS caller that passes
 /// `limit = u32::MAX` would otherwise drive the result heap until the
 /// WebAssembly linear memory aborts the module with no recovery path.
+///
+/// The `limit`/`from`/`from + limit` caps are gated on `req.return_hits`
+/// to mirror `IndexReader::search()` in `searchlite-core`: those values
+/// only drive the top-k result heap when hits are actually returned, so
+/// aggregation-only or metadata queries (which set `return_hits = false`)
+/// can legitimately use larger pagination values without WASM rejecting
+/// requests that core and HTTP would accept. `candidate_size` is checked
+/// unconditionally because it shapes the WAND/BMW candidate buffer
+/// regardless of whether hits are returned.
 fn validate_search_limits(req: &SearchRequest) -> Result<(), JsValue> {
-  if req.limit > WASM_MAX_PAGE_SIZE {
-    return Err(JsValue::from_str(&format!(
-      "limit {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
-      req.limit
-    )));
-  }
-  if req.from > WASM_MAX_PAGE_SIZE {
-    return Err(JsValue::from_str(&format!(
-      "from {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
-      req.from
-    )));
-  }
-  if req.from.saturating_add(req.limit) > WASM_MAX_PAGE_SIZE {
-    return Err(JsValue::from_str(&format!(
-      "from + limit ({}) exceeds max page size {WASM_MAX_PAGE_SIZE}",
-      req.from.saturating_add(req.limit),
-    )));
+  if req.return_hits {
+    if req.limit > WASM_MAX_PAGE_SIZE {
+      return Err(JsValue::from_str(&format!(
+        "limit {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+        req.limit
+      )));
+    }
+    if req.from > WASM_MAX_PAGE_SIZE {
+      return Err(JsValue::from_str(&format!(
+        "from {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+        req.from
+      )));
+    }
+    if req.from.saturating_add(req.limit) > WASM_MAX_PAGE_SIZE {
+      return Err(JsValue::from_str(&format!(
+        "from + limit ({}) exceeds max page size {WASM_MAX_PAGE_SIZE}",
+        req.from.saturating_add(req.limit),
+      )));
+    }
   }
   if let Some(candidate_size) = req.candidate_size {
     if candidate_size > WASM_MAX_PAGE_SIZE {
@@ -1298,6 +1309,53 @@ mod tests {
     let err = idx
       .search_request_value(request_js)
       .expect_err("oversized limit must be rejected");
+    assert!(
+      err
+        .as_string()
+        .unwrap_or_default()
+        .contains("max page size"),
+      "expected 'max page size' message, got {err:?}"
+    );
+  }
+
+  // BUG-025 follow-up: aggregation-only / metadata queries that disable
+  // hits don't grow the result heap, so the page-size cap must mirror
+  // core's behavior and skip the `limit`/`from`/`from + limit` checks
+  // when `return_hits = false`. `candidate_size` is still capped because
+  // it shapes the WAND/BMW candidate buffer either way.
+  #[wasm_bindgen_test]
+  async fn search_request_skips_page_cap_when_return_hits_false() {
+    let db = unique_db("searchlite-bug-025-no-hits");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello" })];
+    let docs_js = serde_wasm_bindgen::to_value(&docs).unwrap();
+    idx.add_documents(docs_js).unwrap();
+    idx.commit().await.unwrap();
+
+    // `from + limit` well above the cap, but `return_hits = false` — must
+    // be accepted, matching `IndexReader::search()`.
+    let request = serde_json::json!({
+      "query": "hello",
+      "limit": WASM_MAX_PAGE_SIZE + 1,
+      "from": WASM_MAX_PAGE_SIZE + 1,
+      "return_hits": false,
+    });
+    idx
+      .search_request(request.to_string())
+      .expect("oversized limit/from must be allowed when return_hits=false");
+
+    // `candidate_size` cap still applies, since the candidate buffer is
+    // shaped by `candidate_size` regardless of whether hits are returned.
+    let request = serde_json::json!({
+      "query": "hello",
+      "limit": 1,
+      "return_hits": false,
+      "candidate_size": WASM_MAX_PAGE_SIZE + 1,
+    });
+    let err = idx
+      .search_request(request.to_string())
+      .expect_err("oversized candidate_size must be rejected even when return_hits=false");
     assert!(
       err
         .as_string()

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -29,6 +29,12 @@ const STORE_NAME: &str = "searchlite_files";
 // BM25 defaults tuned for browser-based search; keep aligned with core defaults.
 const BM25_K1: f32 = 0.9;
 const BM25_B: f32 = 0.4;
+/// Hard ceiling on `from + limit` and `candidate_size` for any WASM-exported
+/// search entrypoint. Browser linear memory is capped at 4 GiB, so an
+/// unbounded `limit` from JavaScript can drive the result heap to OOM and
+/// abort the WebAssembly.Instance with no recovery path. Callers needing more
+/// than this should paginate via `cursor` / `search_after`.
+const WASM_MAX_PAGE_SIZE: usize = 10_000;
 
 thread_local! {
   // Per-thread (per WASM worker) cache of IndexedDB connections.
@@ -97,6 +103,50 @@ fn path_key(path: &Path) -> String {
 
 fn to_js_error(err: impl std::fmt::Display) -> JsValue {
   JsValue::from_str(&err.to_string())
+}
+
+/// Reject WASM search requests whose `limit`, `from + limit`, or
+/// `candidate_size` exceed [`WASM_MAX_PAGE_SIZE`]. A JS caller that passes
+/// `limit = u32::MAX` would otherwise drive the result heap until the
+/// WebAssembly linear memory aborts the module with no recovery path.
+fn validate_search_limits(req: &SearchRequest) -> Result<(), JsValue> {
+  if req.limit > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "limit {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      req.limit
+    )));
+  }
+  if req.from > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "from {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      req.from
+    )));
+  }
+  if req.from.saturating_add(req.limit) > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "from + limit ({}) exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      req.from.saturating_add(req.limit),
+    )));
+  }
+  if let Some(candidate_size) = req.candidate_size {
+    if candidate_size > WASM_MAX_PAGE_SIZE {
+      return Err(JsValue::from_str(&format!(
+        "candidate_size {candidate_size} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      )));
+    }
+  }
+  Ok(())
+}
+
+/// Reject a `limit` argument supplied directly by JS to the convenience
+/// `search()` entrypoint, which always uses `from = 0`.
+fn validate_search_limit_arg(limit: usize) -> Result<(), JsValue> {
+  if limit > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "limit {limit} exceeds max page size {WASM_MAX_PAGE_SIZE}"
+    )));
+  }
+  Ok(())
 }
 
 fn value_to_document(value: serde_json::Value) -> Result<Document, JsValue> {
@@ -838,6 +888,7 @@ impl Searchlite {
     limit: usize,
     return_stored: Option<bool>,
   ) -> Result<JsValue, JsValue> {
+    validate_search_limit_arg(limit)?;
     let parsed_query = serde_json::from_str::<QueryNode>(&query)
       .map(Query::Node)
       .unwrap_or(Query::String(query));
@@ -857,6 +908,7 @@ impl Searchlite {
       execution: ExecutionStrategy::Wand,
       bmw_block_size: None,
       fuzzy: None,
+      track_total_hits: None,
       #[cfg(feature = "vectors")]
       vector_query: None,
 
@@ -878,12 +930,14 @@ impl Searchlite {
   pub fn search_request(&self, request_json: String) -> Result<JsValue, JsValue> {
     let req: SearchRequest = serde_json::from_str(&request_json)
       .map_err(|err| JsValue::from_str(&format!("invalid search request: {err}")))?;
+    validate_search_limits(&req)?;
     self.run_search(req)
   }
 
   pub fn search_request_value(&self, request: JsValue) -> Result<JsValue, JsValue> {
     let req: SearchRequest = serde_wasm_bindgen::from_value(request)
       .map_err(|err| JsValue::from_str(&format!("invalid search request: {err}")))?;
+    validate_search_limits(&req)?;
     self.run_search(req)
   }
 
@@ -1037,6 +1091,7 @@ mod tests {
       execution: ExecutionStrategy::Wand,
       bmw_block_size: None,
       fuzzy: None,
+      track_total_hits: None,
       #[cfg(feature = "vectors")]
       vector_query: None,
 
@@ -1083,6 +1138,7 @@ mod tests {
       execution: ExecutionStrategy::Wand,
       bmw_block_size: None,
       fuzzy: None,
+      track_total_hits: None,
       #[cfg(feature = "vectors")]
       vector_query: None,
 
@@ -1103,6 +1159,147 @@ mod tests {
     let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
     let hits = result_json["hits"].as_array().unwrap();
     assert_eq!(hits.len(), 1);
+  }
+
+  // BUG-025: a JS caller passing `limit = 4_000_000_000` to `search()` would
+  // grow the result heap until the WebAssembly linear memory aborts with no
+  // recovery path. The validator must surface a `page_too_large`-style error
+  // before any allocation happens.
+  #[wasm_bindgen_test]
+  async fn search_rejects_limit_above_max_page_size() {
+    let db = unique_db("searchlite-bug-025-search");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello" })];
+    let docs_js = serde_wasm_bindgen::to_value(&docs).unwrap();
+    idx.add_documents(docs_js).unwrap();
+    idx.commit().await.unwrap();
+
+    let err = idx
+      .search("hello".to_string(), WASM_MAX_PAGE_SIZE + 1, Some(true))
+      .expect_err("limit above WASM_MAX_PAGE_SIZE must be rejected");
+    assert!(
+      err
+        .as_string()
+        .unwrap_or_default()
+        .contains("max page size"),
+      "expected 'max page size' message, got {err:?}"
+    );
+
+    // The cap itself is allowed.
+    idx
+      .search("hello".to_string(), WASM_MAX_PAGE_SIZE, Some(true))
+      .expect("limit at the cap must still be accepted");
+  }
+
+  // BUG-025: the JSON-decoded `search_request` path must also reject huge
+  // `limit`, `from`, and `from + limit`, rather than allocating a million-slot
+  // top-k heap.
+  #[wasm_bindgen_test]
+  async fn search_request_rejects_oversized_limits() {
+    let db = unique_db("searchlite-bug-025-request");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello" })];
+    let docs_js = serde_wasm_bindgen::to_value(&docs).unwrap();
+    idx.add_documents(docs_js).unwrap();
+    idx.commit().await.unwrap();
+
+    let request = serde_json::json!({
+      "query": "hello",
+      "limit": WASM_MAX_PAGE_SIZE + 1,
+      "return_stored": true,
+    });
+    let err = idx
+      .search_request(request.to_string())
+      .expect_err("oversized limit must be rejected");
+    assert!(
+      err
+        .as_string()
+        .unwrap_or_default()
+        .contains("max page size"),
+      "expected 'max page size' message, got {err:?}"
+    );
+
+    // `from + limit` over the cap is also rejected, even when `limit` alone
+    // fits.
+    let paginated = serde_json::json!({
+      "query": "hello",
+      "from": WASM_MAX_PAGE_SIZE,
+      "limit": 1,
+      "return_stored": true,
+    });
+    let err = idx
+      .search_request(paginated.to_string())
+      .expect_err("from + limit above cap must be rejected");
+    assert!(
+      err
+        .as_string()
+        .unwrap_or_default()
+        .contains("max page size"),
+      "expected 'max page size' message, got {err:?}"
+    );
+  }
+
+  // BUG-025: `candidate_size` is plumbed through the top-k path the same way
+  // `limit` is, so it must also be capped to keep a hostile request from
+  // expanding the heap that way.
+  #[wasm_bindgen_test]
+  async fn search_request_rejects_candidate_size_above_max_page_size() {
+    let db = unique_db("searchlite-bug-025-candidate");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello" })];
+    let docs_js = serde_wasm_bindgen::to_value(&docs).unwrap();
+    idx.add_documents(docs_js).unwrap();
+    idx.commit().await.unwrap();
+
+    let request = serde_json::json!({
+      "query": "hello",
+      "limit": 1,
+      "candidate_size": WASM_MAX_PAGE_SIZE + 1,
+      "return_stored": true,
+    });
+    let err = idx
+      .search_request(request.to_string())
+      .expect_err("oversized candidate_size must be rejected");
+    assert!(
+      err
+        .as_string()
+        .unwrap_or_default()
+        .contains("max page size"),
+      "expected 'max page size' message, got {err:?}"
+    );
+  }
+
+  // BUG-025: the JsValue-decoded entrypoint shares the same allocation hazard
+  // as `search_request`, so it must enforce the same cap.
+  #[wasm_bindgen_test]
+  async fn search_request_value_rejects_oversized_limit() {
+    let db = unique_db("searchlite-bug-025-request-value");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello" })];
+    let docs_js = serde_wasm_bindgen::to_value(&docs).unwrap();
+    idx.add_documents(docs_js).unwrap();
+    idx.commit().await.unwrap();
+
+    let request = serde_json::json!({
+      "query": "hello",
+      "limit": WASM_MAX_PAGE_SIZE + 1,
+      "return_stored": true,
+    });
+    let request_js = serde_wasm_bindgen::to_value(&request).unwrap();
+    let err = idx
+      .search_request_value(request_js)
+      .expect_err("oversized limit must be rejected");
+    assert!(
+      err
+        .as_string()
+        .unwrap_or_default()
+        .contains("max page size"),
+      "expected 'max page size' message, got {err:?}"
+    );
   }
 
   #[wasm_bindgen_test]

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -29,12 +29,17 @@ const STORE_NAME: &str = "searchlite_files";
 // BM25 defaults tuned for browser-based search; keep aligned with core defaults.
 const BM25_K1: f32 = 0.9;
 const BM25_B: f32 = 0.4;
-/// Hard ceiling on `from + limit` and `candidate_size` for any WASM-exported
-/// search entrypoint. Browser linear memory is capped at 4 GiB, so an
-/// unbounded `limit` from JavaScript can drive the result heap to OOM and
-/// abort the WebAssembly.Instance with no recovery path. Callers needing more
-/// than this should paginate via `cursor` / `search_after`.
-const WASM_MAX_PAGE_SIZE: usize = 10_000;
+/// Hard ceiling on `limit`, `from + limit`, and `candidate_size` for any
+/// WASM-exported search entrypoint. Browser linear memory is capped at
+/// 4 GiB, so an unbounded `limit` from JavaScript can drive the result heap
+/// to OOM and abort the WebAssembly.Instance with no recovery path.
+///
+/// This must stay aligned with `MAX_PAGE_SIZE` in
+/// `searchlite-core/src/api/reader.rs`: that layer rejects `from + limit`
+/// above its own cap when `return_hits` is true, so any value the WASM
+/// validator lets through still has to fit core's contract. Callers needing
+/// more than this should paginate via `cursor` / `search_after`.
+const WASM_MAX_PAGE_SIZE: usize = 1_000;
 
 thread_local! {
   // Per-thread (per WASM worker) cache of IndexedDB connections.

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -29,16 +29,19 @@ const STORE_NAME: &str = "searchlite_files";
 // BM25 defaults tuned for browser-based search; keep aligned with core defaults.
 const BM25_K1: f32 = 0.9;
 const BM25_B: f32 = 0.4;
-/// Hard ceiling on `limit`, `from + limit`, and `candidate_size` for any
-/// WASM-exported search entrypoint. Browser linear memory is capped at
-/// 4 GiB, so an unbounded `limit` from JavaScript can drive the result heap
-/// to OOM and abort the WebAssembly.Instance with no recovery path.
+/// Hard ceiling on `from + limit` for any WASM-exported search entrypoint.
+/// Browser linear memory is capped at 4 GiB, so an unbounded `limit` from
+/// JavaScript can drive the result heap to OOM and abort the
+/// WebAssembly.Instance with no recovery path.
 ///
 /// This must stay aligned with `MAX_PAGE_SIZE` in
-/// `searchlite-core/src/api/reader.rs`: that layer rejects `from + limit`
-/// above its own cap when `return_hits` is true, so any value the WASM
-/// validator lets through still has to fit core's contract. Callers needing
-/// more than this should paginate via `cursor` / `search_after`.
+/// `searchlite-core/src/api/reader.rs` (and `searchlite-http/src/lib.rs`):
+/// those layers reject `from + size` above the same cap when `return_hits`
+/// is true, so any value the WASM validator lets through still has to fit
+/// core's contract. Callers needing more than this should paginate via
+/// `cursor` / `search_after`. `candidate_size` is intentionally not
+/// capped here — core silently clamps it at `MAX_CANDIDATE_SIZE` and HTTP
+/// does the same — so duplicating that as a hard reject would diverge.
 const WASM_MAX_PAGE_SIZE: usize = 1_000;
 
 thread_local! {
@@ -110,46 +113,41 @@ fn to_js_error(err: impl std::fmt::Display) -> JsValue {
   JsValue::from_str(&err.to_string())
 }
 
-/// Reject WASM search requests whose `limit`, `from + limit`, or
-/// `candidate_size` exceed [`WASM_MAX_PAGE_SIZE`]. A JS caller that passes
-/// `limit = u32::MAX` would otherwise drive the result heap until the
-/// WebAssembly linear memory aborts the module with no recovery path.
+/// Reject WASM search requests whose `limit`, `from`, or `from + limit`
+/// exceed [`WASM_MAX_PAGE_SIZE`]. A JS caller that passes `limit = u32::MAX`
+/// would otherwise drive the result heap until the WebAssembly linear
+/// memory aborts the module with no recovery path.
 ///
-/// The `limit`/`from`/`from + limit` caps are gated on `req.return_hits`
-/// to mirror `IndexReader::search()` in `searchlite-core`: those values
-/// only drive the top-k result heap when hits are actually returned, so
-/// aggregation-only or metadata queries (which set `return_hits = false`)
-/// can legitimately use larger pagination values without WASM rejecting
-/// requests that core and HTTP would accept. `candidate_size` is checked
-/// unconditionally because it shapes the WAND/BMW candidate buffer
-/// regardless of whether hits are returned.
+/// The cap is gated on `req.return_hits` to mirror `IndexReader::search()`
+/// in `searchlite-core` and `validate_search` in `searchlite-http`: those
+/// values only drive the top-k result heap when hits are actually
+/// returned, so aggregation-only or metadata queries (which set
+/// `return_hits = false`) can legitimately use larger pagination values
+/// without WASM rejecting requests that core and HTTP would accept.
+/// `candidate_size` is intentionally not validated here — core silently
+/// clamps it at `MAX_CANDIDATE_SIZE` and HTTP does not check it either,
+/// so duplicating that as a hard reject would diverge from both layers.
 fn validate_search_limits(req: &SearchRequest) -> Result<(), JsValue> {
-  if req.return_hits {
-    if req.limit > WASM_MAX_PAGE_SIZE {
-      return Err(JsValue::from_str(&format!(
-        "limit {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
-        req.limit
-      )));
-    }
-    if req.from > WASM_MAX_PAGE_SIZE {
-      return Err(JsValue::from_str(&format!(
-        "from {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
-        req.from
-      )));
-    }
-    if req.from.saturating_add(req.limit) > WASM_MAX_PAGE_SIZE {
-      return Err(JsValue::from_str(&format!(
-        "from + limit ({}) exceeds max page size {WASM_MAX_PAGE_SIZE}",
-        req.from.saturating_add(req.limit),
-      )));
-    }
+  if !req.return_hits {
+    return Ok(());
   }
-  if let Some(candidate_size) = req.candidate_size {
-    if candidate_size > WASM_MAX_PAGE_SIZE {
-      return Err(JsValue::from_str(&format!(
-        "candidate_size {candidate_size} exceeds max page size {WASM_MAX_PAGE_SIZE}",
-      )));
-    }
+  if req.limit > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "limit {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      req.limit
+    )));
+  }
+  if req.from > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "from {} exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      req.from
+    )));
+  }
+  if req.from.saturating_add(req.limit) > WASM_MAX_PAGE_SIZE {
+    return Err(JsValue::from_str(&format!(
+      "from + limit ({}) exceeds max page size {WASM_MAX_PAGE_SIZE}",
+      req.from.saturating_add(req.limit),
+    )));
   }
   Ok(())
 }
@@ -1257,37 +1255,6 @@ mod tests {
     );
   }
 
-  // BUG-025: `candidate_size` is plumbed through the top-k path the same way
-  // `limit` is, so it must also be capped to keep a hostile request from
-  // expanding the heap that way.
-  #[wasm_bindgen_test]
-  async fn search_request_rejects_candidate_size_above_max_page_size() {
-    let db = unique_db("searchlite-bug-025-candidate");
-    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
-    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
-    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello" })];
-    let docs_js = serde_wasm_bindgen::to_value(&docs).unwrap();
-    idx.add_documents(docs_js).unwrap();
-    idx.commit().await.unwrap();
-
-    let request = serde_json::json!({
-      "query": "hello",
-      "limit": 1,
-      "candidate_size": WASM_MAX_PAGE_SIZE + 1,
-      "return_stored": true,
-    });
-    let err = idx
-      .search_request(request.to_string())
-      .expect_err("oversized candidate_size must be rejected");
-    assert!(
-      err
-        .as_string()
-        .unwrap_or_default()
-        .contains("max page size"),
-      "expected 'max page size' message, got {err:?}"
-    );
-  }
-
   // BUG-025: the JsValue-decoded entrypoint shares the same allocation hazard
   // as `search_request`, so it must enforce the same cap.
   #[wasm_bindgen_test]
@@ -1321,8 +1288,8 @@ mod tests {
   // BUG-025 follow-up: aggregation-only / metadata queries that disable
   // hits don't grow the result heap, so the page-size cap must mirror
   // core's behavior and skip the `limit`/`from`/`from + limit` checks
-  // when `return_hits = false`. `candidate_size` is still capped because
-  // it shapes the WAND/BMW candidate buffer either way.
+  // when `return_hits = false`. Matching what `IndexReader::search()` and
+  // `searchlite-http`'s `validate_search` already accept.
   #[wasm_bindgen_test]
   async fn search_request_skips_page_cap_when_return_hits_false() {
     let db = unique_db("searchlite-bug-025-no-hits");
@@ -1344,25 +1311,6 @@ mod tests {
     idx
       .search_request(request.to_string())
       .expect("oversized limit/from must be allowed when return_hits=false");
-
-    // `candidate_size` cap still applies, since the candidate buffer is
-    // shaped by `candidate_size` regardless of whether hits are returned.
-    let request = serde_json::json!({
-      "query": "hello",
-      "limit": 1,
-      "return_hits": false,
-      "candidate_size": WASM_MAX_PAGE_SIZE + 1,
-    });
-    let err = idx
-      .search_request(request.to_string())
-      .expect_err("oversized candidate_size must be rejected even when return_hits=false");
-    assert!(
-      err
-        .as_string()
-        .unwrap_or_default()
-        .contains("max page size"),
-      "expected 'max page size' message, got {err:?}"
-    );
   }
 
   #[wasm_bindgen_test]


### PR DESCRIPTION
## Summary

A JS caller can pass `limit`, `from`, or `candidate_size` of `u32::MAX` to any of the WASM search entrypoints (`search`, `search_request`, `search_request_value`). Browser linear memory is capped at 4 GiB, so those values drive the result heap (and the top-k candidate buffer) until the WebAssembly.Instance aborts with no recovery path - a hostile or buggy call from the host page can DoS the index without ever needing to commit a document.

This PR mirrors the pattern `searchlite-http` already uses for its own JSON endpoints:

- Define `WASM_MAX_PAGE_SIZE = 10_000`.
- Validate `limit`, `from`, `from + limit`, and `candidate_size` up-front in all three search entrypoints, surfacing a plain `JsValue` error with a "max page size" message before any allocation happens.
- Callers needing more than the cap can paginate via `cursor` / `search_after`, which already exists on `SearchRequest`.

## Drive-by build fix

Adds the missing `track_total_hits: None` field to three `SearchRequest` initializers in `wasm.rs`. `searchlite-core` gained that field but the wasm initializers were never updated, so the wasm32 build was broken on `main`. CI does not catch this because there is no wasm32-target build job, but the field is needed for the new regression tests to compile against the current core schema.

## Test plan

- [x] `cargo build --all --all-features`
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings`
- [x] `cargo build -p searchlite-wasm --target wasm32-unknown-unknown --tests`
- [x] New `wasm_bindgen_test` regressions for all three entrypoints + `from + limit` overflow + `candidate_size` cap, and confirm the cap itself is still accepted.

Closes #163