### PR TITLE
fix(aggs): normalize day before month in quarter calendar truncation (BUG-233)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3863,7 +3863,10 @@ fn truncate_calendar(value: i64, unit: CalendarUnit) -> Option<i64> {
     CalendarUnit::Quarter => {
       let month = date.month();
       let quarter_start = ((month - 1) / 3) * 3 + 1;
-      date.with_month(quarter_start)?.with_day(1)?
+      // Normalize day to 1 before changing month — with_month fails when
+      // the current day exceeds the target month's length (e.g. May 31 →
+      // April has only 30 days).
+      date.with_day(1)?.with_month(quarter_start)?
     }
     CalendarUnit::Year => date.with_month(1)?.with_day(1)?,
   };
@@ -4241,5 +4244,58 @@ mod tests {
       panic!("missing derivative on bucket");
     }
     assert!(responses.contains_key("diff"));
+  }
+
+  /// Regression for BUG-233: truncate_calendar Quarter arm must not return
+  /// None for May 31 (day 31 → April has only 30 days). The fix normalizes
+  /// day to 1 before changing the month.
+  #[test]
+  fn truncate_calendar_quarter_handles_may_31() {
+    use chrono::{NaiveDate, Utc};
+    let dt = NaiveDate::from_ymd_opt(2024, 5, 31)
+      .unwrap()
+      .and_hms_opt(12, 0, 0)
+      .unwrap();
+    let ts = chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).timestamp_millis();
+    let result = truncate_calendar(ts, CalendarUnit::Quarter);
+    assert!(
+      result.is_some(),
+      "truncate_calendar must not return None for May 31"
+    );
+    let expected = NaiveDate::from_ymd_opt(2024, 4, 1)
+      .unwrap()
+      .and_hms_opt(0, 0, 0)
+      .unwrap();
+    let expected_ts =
+      chrono::DateTime::<Utc>::from_naive_utc_and_offset(expected, Utc).timestamp_millis();
+    assert_eq!(result.unwrap(), expected_ts);
+  }
+
+  /// Exhaustive sweep: truncate_calendar must never return None for any
+  /// valid date across all five calendar units (Day, Week, Month, Quarter,
+  /// Year). Uses every day of leap-year 2024 (366 days).
+  #[test]
+  fn truncate_calendar_never_returns_none_for_valid_dates() {
+    use chrono::{NaiveDate, Utc};
+    let units = [
+      CalendarUnit::Day,
+      CalendarUnit::Week,
+      CalendarUnit::Month,
+      CalendarUnit::Quarter,
+      CalendarUnit::Year,
+    ];
+    let mut date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+    let end = NaiveDate::from_ymd_opt(2024, 12, 31).unwrap();
+    while date <= end {
+      let dt = date.and_hms_opt(12, 0, 0).unwrap();
+      let ts = chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).timestamp_millis();
+      for unit in &units {
+        assert!(
+          truncate_calendar(ts, *unit).is_some(),
+          "truncate_calendar returned None for {date}"
+        );
+      }
+      date = date.succ_opt().unwrap();
+    }
   }
 }

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2463,3 +2463,134 @@ mod bug_222 {
     search_with_agg(&idx, aggs).expect("typical top_hits values must be accepted");
   }
 }
