### PR TITLE
fix(suggest): bound fuzzy candidate scan against MAX_SUGGEST_CANDIDATES (BUG-024)

### DIFF
--- a/searchlite-core/src/api/suggestion.rs
+++ b/searchlite-core/src/api/suggestion.rs
@@ -75,8 +75,15 @@ fn collect_completion_candidates(
       let prefix = char_prefix(term, prefix_len);
       let prefix_key = build_term_key(field, prefix);
       let field_prefix_len = field.len() + 1;
-      let mut global_cap = fuzzy.max_expansions.min(MAX_SUGGEST_CANDIDATES);
-      global_cap = global_cap.max(size);
+      // Bound the inner-iteration cap against the hard ceiling even when the
+      // caller asks for a very large final `size`. Before the fix, a request
+      // with `size: 1_000_000` and `max_expansions: 1` lifted the cap to
+      // 1_000_000 and forced a full bounded_levenshtein scan over every
+      // prefix-matching term in the segment — an unauthenticated DoS vector
+      // (BUG-024). `max_expansions` is still honoured as the lower bound
+      // when it is larger than `size`, so legitimate callers that request
+      // wider expansion continue to get the same behaviour up to the cap.
+      let global_cap = fuzzy.max_expansions.max(size).min(MAX_SUGGEST_CANDIDATES);
       for seg in segments.iter() {
         for key in seg.terms_with_prefix(&prefix_key) {
           if expanded_total >= global_cap {

--- a/searchlite-core/tests/prefix_and_suggest.rs
+++ b/searchlite-core/tests/prefix_and_suggest.rs
@@ -257,3 +257,117 @@ fn fuzzy_completion_suggests_close_terms() {
   assert!(!options.is_empty());
   assert_eq!(options[0].text, "rust");
 }
+
+// BUG-024 regression: the fuzzy branch of `collect_completion_candidates`
+// previously computed its inner iteration cap as
+// `fuzzy.max_expansions.min(MAX_SUGGEST_CANDIDATES).max(size)`, which let a
+// caller-supplied `size` lift the cap past the hard ceiling
+// `MAX_SUGGEST_CANDIDATES = 256`. A request with
+// `{ size: 1_000_000, fuzzy: { max_expansions: 1, ... } }` forced
+// `bounded_levenshtein` across every prefix-matching term in the segment
+// — an unauthenticated DoS. The fix bounds the cap at the ceiling:
+// `max_expansions.max(size).min(MAX_SUGGEST_CANDIDATES)`. This test seeds
+// 300 unique prefix-matching terms and asserts the returned options are
+// bounded by the hard ceiling even when the caller asks for a million.
+#[test]
+fn fuzzy_completion_large_size_does_not_bypass_candidate_cap() {
+  // Keep the literal in sync with MAX_SUGGEST_CANDIDATES in
+  // searchlite-core/src/api/term_expansion.rs.
+  const MAX_SUGGEST_CANDIDATES: usize = 256;
+
+  let dir = tempfile::tempdir().unwrap();
+  let path = dir.path().join("idx-fuzzy-cap");
+  let idx = Index::create(&path, Schema::default_text_body(), opts(&path)).unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // 300 unique 3-char tokens that all start with 'a' — every one is
+    // within 2 edits of the 1-char search term "a" (two inserts), so
+    // before the fix all 300 would enter the fuzzy-candidate loop.
+    for i in 0..300usize {
+      let c1 = (b'a' + ((i / 26) % 26) as u8) as char;
+      let c2 = (b'a' + (i % 26) as u8) as char;
+      let body = format!("a{c1}{c2}");
+      writer
+        .add_document(&Document {
+          fields: [
+            ("_id".into(), serde_json::json!(format!("d{i:03}"))),
+            ("body".into(), serde_json::json!(body)),
+          ]
+          .into_iter()
+          .collect(),
+        })
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  let reader = idx.reader().unwrap();
+  let mut suggest = BTreeMap::new();
+  suggest.insert(
+    "complete".into(),
+    SuggestRequest::Completion {
+      field: "body".into(),
+      prefix: "a".into(),
+      size: 1_000_000,
+      fuzzy: Some(FuzzyOptions {
+        max_edits: 2,
+        prefix_length: 1,
+        max_expansions: 1,
+        min_length: 1,
+      }),
+    },
+  );
+  let res = reader
+    .search(&SearchRequest {
+      query: Query::Node(QueryNode::MatchAll { boost: None }),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: false,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs: BTreeMap::new(),
+      suggest,
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  let options = res
+    .suggest
+    .get("complete")
+    .expect("missing suggestion")
+    .options
+    .clone();
+  // The inner scan must stop at MAX_SUGGEST_CANDIDATES regardless of `size`.
+  // Before the fix this would be 300 (every prefix-matching term scanned).
+  assert!(
+    options.len() <= MAX_SUGGEST_CANDIDATES,
+    "fuzzy scan exceeded MAX_SUGGEST_CANDIDATES: got {} options for size=1_000_000",
+    options.len()
+  );
+  // Sanity: the cap doesn't kill the feature — with 300 matching terms we
+  // still return a full batch up to the ceiling.
+  assert!(
+    options.len() >= MAX_SUGGEST_CANDIDATES - 32,
+    "expected close to the cap's worth of candidates, got {}",
+    options.len()
+  );
+}


### PR DESCRIPTION
## Summary

Fixes BUG-024 (#162). The fuzzy branch of `collect_completion_candidates` in `searchlite-core/src/api/suggestion.rs` computed its inner iteration cap as:

```rust
let mut global_cap = fuzzy.max_expansions.min(MAX_SUGGEST_CANDIDATES);
global_cap = global_cap.max(size);
```

The first line correctly capped the scan at `MAX_SUGGEST_CANDIDATES = 256`. The second line lifted the cap back up to the caller-supplied `size` — so a request with `{"size": 1_000_000, "fuzzy": {"max_expansions": 1, ...}}` ran `bounded_levenshtein` against every prefix-matching term in the segment, an O(size × term_len × candidate_len) unauthenticated DoS whose cost scaled with corpus size rather than with the `max_expansions` the caller asked for. The top-k truncation at `completion_suggest` happens after the scan, so response size limits do nothing to defend against it. The non-fuzzy branch already clamps correctly via `.clamp(DEFAULT_SUGGEST_SCAN, MAX_SUGGEST_CANDIDATES)` and is unchanged.

## What changed

- Replace the two-step clamp with `max_expansions.max(size).min(MAX_SUGGEST_CANDIDATES)` so the hard ceiling is always the final word. `max_expansions` is still honoured as a lower bound when larger than `size`, so legitimate callers who deliberately request wider expansion keep working up to the ceiling. (`searchlite-core/src/api/suggestion.rs`)
- Add a regression test (`fuzzy_completion_large_size_does_not_bypass_candidate_cap`) that seeds 300 unique prefix-matching terms and issues `size: 1_000_000, max_expansions: 1`. Before the fix the scan iterated all 300 terms and returned them all; after the fix it stops at the 256-candidate ceiling. Verified the test fails without the code change (assertion fires on 300 options) and passes with it. (`searchlite-core/tests/prefix_and_suggest.rs`)

## Test plan

- [x] `cargo test -p searchlite-core --test prefix_and_suggest` — 4/4 pass (existing 3 + new regression).
- [x] `cargo test -p searchlite-core --lib` — 277/277 pass.
- [x] `cargo test -p searchlite-core` — full core test matrix green.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.
- [x] Verified regression test catches the original bug by temporarily reverting the fix — test fails on unfixed code.

Closes #162
