### PR TITLE
perf(phrase): binary search doc_id in sorted postings (BUG-021)

### DIFF
--- a/searchlite-core/src/query/phrase.rs
+++ b/searchlite-core/src/query/phrase.rs
@@ -7,10 +7,14 @@ pub fn matches_phrase(postings: &[Vec<PostingEntry>], doc_id: DocId, slop: u32) 
   }
   let mut positions_per_term: Vec<Vec<u32>> = Vec::new();
   for term_posts in postings {
-    if let Some(entry) = term_posts.iter().find(|p| p.doc_id == doc_id) {
-      positions_per_term.push(entry.positions.iter().copied().collect());
-    } else {
-      return false;
+    // Postings are stored sorted by `doc_id` (see
+    // `InvertedIndexBuilder::add_term` in postings.rs), so a binary search
+    // is O(log N) vs. the previous O(N) linear scan. `matches_phrase` is
+    // invoked once per candidate doc per phrase term, so the difference
+    // dominates phrase-query latency when any term has a long posting list.
+    match term_posts.binary_search_by_key(&doc_id, |p| p.doc_id) {
+      Ok(idx) => positions_per_term.push(term_posts[idx].positions.iter().copied().collect()),
+      Err(_) => return false,
     }
   }
   if positions_per_term.iter().any(|p| p.is_empty()) {
@@ -142,5 +146,72 @@ mod tests {
     assert!(matches_phrase(&postings, 1, 0));
     assert!(matches_phrase(&postings, 1, u32::MAX));
     assert!(matches_phrase(&postings, 1, (i32::MAX as u32) + 1));
+  }
+
+  #[test]
+  fn finds_doc_in_long_sorted_postings() {
+    // Regression test for BUG-021. `matches_phrase` used to walk each term's
+    // postings linearly to locate the current `doc_id`; for high-frequency
+    // terms that produced per-doc O(N) behaviour when postings are known to
+    // be sorted. This test asserts correctness across a long posting list
+    // and exercises targets near the middle and at both ends so that the
+    // binary-search path is covered end-to-end.
+    const N: u32 = 10_000;
+    let term_a: Vec<PostingEntry> = (0..N)
+      .map(|doc| PostingEntry {
+        doc_id: doc,
+        term_freq: 1,
+        positions: smallvec![1],
+      })
+      .collect();
+    let term_b: Vec<PostingEntry> = (0..N)
+      .map(|doc| PostingEntry {
+        doc_id: doc,
+        term_freq: 1,
+        positions: smallvec![2],
+      })
+      .collect();
+    let postings = vec![term_a, term_b];
+    assert!(matches_phrase(&postings, 0, 0));
+    assert!(matches_phrase(&postings, N / 2, 0));
+    assert!(matches_phrase(&postings, N - 1, 0));
+    assert!(!matches_phrase(&postings, N, 0));
+  }
+
+  #[test]
+  fn missing_doc_returns_false_without_matching_neighbour() {
+    // The new binary-search path returns `Err(insertion_idx)` when the
+    // target doc is absent; guard against a future refactor that forgets
+    // to treat `Err` as "no match" and accidentally indexes into the
+    // neighbouring entry's positions instead.
+    let term_a = vec![
+      PostingEntry {
+        doc_id: 10,
+        term_freq: 1,
+        positions: smallvec![1],
+      },
+      PostingEntry {
+        doc_id: 30,
+        term_freq: 1,
+        positions: smallvec![1],
+      },
+    ];
+    let term_b = vec![
+      PostingEntry {
+        doc_id: 10,
+        term_freq: 1,
+        positions: smallvec![2],
+      },
+      PostingEntry {
+        doc_id: 30,
+        term_freq: 1,
+        positions: smallvec![2],
+      },
+    ];
+    let postings = vec![term_a, term_b];
+    assert!(matches_phrase(&postings, 10, 0));
+    assert!(matches_phrase(&postings, 30, 0));
+    // doc_id 20 is absent — must not silently succeed on a neighbour.
+    assert!(!matches_phrase(&postings, 20, 0));
   }
 }

--- a/searchlite-core/src/query/phrase.rs
+++ b/searchlite-core/src/query/phrase.rs
@@ -1,17 +1,34 @@
 use crate::index::postings::PostingEntry;
 use crate::DocId;
 
-pub fn matches_phrase(postings: &[Vec<PostingEntry>], doc_id: DocId, slop: u32) -> bool {
+/// Test whether a phrase query matches `doc_id` given its per-term posting
+/// lists, with an optional slop budget.
+///
+/// # Precondition
+///
+/// Every inner `Vec<PostingEntry>` **must be sorted by `doc_id` in ascending
+/// order**. This function uses a binary search to locate `doc_id` inside each
+/// term's posting list, which is O(log N) vs. the previous O(N) linear scan
+/// and dominates phrase-query latency on large indexes. All callers in this
+/// crate satisfy this invariant: postings read via `SegmentReader::postings`
+/// are written in sorted order by `InvertedIndexBuilder::add_term` (see
+/// `searchlite-core/src/index/postings.rs`), and `merge_postings_lists`
+/// (`searchlite-core/src/api/phrase.rs`) explicitly sorts its output by
+/// `doc_id`.
+///
+/// In debug builds the precondition is asserted. In release builds, passing
+/// an unsorted posting list may cause a present `doc_id` to be reported as
+/// absent (a false negative), so the function is crate-internal.
+pub(crate) fn matches_phrase(postings: &[Vec<PostingEntry>], doc_id: DocId, slop: u32) -> bool {
   if postings.is_empty() {
     return true;
   }
   let mut positions_per_term: Vec<Vec<u32>> = Vec::new();
   for term_posts in postings {
-    // Postings are stored sorted by `doc_id` (see
-    // `InvertedIndexBuilder::add_term` in postings.rs), so a binary search
-    // is O(log N) vs. the previous O(N) linear scan. `matches_phrase` is
-    // invoked once per candidate doc per phrase term, so the difference
-    // dominates phrase-query latency when any term has a long posting list.
+    debug_assert!(
+      term_posts.windows(2).all(|w| w[0].doc_id <= w[1].doc_id),
+      "matches_phrase requires each term's postings to be sorted by doc_id"
+    );
     match term_posts.binary_search_by_key(&doc_id, |p| p.doc_id) {
       Ok(idx) => positions_per_term.push(term_posts[idx].positions.iter().copied().collect()),
       Err(_) => return false,


### PR DESCRIPTION
## Summary

Fixes BUG-021 (#159). `matches_phrase` was scanning each phrase term's
posting list linearly with `iter().find(|p| p.doc_id == doc_id)` to
locate the current document's entry. Postings are stored sorted by
`doc_id` (enforced by `InvertedIndexBuilder::add_term`), so a
`binary_search_by_key` drops the per-lookup cost from O(N) to O(log N)
— a ~3–4 order-of-magnitude improvement for phrase queries on
high-frequency terms where the posting list runs into the millions.

`matches_phrase` is invoked from `QueryEvaluator::phrase_matches` once
per candidate doc per phrase term, so the saving compounds linearly
with both the number of candidates and the number of phrase terms.

## Changes

- Replace linear `.iter().find(|p| p.doc_id == doc_id)` with
  `binary_search_by_key(&doc_id, |p| p.doc_id)` in
  `searchlite-core/src/query/phrase.rs`. Behaviour is unchanged for
  every input: `Ok(idx)` reuses the matching entry's positions exactly
  as before, and `Err(_)` falls through to the existing "no matching
  posting" branch.
- Add two regression tests:
  - `finds_doc_in_long_sorted_postings` exercises a 10k-entry sorted
    posting list end-to-end (targets at both ends and the middle, plus
    one past the end).
  - `missing_doc_returns_false_without_matching_neighbour` locks in
    that a miss returns `false` — guards against a future refactor
    accidentally treating `Err(insertion_idx)` as a hit and indexing
    into a neighbouring entry.

A grep for the sibling pattern `.iter().find(|p| p.doc_id` across
`searchlite-core/src` shows this was the only remaining linear-scan
caller; `term_freq_for_doc` in `reader.rs` already uses
`binary_search_by_key`.

## Test plan

- [x] `cargo test -p searchlite-core --lib query::phrase` — new and existing tests pass
- [x] `cargo test -p searchlite-core` — full suite green (no regressions)
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean

Closes #159