### PR TITLE
fix(aggs): normalize day before month in quarter truncation

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -702,7 +702,7 @@ enum DateInterval {
   Calendar(CalendarUnit),
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) enum CalendarUnit {
   Day,
   Week,
@@ -3863,7 +3863,11 @@ fn truncate_calendar(value: i64, unit: CalendarUnit) -> Option<i64> {
     CalendarUnit::Quarter => {
       let month = date.month();
       let quarter_start = ((month - 1) / 3) * 3 + 1;
-      date.with_month(quarter_start)?.with_day(1)?
+      // Normalize the day to 1 before changing the month so that
+      // `with_month` never receives an out-of-range day (e.g. May 31
+      // → April 31 is invalid and returns None).  `with_day(1)` is
+      // always valid, and `with_month(x)` on day 1 is always valid.
+      date.with_day(1)?.with_month(quarter_start)?
     }
     CalendarUnit::Year => date.with_month(1)?.with_day(1)?,
   };
@@ -4241,5 +4245,65 @@ mod tests {
       panic!("missing derivative on bucket");
     }
     assert!(responses.contains_key("diff"));
+  }
+
+  #[test]
+  fn truncate_calendar_quarter_handles_may_31() {
+    // BUG-233: `truncate_calendar` Quarter branch called `with_month`
+    // before `with_day(1)`, causing `NaiveDate::with_month(4)` to
+    // return None for May 31 (April has only 30 days).
+    use chrono::{TimeZone, Utc};
+
+    let dt = Utc.with_ymd_and_hms(2024, 5, 31, 12, 0, 0).unwrap();
+    let ts = dt.timestamp_millis();
+
+    let result = truncate_calendar(ts, CalendarUnit::Quarter);
+    let expected = Utc
+      .with_ymd_and_hms(2024, 4, 1, 0, 0, 0)
+      .unwrap()
+      .timestamp_millis();
+    assert_eq!(
+      result,
+      Some(expected),
+      "May 31 should truncate to Q2 start (2024-04-01)"
+    );
+
+    // Also verify via bucket_start which is what the collector calls.
+    let interval = DateInterval::Calendar(CalendarUnit::Quarter);
+    let bucket = bucket_start(ts, 0, &interval);
+    assert_eq!(
+      bucket,
+      Some(expected),
+      "bucket_start must not return None for May 31"
+    );
+  }
+
+  #[test]
+  fn truncate_calendar_never_returns_none_for_valid_dates() {
+    // Exhaustive sweep over every day of leap year 2024 for all calendar
+    // units to guard against ordering regressions in any branch.
+    use chrono::{NaiveDate, TimeZone, Utc};
+
+    let units = [
+      CalendarUnit::Day,
+      CalendarUnit::Week,
+      CalendarUnit::Month,
+      CalendarUnit::Quarter,
+      CalendarUnit::Year,
+    ];
+
+    let mut date = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+    let end = NaiveDate::from_ymd_opt(2024, 12, 31).unwrap();
+    while date <= end {
+      let ts = date.and_hms_opt(12, 0, 0).unwrap();
+      let ts_millis = Utc.from_utc_datetime(&ts).timestamp_millis();
+      for unit in &units {
+        assert!(
+          truncate_calendar(ts_millis, *unit).is_some(),
+          "truncate_calendar returned None for {date} with unit {unit:?}"
+        );
+      }
+      date = date.succ_opt().unwrap();
+    }
   }
 }

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2467,117 +2467,121 @@ mod bug_222 {
 /// BUG-233: `calendar_interval: "quarter"` silently dropped documents dated
 /// May 31 because `truncate_calendar` called `with_month(4)` before
 /// `with_day(1)`, producing an invalid April-31 date that chrono rejected.
-#[test]
-fn quarter_calendar_interval_counts_may_31_documents() {
-  let tmp = tempfile::tempdir().unwrap();
-  let path = tmp.path().to_path_buf();
-  let mut schema = Schema::default_text_body();
-  schema.numeric_fields.push(NumericField {
-    name: "ts".into(),
-    i64: true,
-    fast: true,
-    stored: true,
-    nullable: false,
-  });
-  let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+mod bug_233 {
+  use super::*;
 
-  let ts = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
-  {
-    let mut writer = idx.writer().unwrap();
-    for (i, t) in [
-      "2024-04-15T00:00:00Z", // Q2
-      "2024-05-31T12:00:00Z", // Q2 — the problematic date
-      "2024-07-10T00:00:00Z", // Q3
-    ]
-    .iter()
-    .enumerate()
+  #[test]
+  fn quarter_calendar_interval_counts_may_31_documents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_path_buf();
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "ts".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+
+    let ts = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
     {
-      writer
-        .add_document(&doc(
-          &format!("q-{i}"),
-          vec![("body", json!("data")), ("ts", json!(ts(t)))],
-        ))
-        .unwrap();
+      let mut writer = idx.writer().unwrap();
+      for (i, t) in [
+        "2024-04-15T00:00:00Z", // Q2
+        "2024-05-31T12:00:00Z", // Q2 — the problematic date
+        "2024-07-10T00:00:00Z", // Q3
+      ]
+      .iter()
+      .enumerate()
+      {
+        writer
+          .add_document(&doc(
+            &format!("q-{i}"),
+            vec![("body", json!("data")), ("ts", json!(ts(t)))],
+          ))
+          .unwrap();
+      }
+      writer.commit().unwrap();
     }
-    writer.commit().unwrap();
-  }
 
-  let mut aggs = BTreeMap::new();
-  aggs.insert(
-    "quarters".into(),
-    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
-      field: "ts".into(),
-      calendar_interval: Some("quarter".into()),
-      fixed_interval: None,
-      offset: None,
-      format: None,
-      min_doc_count: Some(1),
-      extended_bounds: None,
-      hard_bounds: None,
-      missing: None,
-      sampling: None,
-      aggs: BTreeMap::new(),
-    })),
-  );
-
-  let resp = idx
-    .reader()
-    .unwrap()
-    .search(&SearchRequest {
-      query: "data".into(),
-      fields: None,
-      filter: None,
-      limit: 0,
-      from: 0,
-      return_hits: false,
-      candidate_size: None,
-      #[cfg(feature = "vectors")]
-      max_global_vector_candidates: None,
-      sort: Vec::new(),
-      cursor: None,
-      search_after: None,
-      execution: ExecutionStrategy::Wand,
-      bmw_block_size: None,
-      fuzzy: None,
-      track_total_hits: None,
-      #[cfg(feature = "vectors")]
-      vector_query: None,
-      #[cfg(feature = "vectors")]
-      vector_filter: None,
-      return_stored: false,
-      highlight_field: None,
-      highlight: None,
-      collapse: None,
-      aggs,
-      suggest: BTreeMap::new(),
-      rescore: None,
-      explain: false,
-      profile: false,
-    })
-    .unwrap();
-
-  let agg = resp.aggregations.get("quarters").unwrap();
-  if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } = agg {
-    // Q2 bucket (2024-04-01) should contain both April 15 and May 31.
-    let q2_key = ts("2024-04-01T00:00:00Z");
-    let q3_key = ts("2024-07-01T00:00:00Z");
-
-    let q2 = buckets.iter().find(|b| b.key == json!(q2_key));
-    let q3 = buckets.iter().find(|b| b.key == json!(q3_key));
-
-    assert!(q2.is_some(), "Q2 bucket must exist");
-    assert_eq!(
-      q2.unwrap().doc_count,
-      2,
-      "Q2 must count both Apr 15 and May 31"
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "quarters".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: Some("quarter".into()),
+        fixed_interval: None,
+        offset: None,
+        format: None,
+        min_doc_count: Some(1),
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
     );
-    assert!(q3.is_some(), "Q3 bucket must exist");
-    assert_eq!(q3.unwrap().doc_count, 1, "Q3 must count Jul 10");
 
-    // Total doc_count across all buckets must equal the number of indexed docs.
-    let total: u64 = buckets.iter().map(|b| b.doc_count).sum();
-    assert_eq!(total, 3, "no document may be silently dropped");
-  } else {
-    panic!("expected date histogram response");
+    let resp = idx
+      .reader()
+      .unwrap()
+      .search(&SearchRequest {
+        query: "data".into(),
+        fields: None,
+        filter: None,
+        limit: 0,
+        from: 0,
+        return_hits: false,
+        candidate_size: None,
+        #[cfg(feature = "vectors")]
+        max_global_vector_candidates: None,
+        sort: Vec::new(),
+        cursor: None,
+        search_after: None,
+        execution: ExecutionStrategy::Wand,
+        bmw_block_size: None,
+        fuzzy: None,
+        track_total_hits: None,
+        #[cfg(feature = "vectors")]
+        vector_query: None,
+        #[cfg(feature = "vectors")]
+        vector_filter: None,
+        return_stored: false,
+        highlight_field: None,
+        highlight: None,
+        collapse: None,
+        aggs,
+        suggest: BTreeMap::new(),
+        rescore: None,
+        explain: false,
+        profile: false,
+      })
+      .unwrap();
+
+    let agg = resp.aggregations.get("quarters").unwrap();
+    if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } = agg {
+      // Q2 bucket (2024-04-01) should contain both April 15 and May 31.
+      let q2_key = ts("2024-04-01T00:00:00Z");
+      let q3_key = ts("2024-07-01T00:00:00Z");
+
+      let q2 = buckets.iter().find(|b| b.key == json!(q2_key));
+      let q3 = buckets.iter().find(|b| b.key == json!(q3_key));
+
+      assert!(q2.is_some(), "Q2 bucket must exist");
+      assert_eq!(
+        q2.unwrap().doc_count,
+        2,
+        "Q2 must count both Apr 15 and May 31"
+      );
+      assert!(q3.is_some(), "Q3 bucket must exist");
+      assert_eq!(q3.unwrap().doc_count, 1, "Q3 must count Jul 10");
+
+      // Total doc_count across all buckets must equal the number of indexed docs.
+      let total: u64 = buckets.iter().map(|b| b.doc_count).sum();
+      assert_eq!(total, 3, "no document may be silently dropped");
+    } else {
+      panic!("expected date histogram response");
+    }
   }
 }

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2463,3 +2463,121 @@ mod bug_222 {
     search_with_agg(&idx, aggs).expect("typical top_hits values must be accepted");
   }
 }
