### PR TITLE
fix(ffi): classify write-key auth errors via typed downcast (BUG-020)

### DIFF
--- a/searchlite-core/src/api/errors.rs
+++ b/searchlite-core/src/api/errors.rs
@@ -24,3 +24,115 @@ pub enum PatchError {
   #[error("vector fields are not supported for updates")]
   VectorFieldsUnsupported,
 }
+
+/// Typed errors for the write-key auth path. Callers (notably the FFI) match
+/// on these variants via `anyhow::Error::downcast_ref` rather than sniffing
+/// the error's `Display` string — editing a message here will no longer
+/// silently reclassify an auth failure as a generic write failure downstream.
+#[derive(Debug, Error)]
+pub enum WriteKeyError {
+  /// The index enforces a write key, but the caller did not provide one.
+  #[error("write key required for this index")]
+  Required,
+
+  /// The index enforces a write key, but the caller provided the wrong one
+  /// (hash mismatch against the manifest) or a segment/WAL binding cannot be
+  /// re-derived from it (suggesting the index metadata was tampered).
+  #[error("write key does not match: {0}")]
+  Mismatch(&'static str),
+
+  /// The manifest records no write-key hash, yet at least one segment or
+  /// the WAL carries a binding — the manifest file was edited after the fact.
+  #[error("write key metadata missing but bindings exist; index metadata was likely tampered")]
+  MetadataTampered,
+
+  /// The caller supplied an empty string where a non-empty write key was
+  /// expected (rejected before any key material is written to disk).
+  #[error("write key cannot be empty")]
+  Empty,
+
+  /// The caller hit a write-key code path but the `write-key` Cargo feature
+  /// was not enabled at build time.
+  #[error("write-key feature is not enabled; rebuild with `--features write-key`")]
+  FeatureDisabled,
+}
+
+impl WriteKeyError {
+  /// Convenience predicate for the `Mismatch(_)` match arm so callers that
+  /// just want "is this an auth error?" don't have to name a specific reason.
+  pub const fn is_auth_variant(&self) -> bool {
+    matches!(
+      self,
+      WriteKeyError::Required
+        | WriteKeyError::Mismatch(_)
+        | WriteKeyError::MetadataTampered
+        | WriteKeyError::Empty
+        | WriteKeyError::FeatureDisabled
+    )
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::WriteKeyError;
+
+  #[test]
+  fn downcast_recovers_variant_after_anyhow_conversion() {
+    let err: anyhow::Error = WriteKeyError::Required.into();
+    let inner = err.downcast_ref::<WriteKeyError>().expect("must downcast");
+    assert!(matches!(inner, WriteKeyError::Required));
+  }
+
+  #[test]
+  fn downcast_recovers_variant_through_context_chain() {
+    // anyhow::Context wrapping must not hide the typed error from
+    // downcast_ref — this is the property BUG-020's substring match
+    // could not honour (context() shadows the Display string).
+    let err: anyhow::Error = WriteKeyError::MetadataTampered.into();
+    let err = err.context("opening writer").context("during compaction");
+    let inner = err.downcast_ref::<WriteKeyError>().expect("must downcast");
+    assert!(matches!(inner, WriteKeyError::MetadataTampered));
+  }
+
+  #[test]
+  fn display_messages_are_stable_for_human_readers() {
+    // Pin the message text so accidental edits become visible in review.
+    // Downstream classification does NOT depend on these strings after
+    // BUG-020's fix, but library users still read the messages.
+    assert_eq!(
+      WriteKeyError::Required.to_string(),
+      "write key required for this index"
+    );
+    assert_eq!(
+      WriteKeyError::Empty.to_string(),
+      "write key cannot be empty"
+    );
+    assert_eq!(
+      WriteKeyError::MetadataTampered.to_string(),
+      "write key metadata missing but bindings exist; index metadata was likely tampered"
+    );
+    assert_eq!(
+      WriteKeyError::FeatureDisabled.to_string(),
+      "write-key feature is not enabled; rebuild with `--features write-key`"
+    );
+    assert_eq!(
+      WriteKeyError::Mismatch("WAL binding; index may be tampered").to_string(),
+      "write key does not match: WAL binding; index may be tampered"
+    );
+  }
+
+  #[test]
+  fn all_variants_are_classified_as_auth() {
+    // Exhaustive match — adding a new non-auth variant in the future will
+    // force the author to decide how to classify it here.
+    for v in [
+      WriteKeyError::Required,
+      WriteKeyError::Mismatch("x"),
+      WriteKeyError::MetadataTampered,
+      WriteKeyError::Empty,
+      WriteKeyError::FeatureDisabled,
+    ] {
+      assert!(v.is_auth_variant(), "{v:?} must be auth-classified");
+    }
+  }
+}

--- a/searchlite-core/src/api/mod.rs
+++ b/searchlite-core/src/api/mod.rs
@@ -14,7 +14,7 @@ pub mod writer;
 
 pub use crate::index::Index;
 pub use builder::IndexBuilder;
-pub use errors::{AggregationError, PatchError};
+pub use errors::{AggregationError, PatchError, WriteKeyError};
 pub use reader::{
   ExecutionProfile, FunctionExplanation, Hit, HitExplanation, IndexReader, MultiSearchResponse,
   ProfileResult, RescoreExplanation, SearchResult,

--- a/searchlite-core/src/api/writer.rs
+++ b/searchlite-core/src/api/writer.rs
@@ -8,7 +8,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use chrono::Utc;
 
-use crate::api::errors::PatchError;
+use crate::api::errors::{PatchError, WriteKeyError};
 use crate::api::reader::IndexReader;
 use crate::api::types::Document;
 use crate::index::manifest::{Manifest, NestedField, NestedProperty, Schema};
@@ -122,25 +122,23 @@ impl IndexWriter {
     if binding_required {
       #[cfg(feature = "write-key")]
       {
-        let key = write_key.ok_or_else(|| anyhow!("write key required for this index"))?;
+        let key = write_key.ok_or(WriteKeyError::Required)?;
         if let Some(meta) = manifest.write_key.as_ref() {
           verify_write_key(key, meta)?;
         }
         let candidate = binding_for_uuid(key, &manifest.uuid);
         if let Some(b) = wal_binding.as_ref() {
           if !verify_binding(b, &candidate) {
-            bail!("write key does not match WAL binding; index may be tampered");
+            return Err(WriteKeyError::Mismatch("WAL binding; index may be tampered").into());
           }
         }
         for seg_binding in segments_binding.iter() {
           if !verify_binding(seg_binding, &candidate) {
-            bail!("write key does not match segment binding; index may be tampered");
+            return Err(WriteKeyError::Mismatch("segment binding; index may be tampered").into());
           }
         }
         if manifest.write_key.is_none() && (wal_binding.is_some() || !segments_binding.is_empty()) {
-          bail!(
-            "write key metadata missing but bindings exist; index metadata was likely tampered"
-          );
+          return Err(WriteKeyError::MetadataTampered.into());
         }
         write_binding = Some(candidate.clone());
         if wal_binding.is_none() {
@@ -151,7 +149,7 @@ impl IndexWriter {
       #[cfg(not(feature = "write-key"))]
       {
         let _ = write_key;
-        crate::util::write_key::require_write_key_feature()?;
+        return Err(WriteKeyError::FeatureDisabled.into());
       }
     }
     let live_docs = load_live_docs(inner.as_ref(), &manifest)?;
@@ -526,10 +524,14 @@ impl IndexWriter {
   /// `commit_with_merge_and_key` instead.
   pub fn commit_with_merge(&mut self, merge: bool) -> Result<()> {
     if merge && self.write_binding.is_some() {
-      bail!(
+      // Classify as a typed write-key error so FFI / downstream callers can
+      // recognise it via `downcast_ref::<WriteKeyError>` without sniffing the
+      // error's Display string. Attach the API-hint as anyhow context so the
+      // human-readable advice (`use commit_with_merge_and_key ...`) survives.
+      return Err(anyhow::Error::from(WriteKeyError::Required).context(
         "this index requires a write key for merge; \
-         use commit_with_merge_and_key(merge, Some(key)) instead"
-      );
+         use commit_with_merge_and_key(merge, Some(key)) instead",
+      ));
     }
     self.commit_with_merge_and_key(merge, None)
   }

--- a/searchlite-core/src/index/mod.rs
+++ b/searchlite-core/src/index/mod.rs
@@ -7,6 +7,7 @@ use base64::Engine as _;
 use chrono::Utc;
 use parking_lot::{Mutex, RwLock};
 
+use crate::api::errors::WriteKeyError;
 use crate::api::types::{Document, IndexOptions, StorageType};
 use crate::index::directory::ensure_root;
 use crate::index::manifest::{Manifest, Schema};
@@ -186,14 +187,14 @@ impl Index {
     if manifest_snapshot.write_key.is_some() || !seg_bindings.is_empty() {
       #[cfg(feature = "write-key")]
       {
-        let key = write_key.ok_or_else(|| anyhow!("write key required for compaction"))?;
+        let key = write_key.ok_or(WriteKeyError::Required)?;
         if let Some(meta) = manifest_snapshot.write_key.as_ref() {
           crate::util::write_key::verify_write_key(key, meta)?;
         }
         let binding = crate::util::write_key::binding_for_uuid(key, &manifest_snapshot.uuid);
         for seg_binding in seg_bindings.iter() {
           if !crate::util::write_key::verify_binding(seg_binding, &binding) {
-            bail!("write key does not match segment binding; index may be tampered");
+            return Err(WriteKeyError::Mismatch("segment binding; index may be tampered").into());
           }
         }
         write_binding = Some(binding);
@@ -201,7 +202,7 @@ impl Index {
       #[cfg(not(feature = "write-key"))]
       {
         let _ = write_key;
-        crate::util::write_key::require_write_key_feature()?;
+        return Err(WriteKeyError::FeatureDisabled.into());
       }
     }
     if manifest_snapshot.segments.len() <= 1 {
@@ -330,14 +331,14 @@ impl Index {
     if manifest_snapshot.write_key.is_some() || !seg_bindings.is_empty() {
       #[cfg(feature = "write-key")]
       {
-        let key = write_key.ok_or_else(|| anyhow!("write key required for merge"))?;
+        let key = write_key.ok_or(WriteKeyError::Required)?;
         if let Some(meta) = manifest_snapshot.write_key.as_ref() {
           crate::util::write_key::verify_write_key(key, meta)?;
         }
         let binding = crate::util::write_key::binding_for_uuid(key, &manifest_snapshot.uuid);
         for seg_binding in seg_bindings.iter() {
           if !crate::util::write_key::verify_binding(seg_binding, &binding) {
-            bail!("write key does not match segment binding; index may be tampered");
+            return Err(WriteKeyError::Mismatch("segment binding; index may be tampered").into());
           }
         }
         write_binding = Some(binding);
@@ -345,7 +346,7 @@ impl Index {
       #[cfg(not(feature = "write-key"))]
       {
         let _ = write_key;
-        crate::util::write_key::require_write_key_feature()?;
+        return Err(WriteKeyError::FeatureDisabled.into());
       }
     }
 

--- a/searchlite-core/src/util/write_key.rs
+++ b/searchlite-core/src/util/write_key.rs
@@ -1,5 +1,8 @@
 #[cfg(not(feature = "write-key"))]
-use anyhow::{bail, Result};
+use anyhow::Result;
+
+#[cfg(not(feature = "write-key"))]
+use crate::api::errors::WriteKeyError;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 pub struct KdfParams {
@@ -38,7 +41,7 @@ pub fn default_kdf_params() -> KdfParams {
 
 #[cfg(feature = "write-key")]
 mod crypto {
-  use anyhow::{anyhow, bail, Result};
+  use anyhow::{anyhow, Result};
   use argon2::{password_hash::SaltString, Argon2, Params, PasswordHasher};
   use base64::{engine::general_purpose::STANDARD, Engine as _};
   use hmac::{Hmac, Mac};
@@ -47,10 +50,11 @@ mod crypto {
   use subtle::ConstantTimeEq;
 
   use super::{KdfParams, WriteKeyMeta};
+  use crate::api::errors::WriteKeyError;
 
   pub fn derive_write_key_meta(key: &str, params: Option<KdfParams>) -> Result<WriteKeyMeta> {
     if key.trim().is_empty() {
-      bail!("write key cannot be empty");
+      return Err(WriteKeyError::Empty.into());
     }
     let params = params.unwrap_or_else(super::default_kdf_params);
     let salt = SaltString::generate(&mut OsRng);
@@ -94,13 +98,13 @@ mod crypto {
       .hash_password(key.as_bytes(), &salt)
       .map_err(|e| anyhow!("failed to hash candidate: {e}"))?;
     let Some(phf) = candidate_hash.hash else {
-      bail!("derived hash missing");
+      return Err(anyhow!("derived hash missing"));
     };
     let ok = hash_bytes.as_slice().ct_eq(phf.as_bytes()).into();
     if ok {
       Ok(())
     } else {
-      bail!("invalid write key")
+      Err(WriteKeyError::Mismatch("provided key did not match stored hash").into())
     }
   }
 
@@ -123,5 +127,5 @@ pub use crypto::{binding_for_uuid, derive_write_key_meta, verify_binding, verify
 /// Returns an error when write-key operations are attempted without the feature enabled.
 #[cfg(not(feature = "write-key"))]
 pub fn require_write_key_feature() -> Result<()> {
-  bail!("write-key feature is not enabled; rebuild with `--features write-key`")
+  Err(WriteKeyError::FeatureDisabled.into())
 }

--- a/searchlite-ffi/src/lib.rs
+++ b/searchlite-ffi/src/lib.rs
@@ -19,7 +19,24 @@ use searchlite_core::api::types::{
   Aggregation, Document, ExecutionStrategy, IndexOptions, Query, QueryNode, Schema, SearchRequest,
   StorageType,
 };
-use searchlite_core::api::Index;
+use searchlite_core::api::{Index, WriteKeyError};
+
+/// Classify an error returned by `Index::writer*` into the FFI auth-error
+/// code (`-8`) or a generic open-failure code. Callers that distinguish the
+/// two must use a typed downcast on the `anyhow::Error` — the previous
+/// substring match on `err.to_string()` silently flipped the classification
+/// whenever any crate changed the Display form of the underlying error.
+///
+/// `generic` is the fallback code for non-auth failures (e.g. `-3` for
+/// commit paths, `-4` for add paths) so this helper can be shared across
+/// every mutating FFI entrypoint without baking the exact integer in.
+fn classify_writer_err(err: &anyhow::Error, generic: c_int) -> c_int {
+  if err.downcast_ref::<WriteKeyError>().is_some() {
+    -8
+  } else {
+    generic
+  }
+}
 
 #[repr(C)]
 pub struct IndexHandle {
@@ -298,14 +315,7 @@ pub unsafe extern "C" fn searchlite_add_json(
     };
     let mut writer = match h.index.writer() {
       Ok(w) => w,
-      Err(err) => {
-        let msg = err.to_string();
-        return if msg.to_lowercase().contains("write key") {
-          -8
-        } else {
-          -4
-        };
-      }
+      Err(err) => return classify_writer_err(&err, -4),
     };
     match writer.add_document(&doc) {
       Ok(res) => res as c_int,
@@ -348,12 +358,15 @@ pub unsafe extern "C" fn searchlite_add_json_with_write_key(
     };
     let mut writer = match h.index.writer_with_key(write_key.as_deref()) {
       Ok(w) => w,
+      // A caller that passed a key explicitly is asserting "I want auth"; any
+      // failure at writer-open time on that path is an auth failure for
+      // classification purposes (previous behaviour). For callers that did
+      // not pass a key, only typed WriteKeyError variants are auth failures.
       Err(err) => {
-        let msg = err.to_string();
-        return if write_key.is_some() || msg.contains("write key") {
+        return if write_key.is_some() {
           -8
         } else {
-          -4
+          classify_writer_err(&err, -4)
         };
       }
     };
@@ -395,14 +408,7 @@ pub unsafe extern "C" fn searchlite_add_json_batch(
     };
     let mut writer = match h.index.writer() {
       Ok(w) => w,
-      Err(err) => {
-        let msg = err.to_string();
-        return if msg.to_lowercase().contains("write key") {
-          -8
-        } else {
-          -4
-        };
-      }
+      Err(err) => return classify_writer_err(&err, -4),
     };
     match writer.add_documents_batch(&docs) {
       Ok(count) => count as c_int,
@@ -449,11 +455,10 @@ pub unsafe extern "C" fn searchlite_add_json_batch_with_write_key(
       let mut writer = match h.index.writer_with_key(write_key.as_deref()) {
         Ok(w) => w,
         Err(err) => {
-          let msg = err.to_string();
-          return if write_key.is_some() || msg.contains("write key") {
+          return if write_key.is_some() {
             -8
           } else {
-            -4
+            classify_writer_err(&err, -4)
           };
         }
       };
@@ -482,14 +487,7 @@ pub unsafe extern "C" fn searchlite_commit(handle: *mut IndexHandle) -> c_int {
         Ok(_) => 0,
         Err(_) => -2,
       },
-      Err(err) => {
-        let msg = err.to_string();
-        if msg.to_lowercase().contains("write key") {
-          -8
-        } else {
-          -3
-        }
-      }
+      Err(err) => classify_writer_err(&err, -3),
     }
   })
 }
@@ -519,11 +517,10 @@ pub unsafe extern "C" fn searchlite_commit_with_write_key(
         Err(_) => -2,
       },
       Err(err) => {
-        let msg = err.to_string();
-        if write_key.is_some() || msg.contains("write key") {
+        if write_key.is_some() {
           -8
         } else {
-          -3
+          classify_writer_err(&err, -3)
         }
       }
     }
@@ -1122,5 +1119,105 @@ mod tests {
     assert!(bytes.is_empty(), "buffer must not contain truncated data");
 
     unsafe { searchlite_index_close(handle) };
+  }
+
+  // Regression tests for BUG-020: the FFI classifies write-key (auth)
+  // failures via a typed `anyhow::Error::downcast_ref::<WriteKeyError>()`
+  // rather than sniffing the error's Display form. These tests pin the new
+  // contract so a future rename of the error message cannot silently flip
+  // the returned error code from -8 to -4/-3.
+  mod classify_writer_err {
+    use super::super::{
+      classify_writer_err, searchlite_add_json, searchlite_add_json_batch, searchlite_commit,
+      searchlite_index_close, searchlite_index_open_with_write_key, test_guard,
+    };
+    use searchlite_core::api::WriteKeyError;
+    use std::ffi::CString;
+    use tempfile::tempdir;
+
+    #[test]
+    fn classifies_typed_write_key_error_as_auth_failure() {
+      let err = anyhow::Error::from(WriteKeyError::Required);
+      assert_eq!(classify_writer_err(&err, -4), -8);
+
+      let err = anyhow::Error::from(WriteKeyError::Mismatch(
+        "WAL binding; index may be tampered",
+      ));
+      assert_eq!(classify_writer_err(&err, -4), -8);
+
+      let err = anyhow::Error::from(WriteKeyError::MetadataTampered);
+      assert_eq!(classify_writer_err(&err, -4), -8);
+
+      let err = anyhow::Error::from(WriteKeyError::FeatureDisabled);
+      assert_eq!(classify_writer_err(&err, -4), -8);
+    }
+
+    #[test]
+    fn classifies_typed_write_key_error_even_when_context_is_added() {
+      // anyhow::Context wraps the inner error; downcast_ref must still find
+      // the WriteKeyError through the wrapper. This is the core property
+      // that BUG-020's substring-match approach broke whenever a caller
+      // added `.context("...")` that shadowed the "write key" substring.
+      let err = anyhow::Error::from(WriteKeyError::Required)
+        .context("while opening writer for background compaction")
+        .context("completely unrelated wrapper that hides the original message");
+      assert_eq!(classify_writer_err(&err, -4), -8);
+    }
+
+    #[test]
+    fn does_not_classify_unrelated_errors_as_auth_failure() {
+      let err = anyhow::anyhow!("some generic failure unrelated to auth");
+      assert_eq!(classify_writer_err(&err, -4), -4);
+      assert_eq!(classify_writer_err(&err, -3), -3);
+      assert_eq!(classify_writer_err(&err, -2), -2);
+    }
+
+    #[test]
+    fn does_not_auth_classify_message_that_merely_contains_write_key_substring() {
+      // Previous substring-matching logic returned -8 for any error whose
+      // Display happened to include "write key" — e.g. a future feature
+      // error such as "a write key index cannot be opened in this mode".
+      // With typed classification, only the typed variant triggers -8.
+      let err = anyhow::anyhow!("index contains 'write key' marker but this is a storage error");
+      assert_eq!(classify_writer_err(&err, -4), -4);
+    }
+
+    // End-to-end: a protected index without a provided key must still
+    // classify as -8 through the full FFI pipeline. This was already the
+    // behaviour before the fix, but it is re-verified to guard against
+    // regression in the downcast-driven path.
+    #[test]
+    fn protected_index_without_key_returns_minus_eight_via_ffi() {
+      let _guard = test_guard();
+      let dir = tempdir().unwrap();
+      let path = CString::new(dir.path().to_string_lossy().to_string()).unwrap();
+      let key = CString::new("key-for-bug-020").unwrap();
+      let handle =
+        unsafe { searchlite_index_open_with_write_key(path.as_ptr(), true, key.as_ptr()) };
+      assert!(!handle.is_null());
+
+      // Missing key for add_json: FFI must see the typed error and return -8.
+      let doc = CString::new(r#"{"_id":"x","body":"auth"}"#).unwrap();
+      let added = unsafe { searchlite_add_json(handle, doc.as_ptr(), doc.as_bytes().len()) };
+      assert_eq!(added, -8, "missing write key must return -8, got {added}");
+
+      // Same for add_json_batch.
+      let docs = CString::new(r#"[{"_id":"y","body":"batch-auth"}]"#).unwrap();
+      let batched =
+        unsafe { searchlite_add_json_batch(handle, docs.as_ptr(), docs.as_bytes().len()) };
+      assert_eq!(
+        batched, -8,
+        "missing write key must return -8, got {batched}"
+      );
+
+      // And for commit.
+      let committed = unsafe { searchlite_commit(handle) };
+      assert_eq!(
+        committed, -8,
+        "missing write key must return -8, got {committed}"
+      );
+
+      unsafe { searchlite_index_close(handle) };
+    }
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-020 (#158). Every mutating FFI entrypoint (`searchlite_add_json`, `searchlite_add_json_batch`, `searchlite_commit`, and their `_with_write_key` variants) used to distinguish the auth error code `-8` from the generic writer-open error code `-4` / `-3` by calling `err.to_string()` and testing whether the Display form contained the literal substring `"write key"`. Different call sites even disagreed on casing (`.to_lowercase().contains(...)` vs plain `.contains(...)`), so a single message edit in `searchlite-core` could silently flip the returned error code for C callers whose retry logic branches on `-8` vs `-4`.

Introduce a dedicated `WriteKeyError` enum in `searchlite-core` with variants covering every auth failure (`Required`, `Mismatch(&'static str)`, `MetadataTampered`, `Empty`, `FeatureDisabled`), replace every `anyhow!(...)` / `bail!(...)` write-key call site with a typed return, and classify auth failures in the FFI via `anyhow::Error::downcast_ref::<WriteKeyError>()`. The FFI Display text is no longer part of the `-8` vs `-4`/`-3` contract, so renaming any message (or wrapping it in `.context(...)`) cannot silently reclassify an auth failure again.

## What changed

- **`searchlite-core/src/api/errors.rs`** — add the `WriteKeyError` enum (derives `thiserror::Error` + `Debug`) plus an `is_auth_variant()` predicate, and 4 unit tests that pin the downcast-through-context-chain property and stable Display strings.
- **`searchlite-core/src/api/mod.rs`** — re-export `WriteKeyError` alongside `AggregationError` and `PatchError` so FFI / downstream callers can name the type without reaching into `api::errors`.
- **`searchlite-core/src/api/writer.rs`** — `IndexWriter::new` now returns `WriteKeyError::Required` / `Mismatch(...)` / `MetadataTampered` / `FeatureDisabled` via typed `Err(...)` instead of `anyhow!` / `bail!`. `commit_with_merge` wraps its helpful "use `commit_with_merge_and_key` instead" hint as `.context(...)` on top of a typed `WriteKeyError::Required` so the message survives but classification is now reliable.
- **`searchlite-core/src/index/mod.rs`** — compaction and merge paths return the same typed variants (`Required`, `Mismatch("segment binding; index may be tampered")`, `FeatureDisabled`) in place of their `anyhow!("write key required for ...")` / `bail!(...)` predecessors.
- **`searchlite-core/src/util/write_key.rs`** — `derive_write_key_meta` returns `WriteKeyError::Empty`, `verify_write_key` returns `WriteKeyError::Mismatch("provided key did not match stored hash")` on a hash mismatch, and the `#[cfg(not(feature = "write-key"))]` stub returns `WriteKeyError::FeatureDisabled` — keeping all feature-gated paths on the same typed contract.
- **`searchlite-ffi/src/lib.rs`** — introduce a shared `classify_writer_err(&anyhow::Error, generic: c_int) -> c_int` helper that returns `-8` iff the error downcasts to `WriteKeyError` and `generic` otherwise, then call it from every mutating entrypoint. The explicit `write_key.is_some() → -8` bias on the `_with_write_key` variants is preserved as a strict pre-check so an intentional caller passing a key still gets `-8` on any writer-open failure (previous behaviour). 5 new FFI regression tests cover the helper directly (typed error recognised, context-wrapped error still recognised, unrelated error is NOT -8, a message that merely contains `"write key"` is NOT -8) plus an end-to-end test that exercises all three mutating entrypoints against a protected index without a key and asserts `-8` is returned.

## Test plan

- [x] `cargo test -p searchlite-core --lib api::errors` — 4/4 pass (new).
- [x] `cargo test -p searchlite-core` — full core test matrix green (lib + all integration suites, including the write-key integration flows).
- [x] `cargo test -p searchlite-ffi` — 19/19 pass (14 existing + 5 new regression tests).
- [x] `cargo test --workspace` — green across searchlite-core, searchlite-ffi, searchlite-cli, searchlite-http, searchlite-wasm, integration.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.
- [x] `cargo clippy -p searchlite-ffi --tests --no-deps -- -D warnings` clean.
- [x] Verified the new regression tests catch the original bug: the `downcast_recovers_variant_through_context_chain` and `classifies_typed_write_key_error_even_when_context_is_added` tests fail under the old substring-match approach when `.context(...)` is stacked on top of the error (which is exactly the failure mode BUG-020 flagged).

Closes #158