### PR TITLE
fix(aggs): make range/date_range upper bound `to` exclusive

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1118,7 +1118,7 @@ impl<'a> RangeCollector<'a> {
     for entry in self.ranges.iter_mut() {
       if values.iter().any(|val| {
         let ge_from = entry.from.map(|f| *val >= f).unwrap_or(true);
-        let lt_to = entry.to.map(|t| *val <= t).unwrap_or(true);
+        let lt_to = entry.to.map(|t| *val < t).unwrap_or(true);
         ge_from && lt_to
       }) {
         entry.bucket.doc_count += 1;

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -2172,7 +2172,9 @@ fn range_aggregation_counts() {
     .unwrap();
   let range = resp.aggregations.get("score_ranges").unwrap();
   if let searchlite_core::api::types::AggregationResponse::Range { buckets, .. } = range {
-    assert_eq!(buckets[0].doc_count, 2);
+    // With `to` exclusive: score=1 is in low (1 < 5), score=5 is NOT in low (5 < 5 is false).
+    assert_eq!(buckets[0].doc_count, 1);
+    // score=5 and score=10 are in mid (5 >= 5 && 5 < 15, 10 >= 5 && 10 < 15).
     assert_eq!(buckets[1].doc_count, 2);
   }
 }
@@ -3866,5 +3868,260 @@ fn pipeline_missing_metric_path_with_gap_policy_inserts_zeros() {
     assert_eq!(deriv_second, Some(0.0));
   } else {
     panic!("expected histogram agg");
+  }
+}
+
+#[test]
+fn range_aggregation_to_is_exclusive_at_boundary() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "price".into(),
+    i64: false,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    for (i, price) in [25.0, 50.0, 75.0, 100.0, 150.0].iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("p-{i}"),
+          vec![("body", json!("item")), ("price", json!(price))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  // Disjoint ranges matching the searchlite-node README example: cheap/mid/premium.
+  // With `to` exclusive, each boundary value belongs to exactly one bucket.
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "price_ranges".into(),
+    Aggregation::Range(Box::new(RangeAggregation {
+      field: "price".into(),
+      keyed: false,
+      ranges: vec![
+        searchlite_core::api::types::RangeBound {
+          key: Some("cheap".into()),
+          from: None,
+          to: Some(50.0),
+        },
+        searchlite_core::api::types::RangeBound {
+          key: Some("mid".into()),
+          from: Some(50.0),
+          to: Some(100.0),
+        },
+        searchlite_core::api::types::RangeBound {
+          key: Some("premium".into()),
+          from: Some(100.0),
+          to: None,
+        },
+      ],
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "item".into(),
+      fields: None,
+      filter: None,
+      limit: 0,
+      from: 0,
+      return_hits: false,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  let range = resp.aggregations.get("price_ranges").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::Range { buckets, .. } = range {
+    assert_eq!(buckets.len(), 3);
+    // cheap: only 25 (50 is NOT included because to is exclusive)
+    assert_eq!(
+      buckets[0].doc_count, 1,
+      "cheap should contain only price=25"
+    );
+    // mid: 50 and 75 (100 is NOT included because to is exclusive)
+    assert_eq!(
+      buckets[1].doc_count, 2,
+      "mid should contain price=50 and price=75"
+    );
+    // premium: 100 and 150
+    assert_eq!(
+      buckets[2].doc_count, 2,
+      "premium should contain price=100 and price=150"
+    );
+    // Total across buckets must equal the number of matching docs (no double-counting).
+    let total: u64 = buckets.iter().map(|b| b.doc_count).sum();
+    assert_eq!(
+      total, 5,
+      "each doc must be counted exactly once across disjoint ranges"
+    );
+  } else {
+    panic!("expected range agg response");
+  }
+}
+
+#[test]
+fn date_range_to_is_exclusive_at_boundary() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // ts=2000 corresponds to the exact boundary between the two ranges.
+    writer
+      .add_document(&doc(
+        "on-boundary",
+        vec![("body", json!("event")), ("ts", json!(2000))],
+      ))
+      .unwrap();
+    writer
+      .add_document(&doc(
+        "before-boundary",
+        vec![("body", json!("event")), ("ts", json!(1000))],
+      ))
+      .unwrap();
+    writer.commit().unwrap();
+  }
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "ts_ranges".into(),
+    Aggregation::DateRange(Box::new(
+      searchlite_core::api::types::DateRangeAggregation {
+        field: "ts".into(),
+        keyed: false,
+        format: None,
+        ranges: vec![
+          searchlite_core::api::types::DateRangeBound {
+            key: Some("before".into()),
+            from: Some("1970-01-01T00:00:00Z".into()),
+            to: Some("1970-01-01T00:00:02Z".into()), // 2000 ms
+          },
+          searchlite_core::api::types::DateRangeBound {
+            key: Some("after".into()),
+            from: Some("1970-01-01T00:00:02Z".into()), // 2000 ms
+            to: Some("1970-01-01T00:00:04Z".into()),
+          },
+        ],
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      },
+    )),
+  );
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "event".into(),
+      fields: None,
+      filter: None,
+      limit: 0,
+      from: 0,
+      return_hits: false,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  let range = resp.aggregations.get("ts_ranges").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::DateRange { buckets, .. } = range {
+    assert_eq!(buckets.len(), 2);
+    // ts=1000 is in "before" (1000 >= 0 && 1000 < 2000)
+    assert_eq!(buckets[0].doc_count, 1, "before: only ts=1000");
+    // ts=2000 is in "after" (2000 >= 2000 && 2000 < 4000), NOT in "before"
+    assert_eq!(
+      buckets[1].doc_count, 1,
+      "after: only ts=2000 (boundary is exclusive in 'before')"
+    );
+    let total: u64 = buckets.iter().map(|b| b.doc_count).sum();
+    assert_eq!(total, 2, "no double-counting at boundary");
+  } else {
+    panic!("expected date range agg response");
   }
 }

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -3993,11 +3993,12 @@ fn range_aggregation_to_is_exclusive_at_boundary() {
       buckets[2].doc_count, 2,
       "premium should contain price=100 and price=150"
     );
-    // Total across buckets must equal the number of matching docs (no double-counting).
+    // In this fixture each matching document has a single price value, so the bucket totals
+    // should add up to the number of matching docs if boundary values are not double-counted.
     let total: u64 = buckets.iter().map(|b| b.doc_count).sum();
     assert_eq!(
       total, 5,
-      "each doc must be counted exactly once across disjoint ranges"
+      "single-valued price docs should not be double-counted across exclusive range boundaries"
     );
   } else {
     panic!("expected range agg response");


### PR DESCRIPTION
## Summary

`RangeCollector::collect` in `searchlite-core/src/query/aggs/mod.rs` compared values against the upper bound `to` with `<=` rather than `<`. This made `to` inclusive, so documents whose value equalled the boundary between two adjacent ranges were counted in **both** buckets — breaking the disjoint-bucket contract, inflating sub-aggregation populations, and diverging from Elasticsearch-compatible `[from, to)` semantics. `date_range` delegates to the same collector and inherited the defect.

The collector now uses `*val < t`, restoring the **`from` inclusive, `to` exclusive** convention that the disjoint-range example in `searchlite-node/README.md` (`cheap` / `mid` / `premium`) already assumes and that Elasticsearch documents.

## What changed

- **`searchlite-core/src/query/aggs/mod.rs`** — one-character change: `*val <= t` → `*val < t` at the `RangeCollector::collect` call site. The local was already named `lt_to` ("less than to"), which was inconsistent with `<=`. `DateRangeCollector` inherits the fix automatically via its `RangeCollector` wrapper — no additional change needed.
- **`searchlite-core/tests/aggregations.rs`** — three test updates:
  - `range_aggregation_counts`: update expectations so the boundary value (`score = 5`) is counted once in `mid` and **not** also in `low` (now `low = 1, mid = 2` instead of the buggy `2, 2`).
  - New `range_aggregation_to_is_exclusive_at_boundary`: covers the full documented `cheap` / `mid` / `premium` disjoint-range layout with values placed precisely on every boundary (`25, 50, 75, 100, 150`), asserts per-bucket counts **and** that the total `doc_count` across buckets equals the number of matching docs (so no boundary double-counting is possible).
  - New `date_range_to_is_exclusive_at_boundary`: covers the delegated `date_range` path around an exact ISO boundary timestamp (`1970-01-01T00:00:02Z`), asserting the boundary doc lands in the upper range only.

## Test plan

- [x] `cargo test -p searchlite-core --test aggregations` — 40/40 pass (38 existing + 2 new regression tests, 1 expectation updated).
- [x] `cargo test -p searchlite-core` — full core test matrix green (466 tests across lib + all integration suites).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.
- [x] Verified the new `range_aggregation_to_is_exclusive_at_boundary` test catches the original bug: under the old `<=` behaviour its `doc_count` sum exceeds 5 (boundary values are double-counted).

Closes #230