+
+/// BUG-233: `calendar_interval: "quarter"` silently dropped documents dated
+/// May 31 because `truncate_calendar` called `with_month(4)` before
+/// `with_day(1)`, producing an invalid April-31 date that chrono rejected.
+#[test]
+fn quarter_calendar_interval_counts_may_31_documents() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+
+  let ts = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
+  {
+    let mut writer = idx.writer().unwrap();
+    for (i, t) in [
+      "2024-04-15T00:00:00Z", // Q2
+      "2024-05-31T12:00:00Z", // Q2 — the problematic date
+      "2024-07-10T00:00:00Z", // Q3
+    ]
+    .iter()
+    .enumerate()
+    {
+      writer
+        .add_document(&doc(
+          &format!("q-{i}"),
+          vec![("body", json!("data")), ("ts", json!(ts(t)))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "quarters".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: Some("quarter".into()),
+      fixed_interval: None,
+      offset: None,
+      format: None,
+      min_doc_count: Some(1),
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "data".into(),
+      fields: None,
+      filter: None,
+      limit: 0,
+      from: 0,
+      return_hits: false,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+
+  let agg = resp.aggregations.get("quarters").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } = agg {
+    // Q2 bucket (2024-04-01) should contain both April 15 and May 31.
+    let q2_key = ts("2024-04-01T00:00:00Z");
+    let q3_key = ts("2024-07-01T00:00:00Z");
+
+    let q2 = buckets.iter().find(|b| b.key == json!(q2_key));
+    let q3 = buckets.iter().find(|b| b.key == json!(q3_key));
+
+    assert!(q2.is_some(), "Q2 bucket must exist");
+    assert_eq!(
+      q2.unwrap().doc_count,
+      2,
+      "Q2 must count both Apr 15 and May 31"
+    );
+    assert!(q3.is_some(), "Q3 bucket must exist");
+    assert_eq!(q3.unwrap().doc_count, 1, "Q3 must count Jul 10");
+
+    // Total doc_count across all buckets must equal the number of indexed docs.
+    let total: u64 = buckets.iter().map(|b| b.doc_count).sum();
+    assert_eq!(total, 3, "no document may be silently dropped");
+  } else {
+    panic!("expected date histogram response");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #233. `truncate_calendar` for `CalendarUnit::Quarter` called `with_month(quarter_start)` before `with_day(1)`. When the source date was May 31 and the quarter-start month was April (30 days), `NaiveDate::with_month(4)` returned `None` because April 31 is invalid. This caused `bucket_start` to return `None`, and the collector silently skipped the document via `None => continue` — no error, no fallback bucket, no diagnostic.

The only real-world triggering date is **May 31** (any year): quarter-start months are `{Jan, Apr, Jul, Oct}`, April is the only 30-day one among them, and the source month must be in Q2 (April and June have only 30 days, so only May 31 fires).

## What changed

- **`searchlite-core/src/query/aggs/mod.rs`** — swap the order in the `CalendarUnit::Quarter` arm so `with_day(1)` runs before `with_month(quarter_start)`. `with_day(1)` is always valid for any month, and `with_month(x)` on a day-1 date is always valid, so the combined expression is total for any valid input. Added `Debug` derive to `CalendarUnit` to support the exhaustive test assertions.
- **`searchlite-core/src/query/aggs/mod.rs`** (unit tests) — add:
  - `truncate_calendar_quarter_handles_may_31` — pins the Q2 truncation for `2024-05-31T12:00:00Z → 2024-04-01T00:00:00Z` at both `truncate_calendar` and `bucket_start` levels.
  - `truncate_calendar_never_returns_none_for_valid_dates` — exhaustive sweep over every day of leap-year 2024 (366 days) × all 5 calendar units, asserting `truncate_calendar` never returns `None`.
- **`searchlite-core/tests/aggregation_bounds.rs`** — add `quarter_calendar_interval_counts_may_31_documents`: indexes three docs (`2024-04-15`, `2024-05-31`, `2024-07-10`), runs a `calendar_interval: "quarter"` aggregation, and asserts per-bucket counts (Q2=2, Q3=1) and that total `doc_count` equals the number of matching docs (no silent drop).

## Test plan

- [x] `cargo test -p searchlite-core --lib query::aggs::tests::truncate_calendar` — 2/2 pass (new).
- [x] `cargo test -p searchlite-core --test aggregation_bounds quarter_calendar_interval` — 1/1 pass (new).
- [x] `cargo test -p searchlite-core` — full core test matrix green (lib + all integration suites).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.

Closes #233