+
+/// Regression for BUG-233: calendar_interval "quarter" silently dropped
+/// documents dated May 31 because truncate_calendar changed the month
+/// before normalizing the day.
+mod bug_233 {
+  use super::*;
+
+  fn timestamp_index(path: &std::path::Path) -> Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "ts".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = IndexBuilder::create(path, schema, build_base_options(path)).unwrap();
+    let ts = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
+    let mut writer = idx.writer().unwrap();
+    for (id, t) in [
+      ("d1", "2024-04-15T10:00:00Z"),
+      ("d2", "2024-05-31T12:00:00Z"),
+      ("d3", "2024-07-10T08:00:00Z"),
+    ] {
+      writer
+        .add_document(&doc(
+          id,
+          vec![("body", json!("text")), ("ts", json!(ts(t)))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+    idx
+  }
+
+  fn run_quarter_histogram(idx: &Index) -> Vec<(serde_json::Value, u64)> {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "q".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: Some("quarter".into()),
+        fixed_interval: None,
+        offset: None,
+        format: None,
+        min_doc_count: Some(1),
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+    let req = SearchRequest {
+      query: "text".into(),
+      fields: None,
+      filter: None,
+      limit: 0,
+      from: 0,
+      return_hits: false,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    };
+    let reader = idx.reader().unwrap();
+    let resp = reader.search(&req).unwrap();
+    if let Some(searchlite_core::api::types::AggregationResponse::DateHistogram {
+      buckets, ..
+    }) = resp.aggregations.get("q")
+    {
+      buckets
+        .iter()
+        .map(|b| (b.key.clone(), b.doc_count))
+        .collect()
+    } else {
+      panic!("expected DateHistogram response");
+    }
+  }
+
+  #[test]
+  fn quarter_calendar_interval_counts_may_31_documents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+    let buckets = run_quarter_histogram(&idx);
+
+    assert_eq!(
+      buckets.len(),
+      2,
+      "expected exactly 2 quarter buckets (Q2 + Q3); got: {buckets:?}"
+    );
+
+    // Q2 (2024-04-01) must have 2 docs (April 15 + May 31).
+    assert_eq!(
+      buckets[0].1, 2,
+      "Q2 bucket must contain 2 docs; got: {buckets:?}"
+    );
+
+    // Q3 (2024-07-01) must have 1 doc.
+    assert_eq!(
+      buckets[1].1, 1,
+      "Q3 bucket must contain 1 doc; got: {buckets:?}"
+    );
+
+    // Total doc_count across all buckets must equal 3 (no silent drops).
+    let total: u64 = buckets.iter().map(|(_, c)| c).sum();
+    assert_eq!(
+      total, 3,
+      "total doc_count must equal indexed docs; got: {buckets:?}"
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #233. `truncate_calendar` for `CalendarUnit::Quarter` changed the month **before** normalizing the day to 1. When the source day was 31 and the target quarter-start month had only 30 days (April), `NaiveDate::with_month(4)` returned `None`, causing `bucket_start` to propagate the failure and the collector to silently drop the document via its `None => continue` arm.

The only real-world trigger was **May 31** — roughly one day per year of lost aggregation data with no observable error.

## What changed

- **`searchlite-core/src/query/aggs/mod.rs`** — swap the order in the `CalendarUnit::Quarter` arm so `with_day(1)` runs before `with_month(quarter_start)`. `with_day(1)` is always valid for any month, and `with_month(x)` on a day-1 date is always valid. This matches the approach already used by the Month and Year arms.
- **`searchlite-core/src/query/aggs/mod.rs`** (unit tests) — add:
  - `truncate_calendar_quarter_handles_may_31` — pinned regression test asserting `2024-05-31T12:00:00Z` truncates to `2024-04-01T00:00:00Z`.
  - `truncate_calendar_never_returns_none_for_valid_dates` — exhaustive sweep over every day of leap-year 2024 (366 days) × all 5 calendar units, asserting `truncate_calendar` never returns `None`.
- **`searchlite-core/tests/aggregation_bounds.rs`** — add `bug_233::quarter_calendar_interval_counts_may_31_documents` as an end-to-end regression: indexes three docs (Apr 15, May 31, Jul 10), runs a `calendar_interval: "quarter"` aggregation, and asserts both per-bucket counts (Q2=2, Q3=1) and that the total `doc_count` equals 3 (no silent drops).

## Test plan

- [x] `cargo test -p searchlite-core --lib -- truncate_calendar` — 2/2 pass
- [x] `cargo test -p searchlite-core --test aggregation_bounds -- bug_233` — 1/1 pass
- [x] `cargo test -p searchlite-core` — full core test matrix green
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean

Closes #233