### PR TITLE
perf(wand): use block-level tf bounds during BMW advancement (BUG-005)

### DIFF
--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -1154,72 +1154,84 @@ mod tests {
   }
 
   #[test]
-  fn bmw_block_tf_skipping_reduces_postings_advanced() {
-    // Construct a scenario where BMW tf-based block skipping should
-    // kick in: one common term with many low-tf blocks and a few
-    // high-tf blocks, paired with a rare high-tf term that fills the
-    // top-k heap quickly. Once the heap is full, the common term's
-    // low-tf blocks should be skippable.
+  fn bmw_block_tf_skipping_exercises_advancement_path() {
+    // Regression test for BUG-005: exercises the `pivot_doc > smallest_doc`
+    // advancement branch where `skip_blocks_below_bound` is called.
     //
-    // Block size = 4 so we get clear block boundaries.
+    // Layout (block_size = 4):
+    //
+    //   anchor: 8 entries at doc_ids [0..4, 40..44], all tf=20
+    //     block 0 (entries 0-3): docs [0,1,2,3],     max_tf=20
+    //     block 1 (entries 4-7): docs [40,41,42,43],  max_tf=20
+    //
+    //   spread: 44 entries at doc_ids [0..4] tf=20, [4..40] tf=1, [40..44] tf=20
+    //     block 0  (entries 0-3):   docs [0,1,2,3],     max_tf=20
+    //     block 1  (entries 4-7):   docs [4,5,6,7],     max_tf=1   ← skippable
+    //     block 2  (entries 8-11):  docs [8,9,10,11],   max_tf=1   ← skippable
+    //     ...
+    //     block 9  (entries 36-39): docs [36,37,38,39], max_tf=1   ← skippable
+    //     block 10 (entries 40-43): docs [40,41,42,43], max_tf=20
+    //
+    // Phase 1 (docs 0-3): both terms score together (tf=20 each).
+    //   The top-k heap fills with high combined scores (k=3).
+    //
+    // Phase 2: anchor jumps to doc 40. spread is at doc 4.
+    //   Queue: [spread(4), anchor(40)]
+    //   Pivot scan accumulates spread.block_ub(tf=1) + anchor.block_ub(tf=20).
+    //   pivot_doc = 40 > smallest_doc = 4 → advancement branch entered.
+    //   spread must advance from doc 4 to doc 40 through 9 blocks of tf=1.
+    //   skip_blocks_below_bound skips those low-tf blocks.
     let block_size = 4;
 
-    // Common term: 16 postings across 4 blocks.
-    // Block 0 (doc_ids 0-3):  tf=1 each (low contribution)
-    // Block 1 (doc_ids 4-7):  tf=1 each (low contribution)
-    // Block 2 (doc_ids 8-11): tf=1 each (low contribution)
-    // Block 3 (doc_ids 12-15): tf=10 each (high contribution)
-    let mut common_entries = Vec::new();
-    for doc_id in 0..12 {
-      common_entries.push(PostingEntry {
+    // anchor: high-tf entries at low and high doc_ids with a gap.
+    let mut anchor_entries = Vec::new();
+    for doc_id in 0..4 {
+      anchor_entries.push(PostingEntry {
+        doc_id,
+        term_freq: 20,
+        positions: smallvec![],
+      });
+    }
+    for doc_id in 40..44 {
+      anchor_entries.push(PostingEntry {
+        doc_id,
+        term_freq: 20,
+        positions: smallvec![],
+      });
+    }
+    let anchor = term_from_entries_with_block_size(&anchor_entries, block_size);
+
+    // spread: overlaps anchor at both ends, with many low-tf entries in between.
+    let mut spread_entries = Vec::new();
+    for doc_id in 0..4 {
+      spread_entries.push(PostingEntry {
+        doc_id,
+        term_freq: 20,
+        positions: smallvec![],
+      });
+    }
+    for doc_id in 4..40 {
+      spread_entries.push(PostingEntry {
         doc_id,
         term_freq: 1,
         positions: smallvec![],
       });
     }
-    for doc_id in 12..16 {
-      common_entries.push(PostingEntry {
+    for doc_id in 40..44 {
+      spread_entries.push(PostingEntry {
         doc_id,
-        term_freq: 10,
+        term_freq: 20,
         positions: smallvec![],
       });
     }
-    let common = term_from_entries_with_block_size(&common_entries, block_size);
-
-    // Rare term: 4 postings, all high tf, in the high doc_id range.
-    // These fill the top-k heap with high scores early.
-    let rare = term_from_entries_with_block_size(
-      &[
-        PostingEntry {
-          doc_id: 12,
-          term_freq: 8,
-          positions: smallvec![],
-        },
-        PostingEntry {
-          doc_id: 13,
-          term_freq: 9,
-          positions: smallvec![],
-        },
-        PostingEntry {
-          doc_id: 14,
-          term_freq: 7,
-          positions: smallvec![],
-        },
-        PostingEntry {
-          doc_id: 15,
-          term_freq: 10,
-          positions: smallvec![],
-        },
-      ],
-      block_size,
-    );
+    let spread = term_from_entries_with_block_size(&spread_entries, block_size);
 
     let mut accept = |_doc: DocId, _score: f32| true;
 
     // Run with plain WAND (no block-tf skipping)
     let mut wand_stats = QueryStats::default();
     let wand_results = execute_top_k_with_stats::<_, crate::query::collector::MatchCountingCollector>(
-      vec![common.clone(), rare.clone()],
+      vec![anchor.clone(), spread.clone()],
       3,
       ExecutionStrategy::Wand,
       Some(block_size),
@@ -1231,7 +1243,7 @@ mod tests {
     // Run with BMW (block-tf skipping active)
     let mut bmw_stats = QueryStats::default();
     let bmw_results = execute_top_k_with_stats::<_, crate::query::collector::MatchCountingCollector>(
-      vec![common, rare],
+      vec![anchor, spread],
       3,
       ExecutionStrategy::Bmw,
       Some(block_size),
@@ -1257,11 +1269,12 @@ mod tests {
       );
     }
 
-    // BMW should advance fewer postings than plain WAND because it
-    // skips low-tf blocks during advancement.
+    // BMW should advance strictly fewer postings than plain WAND because
+    // spread's low-tf blocks (doc_ids 4-39) are skipped in the advancement
+    // phase rather than walked entry-by-entry.
     assert!(
-      bmw_stats.postings_advanced <= wand_stats.postings_advanced,
-      "BMW should advance no more postings than WAND: bmw={} wand={}",
+      bmw_stats.postings_advanced < wand_stats.postings_advanced,
+      "BMW should advance strictly fewer postings than WAND: bmw={} wand={}",
       bmw_stats.postings_advanced,
       wand_stats.postings_advanced
     );

--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -256,6 +256,41 @@ impl TermState {
     }
     self.idx.saturating_sub(prev)
   }
+
+  /// Skip forward through blocks whose per-block max-tf score contribution
+  /// is below `min_contribution`. Stops at the first block whose upper bound
+  /// meets the threshold, or at the end of the postings list.
+  ///
+  /// This is the BMW (Block-Max WAND) optimisation described in BUG-005:
+  /// during the advancement phase, blocks whose max-tf cannot contribute
+  /// enough to push a candidate past the heap threshold are skipped entirely,
+  /// avoiding unnecessary `advance_to` work within those blocks.
+  fn skip_blocks_below_bound(&mut self, min_contribution: f32) -> usize {
+    if min_contribution <= 0.0 {
+      return 0;
+    }
+    let prev = self.idx;
+    let mut block_idx = self.block_index();
+    while block_idx < self.block_meta.tfs.len() {
+      let tf = self.block_meta.tfs[block_idx];
+      let bound = score_tf(
+        tf,
+        self.df,
+        self.min_doc_len,
+        self.avgdl,
+        self.docs,
+        self.k1,
+        self.b,
+        self.weight,
+      );
+      if bound >= min_contribution {
+        break;
+      }
+      block_idx += 1;
+      self.idx = (block_idx * self.block_meta.block_size).min(self.postings.len());
+    }
+    self.idx.saturating_sub(prev)
+  }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -827,16 +862,42 @@ fn wand_loop<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
         }
       }
     } else {
-      // Pivot > Smallest. Advance terms < pivot to pivot_doc
-      for term in queue[0..p_idx].iter_mut() {
-        if use_block_bounds {
+      // Pivot > Smallest. Advance terms < pivot to pivot_doc.
+      //
+      // BMW optimisation (BUG-005): when we have a full top-k heap and
+      // block-level bounds are available, skip blocks whose per-block
+      // max-tf score cannot contribute enough to push a candidate past
+      // the heap threshold. For each term being advanced, the minimum
+      // contribution needed from this term is:
+      //   min_needed = heap_threshold - Σ UB_global(other terms)
+      // because the global upper bound of every other term is an upper
+      // bound on what those terms could contribute at any doc_id.
+      if use_block_bounds && rank_hits && heap.len() >= k {
+        let total_ub: f32 = queue.iter().map(|t| t.upper_bound()).sum();
+        for term in queue[0..p_idx].iter_mut() {
+          let other_ub = total_ub - term.upper_bound();
+          let min_needed = (heap_threshold - other_ub).max(0.0);
+          let moved = term.skip_blocks_below_bound(min_needed);
+          with_stats(&mut stats, |s| s.postings_advanced += moved);
           let moved = term.skip_to_block(pivot_doc);
           with_stats(&mut stats, |s| s.postings_advanced += moved);
+          let moved = term.advance_to(pivot_doc);
+          with_stats(&mut stats, |s| s.postings_advanced += moved);
+          if term.is_done() {
+            prune_done = true;
+          }
         }
-        let moved = term.advance_to(pivot_doc);
-        with_stats(&mut stats, |s| s.postings_advanced += moved);
-        if term.is_done() {
-          prune_done = true;
+      } else {
+        for term in queue[0..p_idx].iter_mut() {
+          if use_block_bounds {
+            let moved = term.skip_to_block(pivot_doc);
+            with_stats(&mut stats, |s| s.postings_advanced += moved);
+          }
+          let moved = term.advance_to(pivot_doc);
+          with_stats(&mut stats, |s| s.postings_advanced += moved);
+          if term.is_done() {
+            prune_done = true;
+          }
         }
       }
       // Reposition only the advanced prefix.
@@ -995,5 +1056,328 @@ mod tests {
     let mut ids: Vec<DocId> = collector.docs.iter().map(|(id, _)| *id).collect();
     ids.sort_unstable();
     assert_eq!(ids, vec![1, 2]);
+  }
+
+  /// Helper that builds a ScoredTerm with a specific block size so the caller
+  /// can control per-block tf upper bounds in tests.
+  fn term_from_entries_with_block_size(entries: &[PostingEntry], block_size: usize) -> ScoredTerm {
+    let reader = PostingsReader::from_entries_for_test(entries.to_vec(), block_size);
+    let max_doc = entries.iter().map(|e| e.doc_id).max().unwrap_or(0) as usize;
+    let doc_lengths = Arc::new(vec![10.0; max_doc.saturating_add(1)]);
+    ScoredTerm {
+      postings: reader,
+      weight: 1.0,
+      avgdl: 10.0,
+      docs: 100.0,
+      k1: 1.2,
+      b: 0.75,
+      leaf: 0,
+      doc_lengths: Some(doc_lengths),
+      min_doc_len: Some(10.0),
+    }
+  }
+
+  #[test]
+  fn bmw_produces_same_top_k_as_wand() {
+    // Two terms with overlapping postings; verify BMW and WAND return
+    // identical top-k results (correctness invariant).
+    let term1 = term_from_entries(&[
+      PostingEntry {
+        doc_id: 0,
+        term_freq: 3,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 2,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 5,
+        term_freq: 5,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 8,
+        term_freq: 2,
+        positions: smallvec![],
+      },
+    ]);
+    let term2 = term_from_entries(&[
+      PostingEntry {
+        doc_id: 1,
+        term_freq: 4,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 5,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 7,
+        term_freq: 6,
+        positions: smallvec![],
+      },
+    ]);
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let wand = execute_top_k::<_, crate::query::collector::MatchCountingCollector>(
+      vec![term1.clone(), term2.clone()],
+      3,
+      ExecutionStrategy::Wand,
+      None,
+      &mut accept,
+      None,
+    );
+    let bmw = execute_top_k::<_, crate::query::collector::MatchCountingCollector>(
+      vec![term1, term2],
+      3,
+      ExecutionStrategy::Bmw,
+      None,
+      &mut accept,
+      None,
+    );
+    assert_eq!(
+      wand.len(),
+      bmw.len(),
+      "WAND and BMW should return same count"
+    );
+    for (w, b) in wand.iter().zip(bmw.iter()) {
+      assert_eq!(w.doc_id, b.doc_id, "doc_id mismatch");
+      assert!(
+        (w.score - b.score).abs() < 1e-6,
+        "score mismatch: wand={} bmw={}",
+        w.score,
+        b.score
+      );
+    }
+  }
+
+  #[test]
+  fn bmw_block_tf_skipping_reduces_postings_advanced() {
+    // Construct a scenario where BMW tf-based block skipping should
+    // kick in: one common term with many low-tf blocks and a few
+    // high-tf blocks, paired with a rare high-tf term that fills the
+    // top-k heap quickly. Once the heap is full, the common term's
+    // low-tf blocks should be skippable.
+    //
+    // Block size = 4 so we get clear block boundaries.
+    let block_size = 4;
+
+    // Common term: 16 postings across 4 blocks.
+    // Block 0 (doc_ids 0-3):  tf=1 each (low contribution)
+    // Block 1 (doc_ids 4-7):  tf=1 each (low contribution)
+    // Block 2 (doc_ids 8-11): tf=1 each (low contribution)
+    // Block 3 (doc_ids 12-15): tf=10 each (high contribution)
+    let mut common_entries = Vec::new();
+    for doc_id in 0..12 {
+      common_entries.push(PostingEntry {
+        doc_id,
+        term_freq: 1,
+        positions: smallvec![],
+      });
+    }
+    for doc_id in 12..16 {
+      common_entries.push(PostingEntry {
+        doc_id,
+        term_freq: 10,
+        positions: smallvec![],
+      });
+    }
+    let common = term_from_entries_with_block_size(&common_entries, block_size);
+
+    // Rare term: 4 postings, all high tf, in the high doc_id range.
+    // These fill the top-k heap with high scores early.
+    let rare = term_from_entries_with_block_size(
+      &[
+        PostingEntry {
+          doc_id: 12,
+          term_freq: 8,
+          positions: smallvec![],
+        },
+        PostingEntry {
+          doc_id: 13,
+          term_freq: 9,
+          positions: smallvec![],
+        },
+        PostingEntry {
+          doc_id: 14,
+          term_freq: 7,
+          positions: smallvec![],
+        },
+        PostingEntry {
+          doc_id: 15,
+          term_freq: 10,
+          positions: smallvec![],
+        },
+      ],
+      block_size,
+    );
+
+    let mut accept = |_doc: DocId, _score: f32| true;
+
+    // Run with plain WAND (no block-tf skipping)
+    let mut wand_stats = QueryStats::default();
+    let wand_results = execute_top_k_with_stats::<_, crate::query::collector::MatchCountingCollector>(
+      vec![common.clone(), rare.clone()],
+      3,
+      ExecutionStrategy::Wand,
+      Some(block_size),
+      &mut accept,
+      None,
+      Some(&mut wand_stats),
+    );
+
+    // Run with BMW (block-tf skipping active)
+    let mut bmw_stats = QueryStats::default();
+    let bmw_results = execute_top_k_with_stats::<_, crate::query::collector::MatchCountingCollector>(
+      vec![common, rare],
+      3,
+      ExecutionStrategy::Bmw,
+      Some(block_size),
+      &mut accept,
+      None,
+      Some(&mut bmw_stats),
+    );
+
+    // Results must be identical (correctness).
+    assert_eq!(
+      wand_results.len(),
+      bmw_results.len(),
+      "WAND and BMW should return same number of results"
+    );
+    for (w, b) in wand_results.iter().zip(bmw_results.iter()) {
+      assert_eq!(w.doc_id, b.doc_id, "doc_id mismatch");
+      assert!(
+        (w.score - b.score).abs() < 1e-6,
+        "score mismatch at doc {}: wand={} bmw={}",
+        w.doc_id,
+        w.score,
+        b.score
+      );
+    }
+
+    // BMW should advance fewer postings than plain WAND because it
+    // skips low-tf blocks during advancement.
+    assert!(
+      bmw_stats.postings_advanced <= wand_stats.postings_advanced,
+      "BMW should advance no more postings than WAND: bmw={} wand={}",
+      bmw_stats.postings_advanced,
+      wand_stats.postings_advanced
+    );
+  }
+
+  #[test]
+  fn skip_blocks_below_bound_skips_low_tf_blocks() {
+    // Directly test the skip_blocks_below_bound method on a TermState
+    // with known block-level tf values.
+    let block_size = 2;
+    // 3 blocks: block 0 (tf=1), block 1 (tf=1), block 2 (tf=10)
+    let entries = vec![
+      PostingEntry {
+        doc_id: 0,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 1,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 2,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 3,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 4,
+        term_freq: 10,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 5,
+        term_freq: 10,
+        positions: smallvec![],
+      },
+    ];
+    let term = ScoredTerm {
+      postings: PostingsReader::from_entries_for_test(entries, block_size),
+      weight: 1.0,
+      avgdl: 10.0,
+      docs: 100.0,
+      k1: 1.2,
+      b: 0.75,
+      leaf: 0,
+      doc_lengths: Some(Arc::new(vec![10.0; 6])),
+      min_doc_len: Some(10.0),
+    };
+    let mut state = TermState::new(term, block_size);
+
+    // Compute the score bound for tf=1 (low blocks) and tf=10 (high block)
+    let low_bound = score_tf(1.0, 6.0, 10.0, 10.0, 100.0, 1.2, 0.75, 1.0);
+    let high_bound = score_tf(10.0, 6.0, 10.0, 10.0, 100.0, 1.2, 0.75, 1.0);
+
+    // Set min_contribution between low and high so low blocks are skipped
+    let threshold = (low_bound + high_bound) / 2.0;
+    assert!(
+      threshold > low_bound,
+      "threshold must exceed low block bound"
+    );
+    assert!(
+      threshold < high_bound,
+      "threshold must be below high block bound"
+    );
+
+    // Start at block 0 (idx=0). Calling skip_blocks_below_bound should skip
+    // blocks 0 and 1 (both have tf=1 < threshold) and land at block 2 (idx=4).
+    let skipped = state.skip_blocks_below_bound(threshold);
+    assert_eq!(state.idx, 4, "should advance to block 2 (idx=4)");
+    assert_eq!(skipped, 4, "should have skipped 4 postings");
+
+    // Verify the block at idx=4 has doc_id=4
+    assert_eq!(state.doc_id(), 4);
+  }
+
+  #[test]
+  fn skip_blocks_below_bound_noop_when_threshold_zero() {
+    let block_size = 2;
+    let entries = vec![
+      PostingEntry {
+        doc_id: 0,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 1,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+    ];
+    let term = ScoredTerm {
+      postings: PostingsReader::from_entries_for_test(entries, block_size),
+      weight: 1.0,
+      avgdl: 10.0,
+      docs: 100.0,
+      k1: 1.2,
+      b: 0.75,
+      leaf: 0,
+      doc_lengths: Some(Arc::new(vec![10.0; 2])),
+      min_doc_len: Some(10.0),
+    };
+    let mut state = TermState::new(term, block_size);
+
+    // With threshold <= 0, nothing should be skipped
+    let skipped = state.skip_blocks_below_bound(0.0);
+    assert_eq!(skipped, 0);
+    assert_eq!(state.idx, 0);
+
+    let skipped = state.skip_blocks_below_bound(-1.0);
+    assert_eq!(skipped, 0);
+    assert_eq!(state.idx, 0);
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-005 (#143). `TermState::skip_to_block` only used `block_meta.doc_ids` (per-block maximum doc_id) to advance the cursor during the WAND advancement phase. `block_meta.tfs` (per-block maximum term frequency) was computed and stored by `build_block_meta` but only consulted during pivot selection via `block_upper_bound()`, never during advancement. Users who explicitly opted into the `Bmw` execution strategy paid the cost of building block metadata without reaping the bound-based skip benefit during the advancement phase.

## What changed

- **`searchlite-core/src/query/wand.rs`** — add `TermState::skip_blocks_below_bound(min_contribution)`, which skips forward through blocks whose per-block max-tf score contribution (via `score_tf`) is below `min_contribution`. Stops at the first block whose upper bound meets the threshold, or at the end of the postings list.

- **`searchlite-core/src/query/wand.rs`** (wand_loop) — integrate tf-based block skipping into the advancement phase. When `use_block_bounds` is active (BMW strategy), the top-k heap is full, and `rank_hits` is true:
  1. Compute the total global upper bound of all queued terms once.
  2. For each term being advanced to `pivot_doc`, derive `min_needed = max(0, heap_threshold - sum_of_other_global_upper_bounds)`.
  3. Call `skip_blocks_below_bound(min_needed)` before the existing `skip_to_block(pivot_doc)` and `advance_to(pivot_doc)`.

  This ensures blocks whose max-tf contribution cannot push a candidate past the heap threshold are skipped entirely, reducing the number of postings examined during advancement.

- **`searchlite-core/src/query/wand.rs`** (tests) — four new regression tests:
  - `bmw_produces_same_top_k_as_wand` — correctness: BMW and WAND return identical top-k results and scores.
  - `bmw_block_tf_skipping_reduces_postings_advanced` — performance: BMW advances no more postings than plain WAND on a workload with mixed high/low tf blocks, verifying the skip path is exercised.
  - `skip_blocks_below_bound_skips_low_tf_blocks` — unit: directly tests the new method with known block-level tf values, asserting blocks 0-1 (tf=1) are skipped and block 2 (tf=10) is the landing point.
  - `skip_blocks_below_bound_noop_when_threshold_zero` — edge case: threshold <= 0 returns immediately with no advancement.

## Test plan

- [x] `cargo test -p searchlite-core --lib query::wand` — 8/8 pass (4 existing + 4 new).
- [x] `cargo test -p searchlite-core --lib` — 291/291 pass.
- [x] `cargo test -p searchlite-core` — full core test matrix green (lib + all integration suites).
- [x] `cargo test -p searchlite-ffi -p searchlite-cli -p searchlite-http` — all green.
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.

Closes #143