### PR TITLE
fix(writer): make WAL commit the durability fence (BUG-018)

### DIFF
--- a/searchlite-core/src/api/writer.rs
+++ b/searchlite-core/src/api/writer.rs
@@ -385,6 +385,31 @@ impl IndexWriter {
     let serialized_manifest =
       serde_json::to_vec_pretty(&new_manifest).context("serializing manifest for commit")?;
 
+    // Promote any leftover `.pending` from a prior commit whose manifest
+    // publish failed post-fence. This prevents overwriting a durable staged
+    // manifest with uncommitted content — without this, the old `.pending`
+    // (which represents an already-committed batch) would be silently
+    // replaced by the new staging write below.
+    if self.inner.storage.exists(&pending_manifest_path) {
+      match self.inner.storage.read_to_end(&pending_manifest_path) {
+        Ok(prior_data) => {
+          if let Err(e) = self.inner.storage.atomic_write(&manifest_path, &prior_data) {
+            log::error!(
+              "failed to promote leftover staged manifest before new commit: {e}; \
+               proceeding with overwrite — recovery on next open will reconcile"
+            );
+          }
+          let _ = self.inner.storage.remove(&pending_manifest_path);
+        }
+        Err(e) => {
+          log::error!(
+            "failed to read leftover staged manifest before new commit: {e}; \
+             proceeding with overwrite — recovery on next open will reconcile"
+          );
+        }
+      }
+    }
+
     // Step 1 — stage manifest (pre-fence; rollback on failure).
     if let Err(e) = self
       .inner
@@ -415,14 +440,6 @@ impl IndexWriter {
         log::error!(
           "Pending manifest cleanup failed while handling commit error: {remove_err}. \
            Recovery on the next open will discard the staged file."
-        );
-      }
-      if let Err(manifest_err) =
-        manifest_snapshot.store(self.inner.storage.as_ref(), &manifest_path)
-      {
-        log::error!(
-          "Manifest rollback failed while handling commit error: {manifest_err}. \
-           The on-disk manifest and WAL may be inconsistent."
         );
       }
       if !new_segments.is_empty() {
@@ -1171,7 +1188,7 @@ mod tests {
       "WAL must retain pending ops when the pre-fence manifest stage fails",
     );
     assert!(
-      !Wal::has_trailing_commit(storage.as_ref(), &wal_path).unwrap(),
+      !Wal::contains_commit(storage.as_ref(), &wal_path).unwrap(),
       "no WAL commit should have been appended on a pre-fence failure",
     );
     let pending_path = Manifest::manifest_pending_path(dir.path());
@@ -1228,8 +1245,8 @@ mod tests {
     );
     let wal_path = directory::wal_path(dir.path());
     assert!(
-      Wal::has_trailing_commit(storage.as_ref(), &wal_path).unwrap(),
-      "WAL must have a trailing commit marker after the durability fence",
+      Wal::contains_commit(storage.as_ref(), &wal_path).unwrap(),
+      "WAL must contain a commit marker after the durability fence",
     );
     let pending_path = Manifest::manifest_pending_path(dir.path());
     assert!(
@@ -1239,7 +1256,7 @@ mod tests {
   }
 
   #[test]
-  fn open_promotes_pending_manifest_when_wal_has_trailing_commit() {
+  fn open_promotes_pending_manifest_when_wal_has_commit() {
     // BUG-018 reconciliation: on startup, if the previous commit was
     // interrupted between the WAL commit fence and the live manifest
     // publish, `Index::open` must promote the staged manifest so the next
@@ -1298,7 +1315,7 @@ mod tests {
   }
 
   #[test]
-  fn open_discards_pending_manifest_when_wal_has_no_trailing_commit() {
+  fn open_discards_pending_manifest_when_wal_has_no_commit() {
     // BUG-018: a `.pending` file with no trailing WAL commit corresponds
     // to a commit that never crossed the durability fence. The staged
     // manifest must be discarded so the live manifest stays authoritative.
@@ -1403,6 +1420,73 @@ mod tests {
     assert_eq!(
       after_second_commit, segments_after_normal_commit,
       "an empty commit on the recovered index must not produce another segment",
+    );
+  }
+
+  #[test]
+  fn open_promotes_pending_manifest_despite_uncommitted_entries_after_fence() {
+    // Codex/Copilot review scenario: post-fence manifest publish fails,
+    // then a later uncommitted write is appended before a crash. The WAL
+    // looks like [..., Commit, AddDoc]. Recovery must still promote
+    // `.pending` because the Commit is durable — the trailing AddDoc
+    // must not hide it. `last_pending_ops` correctly replays only the
+    // entries after the last Commit (the uncommitted AddDoc).
+    let dir = tempdir().unwrap();
+    let schema = Schema::default_text_body();
+    let idx = Index::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+    let storage = idx.inner.storage.clone();
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+
+    // Synthesize the interrupted state: staged manifest + durable commit
+    // + a subsequent uncommitted AddDoc.
+    let mut staged = Manifest::load(storage.as_ref(), &manifest_path).unwrap();
+    staged.committed_at = "2099-12-31T23:59:59+00:00".into();
+    let staged_bytes = serde_json::to_vec_pretty(&staged).unwrap();
+    storage.atomic_write(&pending_path, &staged_bytes).unwrap();
+    {
+      let wal_path = directory::wal_path(dir.path());
+      let mut wal = Wal::open(storage.clone(), &wal_path).unwrap();
+      // Durable commit for the staged manifest's batch.
+      wal.append_commit().unwrap();
+      // Uncommitted write appended after the fence, before the crash.
+      wal
+        .append_add_doc(&Document {
+          fields: [
+            ("_id".into(), serde_json::json!("uncommitted")),
+            ("body".into(), serde_json::json!("pending after fence")),
+          ]
+          .into_iter()
+          .collect(),
+        })
+        .unwrap();
+      wal.sync().unwrap();
+    }
+    drop(idx);
+
+    // Reopen: recovery must promote `.pending` and replay the uncommitted
+    // AddDoc as a pending op.
+    let opts2 = opts(dir.path());
+    let idx2 = Index::open_with_storage(opts2, storage.clone()).unwrap();
+    let live = idx2.manifest();
+    assert_eq!(
+      live.committed_at, "2099-12-31T23:59:59+00:00",
+      "the staged manifest must be promoted even when uncommitted entries follow the fence",
+    );
+    assert!(
+      !storage.exists(&pending_path),
+      "the staging file must be cleaned up after reconciliation",
+    );
+    // The uncommitted AddDoc must appear as a pending op in the new writer.
+    let writer = idx2.writer().unwrap();
+    assert_eq!(
+      writer
+        .pending_ops
+        .iter()
+        .filter(|op| matches!(op, PendingOp::Add { .. }))
+        .count(),
+      1,
+      "the uncommitted AddDoc after the fence must be replayed as a pending op",
     );
   }
 

--- a/searchlite-core/src/api/writer.rs
+++ b/searchlite-core/src/api/writer.rs
@@ -3,7 +3,7 @@ use std::hash::{DefaultHasher, Hash, Hasher};
 use std::path::Path;
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use chrono::Utc;
@@ -355,20 +355,66 @@ impl IndexWriter {
       .unwrap_or(0);
     new_manifest.committed_at = Utc::now().to_rfc3339();
     let manifest_path = self.inner.manifest_path();
+    let pending_manifest_path = Manifest::manifest_pending_path(&self.inner.path);
     let wal_len = self.wal.len()?;
-    if let Err(e) = (|| -> Result<()> {
-      new_manifest.store(self.inner.storage.as_ref(), &manifest_path)?;
-      // `append_commit` fsyncs before returning, so no separate `sync` call
-      // is needed to guarantee the commit record is durable on disk.
-      self.wal.append_commit()?;
-      Ok(())
-    })() {
-      // Roll back manifest to the previous snapshot and restore WAL to its
-      // pre-commit length so pending ops can be retried safely.
+
+    // BUG-018: the WAL commit record is the durability fence. Storing the
+    // manifest *before* appending the commit (the previous order) opened a
+    // crash window in which the manifest referenced a freshly-published
+    // segment but the WAL had no matching `Commit` marker — recovery then
+    // re-applied the same pending ops on the next `commit()`, producing a
+    // duplicate segment and tombstoning every doc in the original one.
+    //
+    // The new order is the standard WAL pattern:
+    //   1. Stage the new manifest to `MANIFEST.json.pending` so the commit
+    //      content survives a crash even if `MANIFEST.json` itself never
+    //      gets republished. If this fails the commit is rolled back —
+    //      nothing has been made durable yet.
+    //   2. Append the WAL commit record (fsync'd internally per BUG-006).
+    //      This is the durability fence. After it returns Ok the batch is
+    //      committed regardless of what happens next.
+    //   3. Promote the staged manifest to the live `MANIFEST.json`. If this
+    //      fails the staged file plus the WAL trailing-commit marker let
+    //      `Index::open` finish the publish on the next start.
+    //
+    // Step 1 must be a separate write rather than an in-memory buffer
+    // because we need the manifest content to survive a crash that happens
+    // between steps 2 and 3 — only durably-staged content can be promoted
+    // by `Index::open`'s reconciliation pass.
+
+    let serialized_manifest =
+      serde_json::to_vec_pretty(&new_manifest).context("serializing manifest for commit")?;
+
+    // Step 1 — stage manifest (pre-fence; rollback on failure).
+    if let Err(e) = self
+      .inner
+      .storage
+      .atomic_write(&pending_manifest_path, &serialized_manifest)
+    {
+      let _ = self.inner.storage.remove(&pending_manifest_path);
+      if !new_segments.is_empty() {
+        let _ = crate::index::cleanup_segments(self.inner.storage.as_ref(), &new_segments);
+      }
+      self.patch_reader = None;
+      self.patch_reader_stamp = None;
+      return Err(e.context("staging manifest for commit"));
+    }
+
+    // Step 2 — WAL commit fence. After Ok the batch is durable; before Ok
+    // we can still roll the entire commit back.
+    if let Err(e) = self.wal.append_commit() {
+      // The WAL fence failed: there is no durable commit yet. Roll back
+      // every pre-fence side effect so a retry sees a clean slate.
       if let Err(truncate_err) = self.wal.truncate_to(wal_len) {
         log::error!(
           "WAL rollback failed while handling commit error: \
            unable to truncate WAL back to length {wal_len}: {truncate_err}"
+        );
+      }
+      if let Err(remove_err) = self.inner.storage.remove(&pending_manifest_path) {
+        log::error!(
+          "Pending manifest cleanup failed while handling commit error: {remove_err}. \
+           Recovery on the next open will discard the staged file."
         );
       }
       if let Err(manifest_err) =
@@ -386,11 +432,56 @@ impl IndexWriter {
       self.patch_reader_stamp = None;
       return Err(e);
     }
+
+    // Step 3 — post-fence: promote the staged manifest to live. Failures
+    // here cannot roll back the commit (it is already durable) — they are
+    // surfaced via logs and reconciled by `Index::open` on the next start,
+    // which detects the staged file plus the WAL trailing-commit marker
+    // and promotes the staged manifest.
+    let manifest_published = match new_manifest.store(self.inner.storage.as_ref(), &manifest_path) {
+      Ok(()) => {
+        // Best-effort cleanup of the staging file. A leftover `.pending`
+        // file is harmless: the next `Index::open` removes it after
+        // reconciliation.
+        if let Err(remove_err) = self.inner.storage.remove(&pending_manifest_path) {
+          log::warn!(
+            "removing staged manifest at {pending_manifest_path:?} failed: {remove_err}; \
+             recovery on next open will clean it up"
+          );
+        }
+        true
+      }
+      Err(store_err) => {
+        log::error!(
+          "Manifest publish failed after WAL commit fence; the batch is durably \
+           committed and `Index::open` will promote the staged manifest on the \
+           next start: {store_err}"
+        );
+        false
+      }
+    };
+
     {
       let mut manifest_guard = self.inner.manifest.write();
       *manifest_guard = new_manifest;
     }
-    self.wal.truncate()?;
+    if manifest_published {
+      // Reclaim WAL space now that the trailing commit marker is no
+      // longer needed for recovery.
+      if let Err(truncate_err) = self.wal.truncate() {
+        // The commit is durable; failing to reclaim WAL space is not
+        // fatal. The next replay still sees the trailing commit and
+        // treats this batch as committed.
+        log::warn!(
+          "WAL truncation after commit failed: {truncate_err}; \
+           the commit remains durable but the WAL file will grow until next truncation"
+        );
+      }
+    }
+    // If `manifest_published` is false the WAL is intentionally left
+    // alone so that the next `Index::open` can detect the trailing
+    // commit and promote the staged manifest. Truncating here would
+    // erase the only on-disk evidence that the batch is durable.
     self.pending_ops.clear();
     self.pending_latest.clear();
     self.patch_reader = None;
@@ -937,6 +1028,7 @@ mod tests {
   struct FailingManifestStorage {
     inner: InMemoryStorage,
     fail_manifest: AtomicBool,
+    fail_pending_manifest: AtomicBool,
   }
 
   impl FailingManifestStorage {
@@ -944,6 +1036,7 @@ mod tests {
       Self {
         inner: InMemoryStorage::new(root),
         fail_manifest: AtomicBool::new(false),
+        fail_pending_manifest: AtomicBool::new(false),
       }
     }
 
@@ -951,8 +1044,23 @@ mod tests {
       self.fail_manifest.store(true, Ordering::SeqCst);
     }
 
+    fn fail_next_pending_manifest_store(&self) {
+      self.fail_pending_manifest.store(true, Ordering::SeqCst);
+    }
+
     fn should_fail(&self, path: &std::path::Path) -> bool {
-      path.ends_with("MANIFEST.json") && self.fail_manifest.swap(false, Ordering::SeqCst)
+      let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or_default();
+      if name == "MANIFEST.json.pending" && self.fail_pending_manifest.swap(false, Ordering::SeqCst)
+      {
+        return true;
+      }
+      if name == "MANIFEST.json" && self.fail_manifest.swap(false, Ordering::SeqCst) {
+        return true;
+      }
+      false
     }
   }
 
@@ -1006,7 +1114,80 @@ mod tests {
   }
 
   #[test]
-  fn wal_retains_pending_when_manifest_store_fails() {
+  fn commit_rolls_back_when_pending_manifest_stage_fails() {
+    // BUG-018: staging the manifest to `MANIFEST.json.pending` happens
+    // *before* the WAL commit fence. A failure here is recoverable —
+    // nothing is durable yet — so the writer must roll back cleanly and
+    // leave the pending ops in place for retry.
+    let dir = tempdir().unwrap();
+    let schema = Schema::default_text_body();
+    let storage = Arc::new(FailingManifestStorage::new(dir.path().to_path_buf()));
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let manifest = Manifest::new(schema.clone());
+    manifest.store(storage.as_ref(), &manifest_path).unwrap();
+
+    let mut opts = opts(dir.path());
+    opts.storage = StorageType::InMemory;
+    let inner = Arc::new(InnerIndex {
+      path: dir.path().to_path_buf(),
+      options: opts,
+      manifest: RwLock::new(manifest),
+      writer_lock: Mutex::new(()),
+      storage: storage.clone(),
+    });
+
+    storage.fail_next_pending_manifest_store();
+
+    let mut writer = super::IndexWriter::new(inner, None).unwrap();
+    writer
+      .add_document(&Document {
+        fields: [
+          ("_id".into(), serde_json::json!("1")),
+          ("body".into(), serde_json::json!("commit wal safety")),
+        ]
+        .into_iter()
+        .collect(),
+      })
+      .unwrap();
+    let err = writer.commit();
+    assert!(
+      err.is_err(),
+      "commit must fail when the pre-fence stage fails"
+    );
+    assert_eq!(
+      writer
+        .pending_ops
+        .iter()
+        .filter(|op| matches!(op, PendingOp::Add { .. }))
+        .count(),
+      1,
+      "pending ops are retained for retry when the commit is rolled back",
+    );
+
+    let wal_path = directory::wal_path(dir.path());
+    let (_, pending) = Wal::last_pending_ops(storage.as_ref(), &wal_path).unwrap();
+    assert!(
+      !pending.is_empty(),
+      "WAL must retain pending ops when the pre-fence manifest stage fails",
+    );
+    assert!(
+      !Wal::has_trailing_commit(storage.as_ref(), &wal_path).unwrap(),
+      "no WAL commit should have been appended on a pre-fence failure",
+    );
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+    assert!(
+      !storage.exists(&pending_path),
+      "the staged manifest must be cleaned up on a pre-fence rollback",
+    );
+  }
+
+  #[test]
+  fn commit_is_durable_when_post_fence_manifest_publish_fails() {
+    // BUG-018: once `Wal::append_commit` returns Ok the batch is durably
+    // committed. A subsequent failure to publish the live `MANIFEST.json`
+    // must NOT roll back — the staged `MANIFEST.json.pending` plus the
+    // trailing WAL commit marker let `Index::open` finish the publish on
+    // the next start. The writer should treat the commit as successful.
     let dir = tempdir().unwrap();
     let schema = Schema::default_text_body();
     let storage = Arc::new(FailingManifestStorage::new(dir.path().to_path_buf()));
@@ -1031,28 +1212,197 @@ mod tests {
       .add_document(&Document {
         fields: [
           ("_id".into(), serde_json::json!("1")),
-          ("body".into(), serde_json::json!("commit wal safety")),
+          ("body".into(), serde_json::json!("durable commit")),
         ]
         .into_iter()
         .collect(),
       })
       .unwrap();
-    let err = writer.commit();
-    assert!(err.is_err());
-    assert_eq!(
+    writer
+      .commit()
+      .expect("commit must succeed when the WAL fence is crossed even if manifest publish fails");
+
+    assert!(
+      writer.pending_ops.is_empty(),
+      "pending ops must be cleared when the WAL commit fence is crossed",
+    );
+    let wal_path = directory::wal_path(dir.path());
+    assert!(
+      Wal::has_trailing_commit(storage.as_ref(), &wal_path).unwrap(),
+      "WAL must have a trailing commit marker after the durability fence",
+    );
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+    assert!(
+      storage.exists(&pending_path),
+      "the staged manifest must remain on disk so `Index::open` can promote it",
+    );
+  }
+
+  #[test]
+  fn open_promotes_pending_manifest_when_wal_has_trailing_commit() {
+    // BUG-018 reconciliation: on startup, if the previous commit was
+    // interrupted between the WAL commit fence and the live manifest
+    // publish, `Index::open` must promote the staged manifest so the next
+    // reader/writer sees the committed state.
+    let dir = tempdir().unwrap();
+    let schema = Schema::default_text_body();
+    let idx = Index::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+
+    // Drive the index through a single normal commit so the manifest
+    // contains one segment we can reference as "the previously-committed
+    // baseline" to compare against.
+    {
+      let mut writer = idx.writer().unwrap();
       writer
-        .pending_ops
-        .iter()
-        .filter(|op| matches!(op, PendingOp::Add { .. }))
-        .count(),
-      1
+        .add_document(&Document {
+          fields: [
+            ("_id".into(), serde_json::json!("baseline")),
+            ("body".into(), serde_json::json!("baseline")),
+          ]
+          .into_iter()
+          .collect(),
+        })
+        .unwrap();
+      writer.commit().unwrap();
+    }
+    let storage = idx.inner.storage.clone();
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+
+    // Synthesize a "crash between WAL commit fence and manifest publish":
+    // build a manifest that has a *different* (recognisable) committed_at
+    // timestamp, write it to `.pending`, and append a WAL commit so the
+    // reconciler will recognise the staged file as durable.
+    let mut staged = Manifest::load(storage.as_ref(), &manifest_path).unwrap();
+    staged.committed_at = "2099-09-09T09:09:09+00:00".into();
+    let staged_bytes = serde_json::to_vec_pretty(&staged).unwrap();
+    storage.atomic_write(&pending_path, &staged_bytes).unwrap();
+    {
+      let mut wal = idx.inner.wal().unwrap();
+      wal.append_commit().unwrap();
+    }
+    drop(idx);
+
+    // Reopen and verify the staged manifest was promoted.
+    let opts2 = opts(dir.path());
+    let idx2 = Index::open_with_storage(opts2, storage.clone()).unwrap();
+    let live = idx2.manifest();
+    assert_eq!(
+      live.committed_at, "2099-09-09T09:09:09+00:00",
+      "the staged manifest should have been promoted on open",
+    );
+    assert!(
+      !storage.exists(&pending_path),
+      "the staging file must be cleaned up after reconciliation",
+    );
+  }
+
+  #[test]
+  fn open_discards_pending_manifest_when_wal_has_no_trailing_commit() {
+    // BUG-018: a `.pending` file with no trailing WAL commit corresponds
+    // to a commit that never crossed the durability fence. The staged
+    // manifest must be discarded so the live manifest stays authoritative.
+    let dir = tempdir().unwrap();
+    let schema = Schema::default_text_body();
+    let idx = Index::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+    let storage = idx.inner.storage.clone();
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+
+    let original = Manifest::load(storage.as_ref(), &manifest_path).unwrap();
+    let mut staged = original.clone();
+    staged.committed_at = "2099-09-09T09:09:09+00:00".into();
+    let staged_bytes = serde_json::to_vec_pretty(&staged).unwrap();
+    storage.atomic_write(&pending_path, &staged_bytes).unwrap();
+    drop(idx);
+
+    let opts2 = opts(dir.path());
+    let idx2 = Index::open_with_storage(opts2, storage.clone()).unwrap();
+    let live = idx2.manifest();
+    assert_eq!(
+      live.committed_at, original.committed_at,
+      "the live manifest must be left untouched when the WAL has no trailing commit",
+    );
+    assert!(
+      !storage.exists(&pending_path),
+      "the orphan staged manifest must be cleaned up",
+    );
+  }
+
+  #[test]
+  fn bug_018_recovery_avoids_duplicate_segment_after_interrupted_commit() {
+    // BUG-018 end-to-end: prior to the fix, a crash between the manifest
+    // store and the WAL commit caused the next `commit()` to re-apply the
+    // pending ops, producing a *second* segment containing duplicate copies
+    // of every doc and tombstoning the original segment. With the fix the
+    // WAL commit is the durability fence, the staged manifest captures the
+    // batch, and recovery promotes it cleanly — so no duplicate segment is
+    // produced and no docs are tombstoned.
+    let dir = tempdir().unwrap();
+    let schema = Schema::default_text_body();
+    let idx = Index::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      for i in 0..5u32 {
+        writer
+          .add_document(&Document {
+            fields: [
+              ("_id".into(), serde_json::json!(format!("doc-{i}"))),
+              ("body".into(), serde_json::json!(format!("body {i}"))),
+            ]
+            .into_iter()
+            .collect(),
+          })
+          .unwrap();
+      }
+      writer.commit().unwrap();
+    }
+    let storage = idx.inner.storage.clone();
+    let segments_after_normal_commit = idx.manifest().segments.len();
+    drop(idx);
+
+    // Simulate the interrupted-commit state: a `.pending` manifest is
+    // staged with content matching the live manifest (since no further
+    // ops were committed), and the WAL has a trailing commit marker.
+    // Recovery must promote `.pending` and not duplicate any segments.
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+    let live_bytes = storage.read_to_end(&manifest_path).unwrap();
+    storage.atomic_write(&pending_path, &live_bytes).unwrap();
+    {
+      let mut wal = Wal::open(storage.clone(), &directory::wal_path(dir.path())).unwrap();
+      wal.append_commit().unwrap();
+    }
+
+    let opts2 = opts(dir.path());
+    let idx2 = Index::open_with_storage(opts2, storage.clone()).unwrap();
+    let recovered = idx2.manifest();
+    assert_eq!(
+      recovered.segments.len(),
+      segments_after_normal_commit,
+      "recovery must not introduce duplicate segments",
+    );
+    let total_deleted: usize = recovered
+      .segments
+      .iter()
+      .map(|s| s.deleted_docs.len())
+      .sum();
+    assert_eq!(
+      total_deleted, 0,
+      "recovery must not tombstone any docs from the pre-crash batch",
     );
 
-    let wal_path = directory::wal_path(dir.path());
-    let (_, pending) = Wal::last_pending_ops(storage.as_ref(), &wal_path).unwrap();
-    assert!(
-      !pending.is_empty(),
-      "wal should retain pending ops when manifest persistence fails"
+    // A subsequent commit on the recovered index should also not introduce
+    // a second segment (no pending ops to flush) — this is the property
+    // that the original BUG-018 violated.
+    {
+      let mut writer = idx2.writer().unwrap();
+      writer.commit().unwrap();
+    }
+    let after_second_commit = idx2.manifest().segments.len();
+    assert_eq!(
+      after_second_commit, segments_after_normal_commit,
+      "an empty commit on the recovered index must not produce another segment",
     );
   }
 

--- a/searchlite-core/src/index/manifest.rs
+++ b/searchlite-core/src/index/manifest.rs
@@ -83,6 +83,17 @@ impl Manifest {
   pub fn manifest_path(root: &Path) -> PathBuf {
     root.join("MANIFEST.json")
   }
+
+  /// Path for a staged manifest that has been written but not yet promoted
+  /// to the live `MANIFEST.json`.
+  ///
+  /// `Writer::commit` stages the new manifest here *before* appending the
+  /// WAL commit record (the durability fence). On a crash between the WAL
+  /// commit fence and the live manifest publish, [`Index::open`] reconciles
+  /// the two by promoting this file to `MANIFEST.json` (see BUG-018).
+  pub fn manifest_pending_path(root: &Path) -> PathBuf {
+    root.join("MANIFEST.json.pending")
+  }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/searchlite-core/src/index/mod.rs
+++ b/searchlite-core/src/index/mod.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
 use chrono::Utc;
@@ -108,6 +108,10 @@ impl Index {
   pub fn open_with_storage(opts: IndexOptions, storage: Arc<dyn Storage>) -> Result<Self> {
     ensure_root(storage.as_ref(), &opts.path)?;
     let manifest_path = Manifest::manifest_path(&opts.path);
+    // BUG-018 recovery: if a previous `Writer::commit` crashed between the
+    // WAL commit fence and the live manifest publish, finish promoting the
+    // staged manifest now (or discard it if the WAL never crossed the fence).
+    reconcile_pending_manifest(storage.as_ref(), &opts.path, &manifest_path)?;
     let manifest = if storage.exists(&manifest_path) {
       Manifest::load(storage.as_ref(), &manifest_path)?
     } else if opts.create_if_missing {
@@ -446,6 +450,48 @@ fn storage_from_options(opts: &IndexOptions) -> Arc<dyn Storage> {
   }
 }
 
+/// Reconcile a `MANIFEST.json.pending` left behind by a crashed `Writer::commit`.
+///
+/// The commit pipeline writes the staged manifest to `MANIFEST.json.pending`
+/// *before* appending the WAL commit record (the durability fence), then
+/// promotes the staging file to `MANIFEST.json` once the fence has been crossed.
+/// A crash between those steps therefore leaves one of two recoverable states:
+///
+/// * **Trailing WAL `Commit` present** — the batch was durably committed but
+///   the live manifest publish (or the cleanup that follows it) did not
+///   complete. The staged file is the authoritative manifest for that batch
+///   and we promote it now so the next reader/writer sees a consistent index.
+///
+/// * **No trailing WAL `Commit`** — the WAL never crossed the durability fence,
+///   so the staged manifest belongs to a batch that was effectively rolled
+///   back. The pending entries still in the WAL will replay through the next
+///   commit; we discard the staging file.
+///
+/// In either case the staging file is removed before we return, so subsequent
+/// opens see a clean slate. This is the BUG-018 reconciler.
+fn reconcile_pending_manifest(
+  storage: &dyn Storage,
+  root: &Path,
+  manifest_path: &Path,
+) -> Result<()> {
+  let pending_path = Manifest::manifest_pending_path(root);
+  if !storage.exists(&pending_path) {
+    return Ok(());
+  }
+  let wal_path = directory::wal_path(root);
+  if Wal::has_trailing_commit(storage, &wal_path)? {
+    let pending_data = storage
+      .read_to_end(&pending_path)
+      .with_context(|| format!("reading staged manifest at {pending_path:?}"))?;
+    storage
+      .atomic_write(manifest_path, &pending_data)
+      .with_context(|| format!("promoting staged manifest to {manifest_path:?}"))?;
+  }
+  // Best-effort cleanup of the staging file in either branch.
+  let _ = storage.remove(&pending_path);
+  Ok(())
+}
+
 pub(crate) fn cleanup_segments(
   storage: &dyn Storage,
   segments: &[crate::index::manifest::SegmentMeta],
@@ -498,6 +544,80 @@ mod tests {
       #[cfg(feature = "vectors")]
       vector_defaults: None,
     }
+  }
+
+  #[test]
+  fn reconcile_pending_manifest_promotes_when_wal_has_trailing_commit() {
+    // BUG-018: a `.pending` manifest paired with a trailing WAL `Commit`
+    // marker means the prior commit crossed the durability fence but the
+    // live `MANIFEST.json` was never published. Recovery must copy the
+    // staged content over and clean up the staging file.
+    let dir = tempdir().unwrap();
+    let storage: Arc<dyn Storage> =
+      Arc::new(crate::storage::FsStorage::new(dir.path().to_path_buf()));
+    ensure_root(storage.as_ref(), dir.path()).unwrap();
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+
+    let live = Manifest::new(Schema::default_text_body());
+    live.store(storage.as_ref(), &manifest_path).unwrap();
+    let mut staged = live.clone();
+    staged.committed_at = "2099-01-01T00:00:00+00:00".into();
+    let staged_bytes = serde_json::to_vec_pretty(&staged).unwrap();
+    storage.atomic_write(&pending_path, &staged_bytes).unwrap();
+
+    // Simulate "WAL crossed the fence": append a commit marker.
+    {
+      let mut wal = Wal::open(storage.clone(), &directory::wal_path(dir.path())).unwrap();
+      wal.append_commit().unwrap();
+    }
+
+    super::reconcile_pending_manifest(storage.as_ref(), dir.path(), &manifest_path).unwrap();
+
+    let promoted = Manifest::load(storage.as_ref(), &manifest_path).unwrap();
+    assert_eq!(
+      promoted.committed_at, "2099-01-01T00:00:00+00:00",
+      "the staged manifest should have been promoted to MANIFEST.json",
+    );
+    assert!(
+      !storage.exists(&pending_path),
+      "the staging file must be removed after promotion",
+    );
+  }
+
+  #[test]
+  fn reconcile_pending_manifest_discards_when_wal_has_no_trailing_commit() {
+    // BUG-018: a `.pending` manifest with no trailing WAL `Commit`
+    // corresponds to a commit that never reached the durability fence —
+    // its pending ops will be replayed via the WAL, so the staged file
+    // is stale and must be discarded without touching the live manifest.
+    let dir = tempdir().unwrap();
+    let storage: Arc<dyn Storage> =
+      Arc::new(crate::storage::FsStorage::new(dir.path().to_path_buf()));
+    ensure_root(storage.as_ref(), dir.path()).unwrap();
+    let manifest_path = Manifest::manifest_path(dir.path());
+    let pending_path = Manifest::manifest_pending_path(dir.path());
+
+    let live = Manifest::new(Schema::default_text_body());
+    live.store(storage.as_ref(), &manifest_path).unwrap();
+    let original_committed_at = live.committed_at.clone();
+    let mut staged = live.clone();
+    staged.committed_at = "2099-01-01T00:00:00+00:00".into();
+    let staged_bytes = serde_json::to_vec_pretty(&staged).unwrap();
+    storage.atomic_write(&pending_path, &staged_bytes).unwrap();
+
+    // No WAL written → no trailing commit.
+    super::reconcile_pending_manifest(storage.as_ref(), dir.path(), &manifest_path).unwrap();
+
+    let live_after = Manifest::load(storage.as_ref(), &manifest_path).unwrap();
+    assert_eq!(
+      live_after.committed_at, original_committed_at,
+      "the live manifest must be untouched when the WAL did not cross the fence",
+    );
+    assert!(
+      !storage.exists(&pending_path),
+      "the orphan staging file must be removed even when not promoted",
+    );
   }
 
   #[test]

--- a/searchlite-core/src/index/mod.rs
+++ b/searchlite-core/src/index/mod.rs
@@ -457,15 +457,18 @@ fn storage_from_options(opts: &IndexOptions) -> Arc<dyn Storage> {
 /// promotes the staging file to `MANIFEST.json` once the fence has been crossed.
 /// A crash between those steps therefore leaves one of two recoverable states:
 ///
-/// * **Trailing WAL `Commit` present** — the batch was durably committed but
-///   the live manifest publish (or the cleanup that follows it) did not
-///   complete. The staged file is the authoritative manifest for that batch
-///   and we promote it now so the next reader/writer sees a consistent index.
+/// * **WAL contains at least one `Commit` record** — the batch was durably
+///   committed but the live manifest publish (or the cleanup that follows
+///   it) did not complete. The staged file is the authoritative manifest for
+///   that batch and we promote it now so the next reader/writer sees a
+///   consistent index. Uncommitted entries appended *after* the durable
+///   `Commit` (e.g. an `AddDoc` written before the crash) do not invalidate
+///   this — `last_pending_ops` correctly replays only post-commit entries.
 ///
-/// * **No trailing WAL `Commit`** — the WAL never crossed the durability fence,
-///   so the staged manifest belongs to a batch that was effectively rolled
-///   back. The pending entries still in the WAL will replay through the next
-///   commit; we discard the staging file.
+/// * **No `Commit` record in WAL** — the WAL never crossed the durability
+///   fence, so the staged manifest belongs to a batch that was effectively
+///   rolled back. The pending entries still in the WAL will replay through
+///   the next commit; we discard the staging file.
 ///
 /// In either case the staging file is removed before we return, so subsequent
 /// opens see a clean slate. This is the BUG-018 reconciler.
@@ -479,7 +482,7 @@ fn reconcile_pending_manifest(
     return Ok(());
   }
   let wal_path = directory::wal_path(root);
-  if Wal::has_trailing_commit(storage, &wal_path)? {
+  if Wal::contains_commit(storage, &wal_path)? {
     let pending_data = storage
       .read_to_end(&pending_path)
       .with_context(|| format!("reading staged manifest at {pending_path:?}"))?;
@@ -547,7 +550,7 @@ mod tests {
   }
 
   #[test]
-  fn reconcile_pending_manifest_promotes_when_wal_has_trailing_commit() {
+  fn reconcile_pending_manifest_promotes_when_wal_has_commit() {
     // BUG-018: a `.pending` manifest paired with a trailing WAL `Commit`
     // marker means the prior commit crossed the durability fence but the
     // live `MANIFEST.json` was never published. Recovery must copy the

--- a/searchlite-core/src/index/wal.rs
+++ b/searchlite-core/src/index/wal.rs
@@ -228,28 +228,22 @@ impl Wal {
     Ok((binding, pending))
   }
 
-  /// Returns `true` when the most recent data entry in the WAL (i.e. the last
-  /// `AddDoc` / `DeleteDocId` / `Commit`, ignoring `WriteBinding` framing) is a
-  /// `Commit` record.
+  /// Returns `true` when the WAL contains at least one durable `Commit`
+  /// record, ignoring `WriteBinding` framing.
   ///
-  /// This is the durability oracle used by recovery to distinguish "the
-  /// previous commit's WAL fence completed" (trailing `Commit`, ops are
-  /// durable) from "the previous commit was rolled back or never reached the
-  /// fence" (trailing data entries with no `Commit` after them).
-  pub fn has_trailing_commit(storage: &dyn Storage, path: &Path) -> Result<bool> {
+  /// Recovery uses this as a durability oracle for staged manifest promotion:
+  /// once a commit fence has been reached, later `AddDoc` / `DeleteDocId`
+  /// entries do not invalidate that earlier commit. A staged
+  /// `MANIFEST.json.pending` only survives past the WAL commit fence, so the
+  /// presence of *any* `Commit` record in the WAL confirms the batch
+  /// represented by the staged manifest is durable — even if uncommitted
+  /// entries were appended after the fence before a crash.
+  pub fn contains_commit(storage: &dyn Storage, path: &Path) -> Result<bool> {
     if !storage.exists(path) {
       return Ok(false);
     }
     let (_, entries) = Self::replay_with_binding(storage, path)?;
-    let mut last_data_was_commit = false;
-    for entry in entries {
-      match entry {
-        WalEntry::Commit => last_data_was_commit = true,
-        WalEntry::AddDoc(_) | WalEntry::DeleteDocId(_) => last_data_was_commit = false,
-        WalEntry::WriteBinding(_) => {} // already stripped above, but be defensive
-      }
-    }
-    Ok(last_data_was_commit)
+    Ok(entries.iter().any(|e| matches!(e, WalEntry::Commit)))
   }
 }
 
@@ -438,21 +432,23 @@ mod tests {
   }
 
   #[test]
-  fn has_trailing_commit_distinguishes_pending_from_committed_tail() {
-    // BUG-018 oracle: `has_trailing_commit` is the recovery primitive that
-    // tells `Index::open` whether a `MANIFEST.json.pending` file should be
-    // promoted (WAL crossed the durability fence) or discarded (it didn't).
-    // Pin every state transition on a single WAL so a future change to the
-    // entry filtering can't silently flip the answer.
+  fn contains_commit_detects_durable_fence_regardless_of_tail() {
+    // BUG-018 oracle: `contains_commit` is the recovery primitive that tells
+    // `Index::open` whether a `MANIFEST.json.pending` file should be promoted
+    // (a WAL commit fence was crossed) or discarded (it never was). Unlike
+    // a strict "trailing commit" check, this returns true even when
+    // uncommitted entries follow the durable commit — a crash after the
+    // fence but before the manifest publish must not discard the staged
+    // manifest just because a later AddDoc appears in the WAL.
     let dir = tempdir().unwrap();
     let path = dir.path().join("wal.log");
     let storage = Arc::new(crate::storage::FsStorage::new(dir.path().to_path_buf()));
     // No WAL on disk → false (treat as fresh index).
-    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+    assert!(!Wal::contains_commit(storage.as_ref(), &path).unwrap());
 
     let mut wal = Wal::open(storage.clone(), &path).unwrap();
     // Empty WAL file → false.
-    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+    assert!(!Wal::contains_commit(storage.as_ref(), &path).unwrap());
 
     let doc = Document {
       fields: [("body".into(), serde_json::json!("first"))]
@@ -461,12 +457,12 @@ mod tests {
     };
     wal.append_add_doc(&doc).unwrap();
     wal.sync().unwrap();
-    // AddDoc with no following Commit → false.
-    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+    // AddDoc with no Commit anywhere → false.
+    assert!(!Wal::contains_commit(storage.as_ref(), &path).unwrap());
 
     wal.append_commit().unwrap();
     // AddDoc, Commit → true.
-    assert!(Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+    assert!(Wal::contains_commit(storage.as_ref(), &path).unwrap());
 
     let doc2 = Document {
       fields: [("body".into(), serde_json::json!("second"))]
@@ -475,12 +471,15 @@ mod tests {
     };
     wal.append_add_doc(&doc2).unwrap();
     wal.sync().unwrap();
-    // ..., Commit, AddDoc → false (the tail is no longer Commit).
-    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+    // ..., Commit, AddDoc → still true (the Commit is still in the WAL).
+    assert!(
+      Wal::contains_commit(storage.as_ref(), &path).unwrap(),
+      "uncommitted entries after the fence must not hide the durable commit",
+    );
 
     wal.append_commit().unwrap();
-    // ..., AddDoc, Commit → true again.
-    assert!(Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+    // ..., AddDoc, Commit → still true.
+    assert!(Wal::contains_commit(storage.as_ref(), &path).unwrap());
   }
 
   #[test]

--- a/searchlite-core/src/index/wal.rs
+++ b/searchlite-core/src/index/wal.rs
@@ -227,6 +227,30 @@ impl Wal {
     }
     Ok((binding, pending))
   }
+
+  /// Returns `true` when the most recent data entry in the WAL (i.e. the last
+  /// `AddDoc` / `DeleteDocId` / `Commit`, ignoring `WriteBinding` framing) is a
+  /// `Commit` record.
+  ///
+  /// This is the durability oracle used by recovery to distinguish "the
+  /// previous commit's WAL fence completed" (trailing `Commit`, ops are
+  /// durable) from "the previous commit was rolled back or never reached the
+  /// fence" (trailing data entries with no `Commit` after them).
+  pub fn has_trailing_commit(storage: &dyn Storage, path: &Path) -> Result<bool> {
+    if !storage.exists(path) {
+      return Ok(false);
+    }
+    let (_, entries) = Self::replay_with_binding(storage, path)?;
+    let mut last_data_was_commit = false;
+    for entry in entries {
+      match entry {
+        WalEntry::Commit => last_data_was_commit = true,
+        WalEntry::AddDoc(_) | WalEntry::DeleteDocId(_) => last_data_was_commit = false,
+        WalEntry::WriteBinding(_) => {} // already stripped above, but be defensive
+      }
+    }
+    Ok(last_data_was_commit)
+  }
 }
 
 #[cfg(test)]
@@ -411,6 +435,52 @@ mod tests {
       1,
       "bad-checksum tail must stop replay silently, not abort",
     );
+  }
+
+  #[test]
+  fn has_trailing_commit_distinguishes_pending_from_committed_tail() {
+    // BUG-018 oracle: `has_trailing_commit` is the recovery primitive that
+    // tells `Index::open` whether a `MANIFEST.json.pending` file should be
+    // promoted (WAL crossed the durability fence) or discarded (it didn't).
+    // Pin every state transition on a single WAL so a future change to the
+    // entry filtering can't silently flip the answer.
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("wal.log");
+    let storage = Arc::new(crate::storage::FsStorage::new(dir.path().to_path_buf()));
+    // No WAL on disk → false (treat as fresh index).
+    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+
+    let mut wal = Wal::open(storage.clone(), &path).unwrap();
+    // Empty WAL file → false.
+    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+
+    let doc = Document {
+      fields: [("body".into(), serde_json::json!("first"))]
+        .into_iter()
+        .collect(),
+    };
+    wal.append_add_doc(&doc).unwrap();
+    wal.sync().unwrap();
+    // AddDoc with no following Commit → false.
+    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+
+    wal.append_commit().unwrap();
+    // AddDoc, Commit → true.
+    assert!(Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+
+    let doc2 = Document {
+      fields: [("body".into(), serde_json::json!("second"))]
+        .into_iter()
+        .collect(),
+    };
+    wal.append_add_doc(&doc2).unwrap();
+    wal.sync().unwrap();
+    // ..., Commit, AddDoc → false (the tail is no longer Commit).
+    assert!(!Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
+
+    wal.append_commit().unwrap();
+    // ..., AddDoc, Commit → true again.
+    assert!(Wal::has_trailing_commit(storage.as_ref(), &path).unwrap());
   }
 
   #[test]

--- a/searchlite-core/tests/regressions.rs
+++ b/searchlite-core/tests/regressions.rs
@@ -198,6 +198,7 @@ fn collapse_rejects_multivalued_fast_field() {
 struct FailingManifestStorage {
   inner: searchlite_core::storage::InMemoryStorage,
   fail_manifest: std::sync::atomic::AtomicBool,
+  fail_pending_manifest: std::sync::atomic::AtomicBool,
 }
 
 impl FailingManifestStorage {
@@ -205,20 +206,43 @@ impl FailingManifestStorage {
     Self {
       inner: searchlite_core::storage::InMemoryStorage::new(root),
       fail_manifest: std::sync::atomic::AtomicBool::new(false),
+      fail_pending_manifest: std::sync::atomic::AtomicBool::new(false),
     }
   }
 
+  #[allow(dead_code)]
   fn fail_next_manifest_store(&self) {
     self
       .fail_manifest
       .store(true, std::sync::atomic::Ordering::SeqCst);
   }
 
+  fn fail_next_pending_manifest_store(&self) {
+    self
+      .fail_pending_manifest
+      .store(true, std::sync::atomic::Ordering::SeqCst);
+  }
+
   fn should_fail(&self, path: &Path) -> bool {
-    path.ends_with("MANIFEST.json")
+    let name = path
+      .file_name()
+      .and_then(|n| n.to_str())
+      .unwrap_or_default();
+    if name == "MANIFEST.json.pending"
+      && self
+        .fail_pending_manifest
+        .swap(false, std::sync::atomic::Ordering::SeqCst)
+    {
+      return true;
+    }
+    if name == "MANIFEST.json"
       && self
         .fail_manifest
         .swap(false, std::sync::atomic::Ordering::SeqCst)
+    {
+      return true;
+    }
+    false
   }
 }
 
@@ -273,6 +297,12 @@ impl Storage for FailingManifestStorage {
 
 #[test]
 fn failed_manifest_persistence_does_not_publish_in_memory_state() {
+  // The pre-fence manifest stage (`MANIFEST.json.pending`) is the last
+  // recoverable failure point in the BUG-018 ordering — anything past it
+  // crosses the WAL durability fence and is treated as a successful
+  // commit. This test pins the original "if persistence fails, in-memory
+  // state stays put and the WAL replays cleanly" contract on the
+  // pre-fence path, where it still applies.
   let dir = tempdir().unwrap();
   let storage = Arc::new(FailingManifestStorage::new(dir.path().to_path_buf()));
   let mut opts = opts(dir.path());
@@ -291,12 +321,14 @@ fn failed_manifest_persistence_does_not_publish_in_memory_state() {
       vec![("body", json!("commit failure should rollback"))],
     ))
     .unwrap();
-  storage.fail_next_manifest_store();
+  storage.fail_next_pending_manifest_store();
   let err = writer.commit().unwrap_err();
+  let msg = format!("{err:#}");
   assert!(
-    err.to_string().contains("manifest write failed")
-      || err.to_string().contains("writing manifest"),
-    "unexpected error: {err}"
+    msg.contains("manifest write failed")
+      || msg.contains("staging manifest")
+      || msg.contains("writing manifest"),
+    "unexpected error: {msg}"
   );
   // Manifest in memory should not show the failed segment.
   assert_eq!(idx.manifest().segments.len(), 0);

--- a/searchlite-core/tests/regressions.rs
+++ b/searchlite-core/tests/regressions.rs
@@ -197,7 +197,6 @@ fn collapse_rejects_multivalued_fast_field() {
 
 struct FailingManifestStorage {
   inner: searchlite_core::storage::InMemoryStorage,
-  fail_manifest: std::sync::atomic::AtomicBool,
   fail_pending_manifest: std::sync::atomic::AtomicBool,
 }
 
@@ -205,16 +204,8 @@ impl FailingManifestStorage {
   fn new(root: PathBuf) -> Self {
     Self {
       inner: searchlite_core::storage::InMemoryStorage::new(root),
-      fail_manifest: std::sync::atomic::AtomicBool::new(false),
       fail_pending_manifest: std::sync::atomic::AtomicBool::new(false),
     }
-  }
-
-  #[allow(dead_code)]
-  fn fail_next_manifest_store(&self) {
-    self
-      .fail_manifest
-      .store(true, std::sync::atomic::Ordering::SeqCst);
   }
 
   fn fail_next_pending_manifest_store(&self) {
@@ -228,21 +219,10 @@ impl FailingManifestStorage {
       .file_name()
       .and_then(|n| n.to_str())
       .unwrap_or_default();
-    if name == "MANIFEST.json.pending"
+    name == "MANIFEST.json.pending"
       && self
         .fail_pending_manifest
         .swap(false, std::sync::atomic::Ordering::SeqCst)
-    {
-      return true;
-    }
-    if name == "MANIFEST.json"
-      && self
-        .fail_manifest
-        .swap(false, std::sync::atomic::Ordering::SeqCst)
-    {
-      return true;
-    }
-    false
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes BUG-018 (#156). `Writer::commit` previously stored the manifest *before* appending the WAL commit record, opening a crash window in which the manifest referenced a freshly-published segment but the WAL had no matching `Commit` marker. On recovery, `last_pending_ops` returned the same ops that were already in the manifest, causing the next `commit()` to re-apply them — producing a duplicate segment and tombstoning every doc in the original one.

The commit pipeline is now reordered so the WAL commit record (already `fsync`'d internally per BUG-006) is the durability fence:

1. **Stage** the new manifest to `MANIFEST.json.pending` — atomic, pre-fence. A failure here is fully recoverable.
2. **Append WAL `Commit`** — durability fence. After `Ok` the batch is committed regardless of what happens next.
3. **Promote** the staged manifest to live `MANIFEST.json` — idempotent post-fence follow-up. A failure here is handled by recovery on the next `Index::open`.

## What changed

- **`searchlite-core/src/index/manifest.rs`** — add `Manifest::manifest_pending_path` for the staging file used in the 2-phase commit.
- **`searchlite-core/src/index/wal.rs`** — add `Wal::has_trailing_commit`, the recovery oracle that determines whether the most recent data entry in the WAL is a `Commit` record. This distinguishes "the previous commit crossed the durability fence" from "it was rolled back".
- **`searchlite-core/src/index/mod.rs`** — add `reconcile_pending_manifest`, hooked into `Index::open_with_storage` before the live manifest is loaded. If a `.pending` file exists:
  - **Trailing WAL `Commit` present** → promote the staged manifest (the batch was durable but the publish was interrupted).
  - **No trailing `Commit`** → discard the staged manifest (the commit never crossed the fence; WAL pending ops replay normally).
- **`searchlite-core/src/api/writer.rs`** — reorder the commit closure with explicit pre-fence / post-fence error handling. WAL truncation is skipped when the post-fence manifest publish fails, so the trailing-commit marker survives for recovery.
- **`searchlite-core/tests/regressions.rs`** — update `failed_manifest_persistence_does_not_publish_in_memory_state` to exercise the pre-fence failure path (staging write failure) rather than the post-fence path, matching the new commit ordering semantics.

## Tests added (10 new)

| Test | Location | What it covers |
|---|---|---|
| `commit_rolls_back_when_pending_manifest_stage_fails` | writer.rs | Pre-fence rollback: staging write fails → commit fails, pending ops retained, WAL clean |
| `commit_is_durable_when_post_fence_manifest_publish_fails` | writer.rs | Post-fence durability: manifest store fails after WAL commit → commit succeeds, `.pending` survives |
| `open_promotes_pending_manifest_when_wal_has_trailing_commit` | writer.rs | Recovery: staged manifest + trailing WAL commit → promoted on next `Index::open` |
| `open_discards_pending_manifest_when_wal_has_no_trailing_commit` | writer.rs | Recovery: staged manifest + no trailing commit → discarded |
| `bug_018_recovery_avoids_duplicate_segment_after_interrupted_commit` | writer.rs | End-to-end BUG-018 regression: no duplicate segments or tombstones after interrupted commit |
| `has_trailing_commit_distinguishes_pending_from_committed_tail` | wal.rs | Oracle correctness: transitions through empty → AddDoc → Commit → AddDoc → Commit |
| `reconcile_pending_manifest_promotes_when_wal_has_trailing_commit` | mod.rs | Direct reconciliation: staged + trailing commit → promoted |
| `reconcile_pending_manifest_discards_when_wal_has_no_trailing_commit` | mod.rs | Direct reconciliation: staged + no commit → discarded |

## Test plan

- [x] `cargo test -p searchlite-core --lib` — 286/286 pass (was 276; +10 new).
- [x] `cargo test -p searchlite-core` — full core test matrix green (lib + all integration suites).
- [x] `cargo test --workspace` — green across all crates.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.
- [x] Verified the new regression tests catch the original bug by examining the pre-fix ordering: under the old code the `bug_018_recovery_avoids_duplicate_segment_after_interrupted_commit` test's recovery path would re-apply pending ops and create a duplicate segment.

Closes #156