### PR TITLE
fix(ffi): signal buffer-too-small instead of truncating JSON (BUG-029)

### DIFF
--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -37,6 +37,8 @@ All FFI functions that return `c_int` use the following codes:
 
 `N == buf_cap` is never returned: success always leaves at least one byte for the NUL terminator, so `N > buf_cap` is an unambiguous "buffer too small" signal even when `buf_cap == 0`.
 
+**C callers, signed/unsigned caveat for `searchlite_search`:** the return type is `ssize_t` but `buf_cap` is `size_t`. A direct `ret > buf_cap` comparison will promote a negative sentinel such as `SEARCHLITE_ERR_PANIC` (`-100`) to a huge unsigned value and misclassify it as "buffer too small". Check `ret <= 0` first (handling errors and panics), then compare `(size_t)ret > buf_cap` only when `ret > 0`. `searchlite_search_request` returns `size_t`, so a plain `ret > buf_cap` check is sufficient.
+
 ## WASM
 
 - `add_document` / `add_documents` queue writes; `commit()` persists them and makes them searchable. `flush_storage()` only drains pending storage writes if you need it.

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -26,7 +26,16 @@ All FFI functions that return `c_int` use the following codes:
 
 ### FFI search buffer behavior
 
-`searchlite_search` and `searchlite_search_request` write JSON results into a caller-provided buffer (`out_json_buf` / `buf_cap`). If the result exceeds `buf_cap`, the output is silently truncated to `buf_cap - 1` bytes plus a null terminator. Treat a returned byte count equal to `buf_cap - 1` as potentially truncated and retry with a larger buffer.
+`searchlite_search` and `searchlite_search_request` write JSON results into a caller-provided buffer (`out_json_buf` / `buf_cap`) and use the return value to report success, error, or buffer-too-small:
+
+| Return value `N` | Meaning |
+| --- | --- |
+| `0` | Error (null argument, search failure, or JSON serialization failure). Buffer is untouched. |
+| `0 < N <= buf_cap - 1` | Success. `N` bytes of JSON were written, followed by a NUL terminator. Read the result from `out_json_buf`. |
+| `N > buf_cap` | Buffer was too small. No JSON was written (when `buf_cap >= 1` the buffer is NUL-terminated at index 0). `N` is the required size including the NUL terminator -- allocate `N` bytes and retry. |
+| `-100` | `searchlite_search` only: a Rust panic was caught (`SEARCHLITE_ERR_PANIC`). |
+
+`N == buf_cap` is never returned: success always leaves at least one byte for the NUL terminator, so `N > buf_cap` is an unambiguous "buffer too small" signal even when `buf_cap == 0`.
 
 ## WASM
 

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -120,14 +120,21 @@ int main(void) {
     // Buffer was too small. `written` is the required size including the
     // NUL terminator -- allocate and retry.
     char* big = malloc(written);
-    size_t retry = searchlite_search_request(
-        idx, request, strlen(request), big, written);
-    if (retry > 0 && retry <= written) {
-      printf("%s\n", big);
+    if (big == NULL) {
+      fprintf(stderr, "out of memory\n");
     } else {
-      fprintf(stderr, "search retry failed\n");
+      size_t retry = searchlite_search_request(
+          idx, request, strlen(request), big, written);
+      // Success leaves the return strictly less than buf_cap (so the NUL
+      // terminator fits); retry == written would mean the buffer is still
+      // reported as too small, which should not happen here.
+      if (retry > 0 && retry < written) {
+        printf("%s\n", big);
+      } else {
+        fprintf(stderr, "search retry failed\n");
+      }
+      free(big);
     }
-    free(big);
   } else {
     printf("%s\n", buf);
   }

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -106,7 +106,8 @@ int main(void) {
   }
 
   // 4. Run a search. We allocate a buffer for the JSON response; if the
-  //    result is truncated, retry with a bigger buffer.
+  //    buffer is too small, the return value exceeds `buf_cap` and reports
+  //    the required size so we can retry.
   const char* request =
     "{\"query\":\"rust\",\"limit\":5,\"return_stored\":true}";
   char buf[64 * 1024] = {0};
@@ -114,9 +115,19 @@ int main(void) {
       idx, request, strlen(request), buf, sizeof(buf));
 
   if (written == 0) {
-    fprintf(stderr, "search produced no bytes\n");
-  } else if (written == sizeof(buf) - 1) {
-    fprintf(stderr, "result may be truncated -- retry with larger buffer\n");
+    fprintf(stderr, "search failed\n");
+  } else if (written > sizeof(buf)) {
+    // Buffer was too small. `written` is the required size including the
+    // NUL terminator -- allocate and retry.
+    char* big = malloc(written);
+    size_t retry = searchlite_search_request(
+        idx, request, strlen(request), big, written);
+    if (retry > 0 && retry <= written) {
+      printf("%s\n", big);
+    } else {
+      fprintf(stderr, "search retry failed\n");
+    }
+    free(big);
   } else {
     printf("%s\n", buf);
   }

--- a/searchlite-ffi/searchlite.h
+++ b/searchlite-ffi/searchlite.h
@@ -47,6 +47,17 @@ int32_t searchlite_commit_with_write_key(IndexHandle* handle, const char* write_
 //   Callers should allocate `N` bytes and retry.
 // - `searchlite_search` additionally returns `SEARCHLITE_ERR_PANIC` (`-100`)
 //   if a Rust panic was caught.
+//
+// Signed/unsigned caveat for `searchlite_search`:
+// Its return type is `ssize_t` while `buf_cap` is `size_t`. Because the usual
+// arithmetic conversions promote a signed left operand to unsigned when the
+// right operand is unsigned, a direct `ret > buf_cap` comparison can convert a
+// negative sentinel such as `SEARCHLITE_ERR_PANIC` (`-100`) into a huge
+// unsigned value and misclassify it as "buffer too small". The safe order is:
+// first check `ret <= 0` (handle errors and panic); then, only if `ret > 0`,
+// compare `(size_t)ret > buf_cap` to detect the retry-with-larger-buffer case.
+// `searchlite_search_request` returns `size_t`, so a plain `ret > buf_cap`
+// comparison is sufficient.
 ssize_t searchlite_search(
   IndexHandle* handle,
   const char* query,

--- a/searchlite-ffi/searchlite.h
+++ b/searchlite-ffi/searchlite.h
@@ -35,6 +35,18 @@ int32_t searchlite_add_json_batch(IndexHandle* handle, const char* json, size_t 
 int32_t searchlite_add_json_batch_with_write_key(IndexHandle* handle, const char* json, size_t json_len, const char* write_key);
 int32_t searchlite_commit(IndexHandle* handle);
 int32_t searchlite_commit_with_write_key(IndexHandle* handle, const char* write_key);
+// Search output buffer convention (applies to `searchlite_search` and
+// `searchlite_search_request`):
+// - Return `0` means an error (null argument, search failure, or JSON
+//   serialization failure). The buffer is untouched.
+// - A positive return `N` with `N <= buf_cap - 1` means success: `N` bytes of
+//   JSON were written to `out_json_buf` followed by a NUL terminator.
+// - A positive return `N` with `N > buf_cap` means the buffer was too small:
+//   no JSON was written (when `buf_cap >= 1` the buffer is NUL-terminated at
+//   index 0), and `N` is the required size including the NUL terminator.
+//   Callers should allocate `N` bytes and retry.
+// - `searchlite_search` additionally returns `SEARCHLITE_ERR_PANIC` (`-100`)
+//   if a Rust panic was caught.
 ssize_t searchlite_search(
   IndexHandle* handle,
   const char* query,

--- a/searchlite-ffi/src/lib.rs
+++ b/searchlite-ffi/src/lib.rs
@@ -150,17 +150,47 @@ fn value_to_documents(value: serde_json::Value) -> Result<Vec<Document>, ()> {
   }
 }
 
+/// Copy a JSON payload into a caller-provided C buffer and return the number of
+/// bytes written (not counting the NUL terminator).
+///
+/// Return value convention:
+/// - `0` — the output pointer was null. Nothing was written and the caller has
+///   no way to receive a required-size signal.
+/// - `N` where `0 < N <= buf_cap - 1` — success; `N` bytes of JSON followed by a
+///   NUL byte were written into `out_json_buf`.
+/// - `N` where `N > buf_cap` — the buffer was too small. No JSON was written
+///   (when `buf_cap >= 1` a single NUL byte is written so the buffer is a valid
+///   empty C string). `N` is the required buffer size including the NUL
+///   terminator; the caller should allocate a buffer of that size and retry.
+///
+/// Note: `N == buf_cap` can never be returned — success always leaves at least
+/// one byte for the NUL terminator, so the success case satisfies
+/// `N <= buf_cap - 1`. This makes `N > buf_cap` an unambiguous "buffer too
+/// small" signal even when `buf_cap == 0`.
 fn write_json_to_buffer(json: String, out_json_buf: *mut c_char, buf_cap: usize) -> usize {
-  if out_json_buf.is_null() || buf_cap == 0 {
+  if out_json_buf.is_null() {
     return 0;
   }
   let bytes = json.as_bytes();
-  let len = bytes.len().min(buf_cap.saturating_sub(1));
-  unsafe {
-    std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_json_buf as *mut u8, len);
-    *out_json_buf.add(len) = 0;
+  // Required capacity includes the trailing NUL. `saturating_add` defends
+  // against a pathological `bytes.len() == usize::MAX`, which cannot occur in
+  // practice but lets the helper be total.
+  let required = bytes.len().saturating_add(1);
+  if required > buf_cap {
+    // NUL-terminate what we can so callers that ignore the return value see
+    // an empty C string rather than stale or partial data.
+    if buf_cap >= 1 {
+      unsafe {
+        *out_json_buf = 0;
+      }
+    }
+    return required;
   }
-  len
+  unsafe {
+    std::ptr::copy_nonoverlapping(bytes.as_ptr(), out_json_buf as *mut u8, bytes.len());
+    *out_json_buf.add(bytes.len()) = 0;
+  }
+  bytes.len()
 }
 
 fn run_search(
@@ -905,6 +935,189 @@ mod tests {
       unsafe { searchlite_commit_with_write_key(handle, key.as_ptr()) },
       0
     );
+
+    unsafe { searchlite_index_close(handle) };
+  }
+
+  // Regression tests for BUG-029: callers must be able to distinguish a
+  // successful write from an undersized buffer rather than receiving a
+  // silently-truncated JSON payload.
+  mod write_json_to_buffer {
+    use super::super::write_json_to_buffer;
+    use std::ffi::CStr;
+    use std::os::raw::c_char;
+
+    #[test]
+    fn success_returns_bytes_written_and_nul_terminates() {
+      let json = "{\"a\":1}".to_string();
+      let expected_len = json.len();
+      let mut buf = vec![0xAAu8 as c_char; 64];
+      let written = write_json_to_buffer(json.clone(), buf.as_mut_ptr(), buf.len());
+      assert_eq!(written, expected_len);
+      assert!(written < buf.len(), "success return must be < buf_cap");
+      let c_str = unsafe { CStr::from_ptr(buf.as_ptr()) };
+      assert_eq!(c_str.to_str().unwrap(), json);
+    }
+
+    #[test]
+    fn undersized_buffer_returns_required_size_not_truncated_payload() {
+      // Payload is 7 bytes, so required = 8 (including NUL). Give the caller
+      // only 4 bytes.
+      let json = "{\"a\":1}".to_string();
+      let required = json.len() + 1;
+      let mut buf = vec![0xAAu8 as c_char; 4];
+      let written = write_json_to_buffer(json, buf.as_mut_ptr(), buf.len());
+      // The return value must exceed buf_cap so callers can detect the
+      // too-small-buffer condition, and it must equal the required size.
+      assert_eq!(written, required);
+      assert!(written > buf.len(), "required size must exceed buf_cap");
+      // The buffer must be a valid empty C string rather than a truncated
+      // JSON fragment (no silent data loss).
+      assert_eq!(buf[0], 0);
+      let c_str = unsafe { CStr::from_ptr(buf.as_ptr()) };
+      assert_eq!(c_str.to_bytes(), b"");
+    }
+
+    #[test]
+    fn zero_cap_buffer_still_reports_required_size() {
+      // buf_cap == 0 used to be indistinguishable from other errors because
+      // the helper returned 0. Callers must now learn the required size.
+      let json = "{}".to_string();
+      let required = json.len() + 1;
+      let mut sentinel = 0u8 as c_char;
+      let written = write_json_to_buffer(json, &mut sentinel as *mut c_char, 0);
+      assert_eq!(written, required);
+      assert!(written > 0);
+    }
+
+    #[test]
+    fn exact_fit_buffer_is_success_not_truncation() {
+      // buf_cap == required_size (payload + NUL) must be treated as success,
+      // not as "buffer too small". The return must be bytes_written, which is
+      // strictly less than buf_cap so callers see a value < buf_cap.
+      let json = "hi".to_string();
+      let payload_len = json.len();
+      let mut buf = vec![0xAAu8 as c_char; payload_len + 1];
+      let buf_cap = buf.len();
+      let written = write_json_to_buffer(json, buf.as_mut_ptr(), buf_cap);
+      assert_eq!(written, payload_len);
+      assert!(written < buf_cap, "success return must be < buf_cap");
+      let c_str = unsafe { CStr::from_ptr(buf.as_ptr()) };
+      assert_eq!(c_str.to_str().unwrap(), "hi");
+    }
+
+    #[test]
+    fn null_pointer_returns_zero_for_error() {
+      // With a null pointer we have no way to signal a required size, so
+      // fall back to the generic "0 means error" convention.
+      let json = "{}".to_string();
+      let written = write_json_to_buffer(json, std::ptr::null_mut(), 0);
+      assert_eq!(written, 0);
+    }
+  }
+
+  #[test]
+  fn ffi_search_request_signals_buffer_too_small_without_truncation() {
+    let _guard = test_guard();
+    let dir = tempdir().unwrap();
+    let path = CString::new(dir.path().to_string_lossy().to_string()).unwrap();
+    let handle = unsafe { searchlite_index_open(path.as_ptr(), true) };
+    assert!(!handle.is_null());
+
+    let doc = CString::new(r#"{"_id":"small-buf","body":"buffer too small regression"}"#).unwrap();
+    assert!(unsafe { searchlite_add_json(handle, doc.as_ptr(), doc.as_bytes().len()) } >= 0);
+    assert_eq!(unsafe { searchlite_commit(handle) }, 0);
+
+    let request = json!({
+      "query": "buffer",
+      "limit": 5,
+      "return_stored": true
+    });
+    let request_c = CString::new(request.to_string()).unwrap();
+
+    // First: deliberately undersized buffer. The old behaviour silently
+    // truncated the JSON; the new contract returns the required size.
+    let small_cap = 8usize;
+    let mut small_buf = vec![0xAAu8 as c_char; small_cap];
+    let small_ret = unsafe {
+      searchlite_search_request(
+        handle,
+        request_c.as_ptr(),
+        request_c.as_bytes().len(),
+        small_buf.as_mut_ptr(),
+        small_cap,
+      )
+    };
+    assert!(
+      small_ret > small_cap,
+      "buffer-too-small must be signalled as return > buf_cap, got {small_ret} for cap {small_cap}"
+    );
+    // Buffer must not contain a truncated JSON fragment.
+    let small_bytes = unsafe { CStr::from_ptr(small_buf.as_ptr()) }.to_bytes();
+    assert!(
+      small_bytes.is_empty(),
+      "undersized buffer must not contain truncated payload, got {:?}",
+      String::from_utf8_lossy(small_bytes)
+    );
+
+    // Second: allocate the required size returned by the first call and
+    // retry. The new contract guarantees this retry succeeds.
+    let mut big_buf = vec![0u8 as c_char; small_ret];
+    let big_ret = unsafe {
+      searchlite_search_request(
+        handle,
+        request_c.as_ptr(),
+        request_c.as_bytes().len(),
+        big_buf.as_mut_ptr(),
+        big_buf.len(),
+      )
+    };
+    assert!(big_ret > 0);
+    assert!(
+      big_ret < big_buf.len(),
+      "success return must be < buf_cap (got {big_ret} / {})",
+      big_buf.len()
+    );
+    let parsed: serde_json::Value = serde_json::from_slice(
+      unsafe { CStr::from_ptr(big_buf.as_ptr()) }.to_bytes(),
+    )
+    .expect("retry result must be valid JSON");
+    assert_eq!(parsed["hits"].as_array().unwrap().len(), 1);
+
+    unsafe { searchlite_index_close(handle) };
+  }
+
+  #[test]
+  fn ffi_search_signals_buffer_too_small_via_positive_required_size() {
+    let _guard = test_guard();
+    let dir = tempdir().unwrap();
+    let path = CString::new(dir.path().to_string_lossy().to_string()).unwrap();
+    let handle = unsafe { searchlite_index_open(path.as_ptr(), true) };
+    assert!(!handle.is_null());
+
+    let doc = CString::new(r#"{"_id":"s1","body":"search signal regression"}"#).unwrap();
+    assert!(unsafe { searchlite_add_json(handle, doc.as_ptr(), doc.as_bytes().len()) } >= 0);
+    assert_eq!(unsafe { searchlite_commit(handle) }, 0);
+
+    let query = CString::new("search").unwrap();
+    let small_cap = 8usize;
+    let mut small_buf = vec![0xAAu8 as c_char; small_cap];
+    let ret = unsafe {
+      searchlite_search(
+        handle,
+        query.as_ptr(),
+        5,
+        std::ptr::null(),
+        std::ptr::null(),
+        0,
+        small_buf.as_mut_ptr(),
+        small_cap,
+      )
+    };
+    // Positive and greater than buf_cap signals "required size".
+    assert!(ret > small_cap as isize, "expected required size > buf_cap, got {ret}");
+    let bytes = unsafe { CStr::from_ptr(small_buf.as_ptr()) }.to_bytes();
+    assert!(bytes.is_empty(), "buffer must not contain truncated data");
 
     unsafe { searchlite_index_close(handle) };
   }

--- a/searchlite-ffi/src/lib.rs
+++ b/searchlite-ffi/src/lib.rs
@@ -1078,10 +1078,9 @@ mod tests {
       "success return must be < buf_cap (got {big_ret} / {})",
       big_buf.len()
     );
-    let parsed: serde_json::Value = serde_json::from_slice(
-      unsafe { CStr::from_ptr(big_buf.as_ptr()) }.to_bytes(),
-    )
-    .expect("retry result must be valid JSON");
+    let parsed: serde_json::Value =
+      serde_json::from_slice(unsafe { CStr::from_ptr(big_buf.as_ptr()) }.to_bytes())
+        .expect("retry result must be valid JSON");
     assert_eq!(parsed["hits"].as_array().unwrap().len(), 1);
 
     unsafe { searchlite_index_close(handle) };
@@ -1115,7 +1114,10 @@ mod tests {
       )
     };
     // Positive and greater than buf_cap signals "required size".
-    assert!(ret > small_cap as isize, "expected required size > buf_cap, got {ret}");
+    assert!(
+      ret > small_cap as isize,
+      "expected required size > buf_cap, got {ret}"
+    );
     let bytes = unsafe { CStr::from_ptr(small_buf.as_ptr()) }.to_bytes();
     assert!(bytes.is_empty(), "buffer must not contain truncated data");
 


### PR DESCRIPTION
## Summary

`write_json_to_buffer` silently truncated the JSON response when the caller-supplied buffer was too small, then returned a byte count clamped to `buf_cap - 1`. A C caller could not distinguish a complete response that happened to be exactly `buf_cap - 1` bytes long from a truncated payload, so downstream JSON parsers raised \"unexpected end of JSON\" errors that blamed the data rather than the buffer size. Every FFI `searchlite_search` / `searchlite_search_request` caller was affected.

Closes #167 (BUG-029).

## What changed

Change the return convention in `searchlite-ffi/src/lib.rs` so truncation is detectable:

| Return value `N` | Meaning |
| --- | --- |
| `0` | Error (null argument, search failure, JSON serialization failure). Buffer is untouched. |
| `0 < N <= buf_cap - 1` | Success. `N` JSON bytes written, followed by a NUL terminator. |
| `N > buf_cap` | Buffer was too small. No JSON was written (buffer is NUL-terminated at index 0 when `buf_cap >= 1`). `N` is the required size including the NUL terminator; callers should allocate `N` bytes and retry. |
| `-100` | `searchlite_search` only: `SEARCHLITE_ERR_PANIC`. |

`N == buf_cap` can never be returned, because success always leaves at least one byte for the NUL terminator. That makes `N > buf_cap` an unambiguous \"buffer too small\" signal even when `buf_cap == 0`.

- `searchlite-ffi/src/lib.rs` -- rewrite `write_json_to_buffer` with the new contract and doc-comment. `searchlite_search` / `searchlite_search_request` propagate the value unchanged.
- `searchlite-ffi/searchlite.h` -- document the convention above the search declarations.
- `docs/bindings.md` -- replace the misleading \"treat `buf_cap - 1` as potentially truncated\" guidance with the full return-value table.
- `docs/ffi.md` -- update the C example to branch on `written > sizeof(buf)`, allocate the required size, and retry.

## Test plan

- [x] `cargo test -p searchlite-ffi` -- 14/14 pass (was 9/9 before)
  - New `tests::write_json_to_buffer` module: success, undersized buffer, zero-cap buffer, exact-fit buffer, null pointer.
  - New `ffi_search_request_signals_buffer_too_small_without_truncation` -- end-to-end: first call with 8-byte buffer returns required size, second call with that size succeeds and yields parseable JSON.
  - New `ffi_search_signals_buffer_too_small_via_positive_required_size` -- same check via the `ssize_t` entry point.
- [x] `cargo clippy -p searchlite-ffi --tests` -- clean
- [x] `cargo build --workspace` -- clean