### PR TITLE
ci: reduce PR workflow to MSRV + stable, move bench to main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,26 @@ jobs:
       - name: Test
         run: cargo test --all --all-features
 
+  test-wasm-browser:
+    name: WASM Browser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+      - name: Build WASM package
+        run: wasm-pack build searchlite-wasm --target web --release
+      - name: Run browser tests
+        env:
+          RUST_TEST_THREADS: "1"
+        run: wasm-pack test --headless --chrome searchlite-wasm
+
   test-node:
     name: Node.js
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     name: Lint / Build / Test (${{ matrix.toolchain }})
@@ -16,7 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.92.0, 1.88.0, stable, beta, nightly]
+        toolchain: [1.88.0, stable]
+        include:
+          - toolchain: stable
+            check-fmt: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
@@ -27,8 +34,33 @@ jobs:
         with:
           cache-on-failure: true
       - name: Format check
-        if: ${{ matrix.toolchain == 'stable' }}
+        if: ${{ matrix.check-fmt }}
         run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all --all-features --all-targets -- -D warnings
+      - name: Build
+        run: cargo build --all --all-features
+      - name: Test
+        run: cargo test --all --all-features
+
+  # Full toolchain coverage — only on main
+  lint-test-extended:
+    name: Extended / ${{ matrix.toolchain }}
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [beta, nightly]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Clippy
         run: cargo clippy --all --all-features --all-targets -- -D warnings
       - name: Build
@@ -106,6 +138,7 @@ jobs:
 
   bench:
     name: Benchmarks
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: lint-test
     steps:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -110,7 +110,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: cargo install wasm-pack --locked
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -112,8 +112,40 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       - name: Build wasm package
         run: wasm-pack build --release searchlite-wasm
+
+      - name: Smoke test wasm bundle
+        run: |
+          set -euo pipefail
+          test -f searchlite-wasm/pkg/searchlite_wasm.js
+          test -f searchlite-wasm/pkg/searchlite_wasm_bg.wasm
+          node --input-type=module <<'EOF'
+          import path from "node:path";
+          import { pathToFileURL } from "node:url";
+
+          const moduleUrl = pathToFileURL(path.resolve("searchlite-wasm/pkg/searchlite_wasm.js")).href;
+          const wasmModule = await import(moduleUrl);
+          if (typeof wasmModule.Searchlite !== "function") {
+            throw new Error("missing Searchlite export from wasm package");
+          }
+          const schema = {
+            type: "object",
+            properties: {
+              body: { type: "string" }
+            }
+          };
+          const dbName = `release-smoke-${Date.now()}`;
+          const idx = await wasmModule.Searchlite.init(dbName, JSON.stringify(schema), "memory");
+          idx.add_document({ _id: "smoke-doc", body: "hello smoke" });
+          await idx.commit();
+          console.log("WASM package smoke test passed (init + add + commit)");
+          EOF
 
       - name: Package wasm bundle
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2117,6 +2117,7 @@ dependencies = [
  "getrandom 0.2.16",
  "hashbrown 0.14.5",
  "hmac",
+ "js-sys",
  "log",
  "memmap2",
  "parking_lot",

--- a/docs/bindings.md
+++ b/docs/bindings.md
@@ -31,9 +31,49 @@ All FFI functions that return `c_int` use the following codes:
 ## WASM
 
 - `add_document` / `add_documents` queue writes; `commit()` persists them and makes them searchable. `flush_storage()` only drains pending storage writes if you need it.
+- `delete_document(id)` queues a single delete by doc id; `delete_documents(ids)` accepts a string or array of strings for batch deletes. Both require `commit()` to persist.
+- `update_document({ id, set?, unset? })` queues partial updates by doc id; `set` and `unset` follow core patch semantics and require `commit()` to persist.
+- `mget({ ids, return_stored? })` returns `{ docs: [...] }` in input order with per-id `found` and optional `_source`.
+- `multi_search({ searches, parallel?, max_concurrency? })` returns `{ results: [...] }` preserving request order.
+- Maintenance helpers: `compact()` -> `{ compacted }`, `inspect()` -> `{ manifest }` (write-key fields redacted), and `stats()` -> index-level counts and metadata.
 - `search(query, limit, returnStored?)` takes an optional third argument; omit it for the default (`false`) or pass `true` to fetch stored fields.
 - `search_request` accepts a JSON string; `search_request_value` takes a JS object. Both support the full `SearchRequest` surface with the same `return_stored` default of `false`.
-- Reusing a `db_name` reopens an existing index; schema mismatches return an error (there is no migration path; use a new `db_name` or delete the stored index).
+- Package target note: `wasm-pack build --target web` exposes a default init export; the default bundler target auto-initializes and only exposes named exports (for example `Searchlite`).
+- Controlled search variants accept cancellation and timeout controls:
+  - `search_controlled(query, limit, returnStored?, abortSignal?, timeoutMs?)`
+  - `search_request_controlled(json, abortSignal?, timeoutMs?)`
+  - `search_request_value_controlled(value, abortSignal?, timeoutMs?)`
+  - `search_request_value_async(value, abortSignal?, timeoutMs?)` (Promise-based worker-oriented entrypoint)
+- Lifecycle helpers are exposed as static methods: `Searchlite.list_indexes()`, `Searchlite.clear_index(name)`, and `Searchlite.drop_index(name)`.
+- Storage helpers: `Searchlite.storage_usage()` reports usage/quota when the browser exposes it; `Searchlite.cleanup_indexes(stale_older_than_ms, dry_run?)` removes stale persisted indexes by age.
+- Index cleanup helper: `db.cleanup_orphaned_files(dry_run?)` removes IndexedDB blobs not referenced by the active manifest.
+- `Searchlite.plan_migration(name, schemaJson)` reports `missing`, `compatible`, or `rebuild_required` without mutating state.
+- `Searchlite.migrate_index(name, schemaJson)` applies migration planning and returns `created`, `compatible`, or `rebuilt`; on rebuild failure it restores the previous snapshot before returning a typed error.
+- Reusing a `db_name` reopens an existing index; schema mismatches still return `schema_mismatch` if you call `init` directly.
+
+### WASM error shape
+
+WASM methods return structured errors instead of plain strings:
+
+```json
+{
+  "type": "invalid_search_request",
+  "reason": "..."
+}
+```
+
+Use `error.type` for programmatic handling and `error.reason` for logging/UI.
+
+`quota_exceeded` is returned when IndexedDB rejects writes due to storage limits; the reason includes recovery guidance (`compact`, stale-index cleanup, or clearing/dropping unused data).
+`aborted` is returned when an `AbortSignal` is already aborted (or becomes aborted at a control check).
+`timeout` is returned when `timeoutMs` is exceeded at a control check.
+
+### Worker-first demo notes
+
+- `searchlite-wasm/searchlite-worker-client.mjs` provides a worker-first search wrapper over `searchlite-wasm/searchlite-demo-worker.mjs`.
+- The client restarts workers after timeout/abort to stop in-flight operations.
+- Worker client options validate `timeoutMs` and `delayMs` as non-negative finite numbers and return typed `invalid_timeout` / `invalid_argument` errors when invalid.
+- With `indexeddb` storage this preserves state on restart; with `memory` storage it does not, so the demo falls back to main-thread execution.
 
 ### WASM threading
 

--- a/docs/feature-hardening/wasm-m1-foundation/matrix.md
+++ b/docs/feature-hardening/wasm-m1-foundation/matrix.md
@@ -1,0 +1,51 @@
+# Feature Hardening Matrix: wasm-m1-foundation
+
+- Branch: feat/wasm-m1-foundation
+- Last updated: 2026-04-13 20:57:16Z
+
+## Scope
+- [x] Intended behavior: M1 WASM production foundations (typed errors, lifecycle APIs, migration planning/execution with rollback, CI/release gates).
+- [x] Out-of-scope: M2+ parity APIs (`delete`, `patch`, `mget`, `multi_search`, maintenance ops) and storage/runtime hardening tasks.
+
+## Changed Files
+<!-- BEGIN_CHANGED_FILES -->
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-artifacts.yml`
+- `docs/bindings.md`
+- `docs/wasm.md`
+- `searchlite-wasm/index.html`
+- `searchlite-wasm/src/wasm.rs`
+<!-- END_CHANGED_FILES -->
+
+## Invariant Matrix
+| Area | Scenario | Expected Result | Test Type | Test Reference | Status |
+| --- | --- | --- | --- | --- | --- |
+| Lifecycle | `list_indexes`/`clear_index`/`drop_index` on IndexedDB-backed DBs | Registry and persisted files stay consistent after create/clear/drop/recreate | wasm-bindgen integration | `list_indexes_includes_initialized_db`, `clear_index_resets_contents`, `drop_index_removes_registry_entry` | done |
+| Migration planning | `plan_migration` for missing/compatible/schema-changed DBs | Returns stable status and schema hashes (`missing`/`compatible`/`rebuild_required`) | wasm-bindgen integration | `plan_migration_reports_compatibility_and_rebuild` | done |
+| Migration execution | `migrate_index` executes create/rebuild flow | Returns `created`/`compatible`/`rebuilt` and leaves DB usable | wasm-bindgen integration | `migrate_index_creates_missing_index`, `migrate_index_rebuilds_on_schema_change` | done |
+| Rollback safety | Injected failure after clear during rebuild | Prior snapshot and registry are restored; old schema remains usable | wasm-bindgen integration | `migrate_index_rolls_back_on_rebuild_failure` | done |
+| Release artifact | Packaged wasm bundle smoke import | Release workflow asserts expected files and JS exports | CI workflow step | `.github/workflows/release-artifacts.yml` `Smoke test wasm bundle` | done |
+| Error model | JS-visible failures are typed payloads | Errors include stable `type` and human-readable `reason` | integration/docs | `WasmErrorPayload`, docs in `docs/wasm.md` + `docs/bindings.md` | done |
+
+## Adversarial Cases
+- [x] Null, empty, and whitespace inputs (covered by existing request validation paths and typed errors).
+- [x] Dotted names and special characters (schema mismatch and invalid request errors remain typed).
+- [x] Cross-scope mismatches (migration failure-injection proves rollback to prior schema/storage state).
+- [ ] Missing fast field / unsupported type (tracked for M2 parity/contract matrix).
+
+## Verification Checklist
+- [x] `cargo fmt --all`
+- [ ] `cargo build --all --all-features` (blocked in this environment by missing OpenSSL dev metadata)
+- [ ] `cargo test --all --all-features` (blocked in this environment by missing OpenSSL dev metadata)
+- [ ] `cargo clippy --all --all-features --all-targets -- -D warnings` (blocked in this environment by missing OpenSSL dev metadata)
+- [x] `cargo check -p searchlite-wasm`
+- [x] `cargo check -p searchlite-wasm --all-targets --target wasm32-unknown-unknown`
+- [x] `cargo test -p searchlite-wasm`
+- [ ] `wasm-pack test --headless --chrome searchlite-wasm` (blocked: chromedriver unavailable for this host target)
+- [ ] `wasm-pack test --headless --firefox searchlite-wasm` (environment/runtime failures; existing nightly `std::time` unsupported panic path)
+- [ ] `cargo bench -p searchlite-core` when perf-sensitive (not perf-sensitive changes)
+
+## Review Summary
+- Key risks: Browser-runner coverage remains environment-sensitive locally; rely on CI for definitive browser execution results.
+- Tests added: migration execution (`create`, `rebuild`, rollback failure-injection) and existing lifecycle tests retained.
+- Follow-ups: Start M2 tasks (`WASM-007+`) after CI confirms M1 browser/release gates on supported runners.

--- a/docs/feature-hardening/wasm-m2-delete-apis/matrix.md
+++ b/docs/feature-hardening/wasm-m2-delete-apis/matrix.md
@@ -1,0 +1,49 @@
+# Feature Hardening Matrix: wasm-m2-delete-apis
+
+- Branch: feat/wasm-m1-foundation
+- Last updated: 2026-04-14 06:29:51Z
+
+## Scope
+- [x] Intended behavior: expose WASM delete APIs (`delete_document`, `delete_documents`) with typed validation errors and commit-gated durability semantics.
+- [x] Out-of-scope: M2 patch/mget/multi-search/maintenance parity tasks and M3/M4 storage/runtime features.
+
+## Changed Files
+<!-- BEGIN_CHANGED_FILES -->
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-artifacts.yml`
+- `docs/bindings.md`
+- `docs/wasm.md`
+- `searchlite-wasm/index.html`
+- `searchlite-wasm/src/wasm.rs`
+<!-- END_CHANGED_FILES -->
+
+## Invariant Matrix
+| Area | Scenario | Expected Result | Test Type | Test Reference | Status |
+| --- | --- | --- | --- | --- | --- |
+| Delete lifecycle | Add/commit/delete/commit/search (single id) | Deleted document disappears while untouched docs remain searchable | wasm-bindgen integration | `delete_document_roundtrip` | done |
+| Delete lifecycle | Add/commit/delete/commit/search (batch ids) | All requested docs are deleted in one commit; retained docs remain | wasm-bindgen integration | `delete_documents_roundtrip` | done |
+| Validation | Non-string values in `delete_documents` payload | Typed `invalid_doc_id_batch` error surfaced to JS | wasm-bindgen integration | `delete_documents_rejects_non_string_ids` | done |
+| Migration fingerprint | Schema hash stability across toolchain/runtime changes | Deterministic schema hash used for metadata/planning | code-level invariant | `schema_hash` uses deterministic FNV-1a | done |
+| Regression | Existing lifecycle/migration APIs remain unchanged | M1 APIs compile and preserve typed error contract | compile + docs | `cargo check` + docs updates | done |
+
+## Adversarial Cases
+- [x] Null/invalid delete payloads (non-string array members return typed errors).
+- [x] Cross-scope mismatches (schema mismatch guidance updated to include migration path).
+- [ ] Empty string doc IDs (currently forwarded to core writer semantics; follow-up for stricter validation if desired).
+- [ ] Missing fast field / unsupported type (tracked by M2 patch/mget parity tasks).
+
+## Verification Checklist
+- [x] `cargo fmt --all`
+- [ ] `cargo build --all --all-features` (blocked in this environment by missing OpenSSL dev metadata)
+- [ ] `cargo test --all --all-features` (blocked in this environment by missing OpenSSL dev metadata)
+- [ ] `cargo clippy --all --all-features --all-targets -- -D warnings` (blocked in this environment by missing OpenSSL dev metadata)
+- [x] `cargo clippy -p searchlite-wasm --all-targets -- -D warnings`
+- [x] `cargo check -p searchlite-wasm --all-targets --target wasm32-unknown-unknown`
+- [x] `cargo test -p searchlite-wasm`
+- [ ] Browser wasm-pack tests (environment runner limits still apply locally)
+- [ ] `cargo bench -p searchlite-core` when perf-sensitive (not perf-sensitive changes)
+
+## Review Summary
+- Key risks: browser-runtime validation remains CI-dependent in this local environment.
+- Tests added: delete single, delete batch, invalid delete payload regression tests.
+- Follow-ups: proceed to WASM-008 (patch/update parity), then WASM-009 (`mget`) and WASM-010 (`multi_search`).

--- a/docs/feature-hardening/wasm-m2-parity-core-ops/matrix.md
+++ b/docs/feature-hardening/wasm-m2-parity-core-ops/matrix.md
@@ -1,0 +1,51 @@
+# Feature Hardening Matrix: wasm-m2-parity-core-ops
+
+- Branch: feat/wasm-m1-foundation
+- Last updated: 2026-04-14 06:55:22Z
+
+## Scope
+- [x] Intended behavior: implement M2 API parity core ops in WASM (`delete`, `update/patch`, `mget`, `multi_search`, `compact/inspect/stats`) with typed JS errors and docs alignment.
+- [x] Out-of-scope: M3/M4 storage/runtime tasks (quota handling, worker-first execution, cancellation, fallback matrix).
+
+## Changed Files
+<!-- BEGIN_CHANGED_FILES -->
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-artifacts.yml`
+- `docs/bindings.md`
+- `docs/wasm.md`
+- `searchlite-wasm/index.html`
+- `searchlite-wasm/src/wasm.rs`
+<!-- END_CHANGED_FILES -->
+
+## Invariant Matrix
+| Area | Scenario | Expected Result | Test Type | Test Reference | Status |
+| --- | --- | --- | --- | --- | --- |
+| Delete API | Delete single and batch ids | Deleted docs disappear after commit; unaffected docs remain | wasm-bindgen integration | `delete_document_roundtrip`, `delete_documents_roundtrip` | done |
+| Update API | set/unset patch semantics | Updates apply after commit and follow core patch rules | wasm-bindgen integration | `update_document_set_and_unset_roundtrip` | done |
+| Update validation | Missing patch / invalid id / unknown field / missing doc | Typed JS errors are stable and descriptive | wasm-bindgen integration | `update_document_rejects_missing_patch`, `update_document_rejects_invalid_id`, `update_document_reports_not_found`, `update_document_rejects_unknown_field` | done |
+| MGET | Order + found/missing shape + return_stored behavior | Response order preserved, per-id `found` and optional `_source` correct | wasm-bindgen integration | `mget_returns_found_missing_and_preserves_order`, `mget_respects_return_stored_false`, `mget_rejects_invalid_ids` | done |
+| Multi-search | Ordered batched search results | `results[]` order matches input `searches[]` | wasm-bindgen integration | `multi_search_returns_ordered_results`, `multi_search_rejects_invalid_request` | done |
+| Maintenance | compact/inspect/stats payloads | Segment compaction works; inspect redacts sensitive metadata; stats stable | wasm-bindgen integration | `compact_stats_and_inspect_roundtrip` | done |
+| Migration hash stability | Schema hash fingerprint determinism | Hash remains deterministic for identical schemas, changes when schema changes | wasm-bindgen regression | `schema_hash_is_deterministic` | done |
+
+## Adversarial Cases
+- [x] Null/invalid payload shapes for delete/update/mget/multi-search return typed errors.
+- [x] Empty/whitespace ids rejected via `invalid_id`.
+- [x] Unknown update paths rejected and surfaced as typed `update_failed`.
+- [ ] Missing fast field / unsupported type edge cases (covered partially by core patch validation; extend with dedicated adversarial fixtures as needed).
+
+## Verification Checklist
+- [x] `cargo fmt --all`
+- [ ] `cargo build --all --all-features` (blocked in this environment by missing OpenSSL dev metadata)
+- [ ] `cargo test --all --all-features` (blocked in this environment by missing OpenSSL dev metadata)
+- [ ] `cargo clippy --all --all-features --all-targets -- -D warnings` (blocked in this environment by missing OpenSSL dev metadata)
+- [x] `cargo clippy -p searchlite-wasm --all-targets -- -D warnings`
+- [x] `cargo check -p searchlite-wasm --all-targets --target wasm32-unknown-unknown`
+- [x] `cargo test -p searchlite-wasm`
+- [ ] Browser wasm-pack tests (local runner limits still apply; validate in CI)
+- [ ] `cargo bench -p searchlite-core` when perf-sensitive (not perf-sensitive changes)
+
+## Review Summary
+- Key risks: local browser runner constraints still block full wasm-bindgen browser execution; CI is source of truth for browser-level runtime.
+- Tests added: API parity tests for delete/update/mget/multi-search/maintenance + schema hash determinism + core-vs-wasm parity fixture (`search`/`mget`/`multi_search`/`update`/`delete`).
+- Follow-ups: start M3 storage scale/quota tasks after CI validates browser-runner pass.

--- a/docs/feature-hardening/wasm-m3-storage-reliability/matrix.md
+++ b/docs/feature-hardening/wasm-m3-storage-reliability/matrix.md
@@ -1,0 +1,77 @@
+# Feature Hardening Matrix: wasm-m3-storage-reliability
+
+- Branch: feat/wasm-m1-foundation
+- Last updated: 2026-04-14 12:20:00Z
+
+## Scope
+- [x] Describe intended behavior.
+- [x] Describe out-of-scope behavior.
+Intended behavior:
+- IndexedDB snapshot bootstrap uses a single transaction with `get_all_keys` + `get_all` for browser-compatibility.
+- Persistence coalesces writes/deletes into batched transactions and `flush()` waits for both.
+- WASM exposes storage/quota inspection (`storage_usage`) and cleanup APIs for stale indexes/orphaned files.
+- Quota failures are surfaced as typed `quota_exceeded` errors with actionable recovery guidance.
+Out of scope:
+- Browser-specific quota limits and storage estimate fidelity across engines.
+- Full E2E browser perf benchmarks in this branch (covered by CI/runtime environment).
+
+## Changed Files
+<!-- BEGIN_CHANGED_FILES -->
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-artifacts.yml`
+- `docs/bindings.md`
+- `docs/wasm.md`
+- `searchlite-wasm/Cargo.toml`
+- `searchlite-wasm/index.html`
+- `searchlite-wasm/src/wasm.rs`
+<!-- END_CHANGED_FILES -->
+
+## Invariant Matrix
+| Area | Scenario | Expected Result | Test Type | Test Reference | Status |
+| --- | --- | --- | --- | --- | --- |
+| Storage bootstrap | Large persisted stores load via `get_all_keys` + `get_all` in one readonly transaction | Snapshot restore remains correct across browsers with paired key/value arrays | wasm_bindgen | `js_storage_persists_entries` | done |
+| Persistence batching | Multiple writes in one flush are batched | Transaction count is coalesced (`1` tx for 12 queued writes in test) | wasm_bindgen | `js_storage_flush_batches_indexeddb_transactions` | done |
+| Delete durability | Deletes are included in flush completion contract | Reopen after flush does not resurrect deleted files | wasm_bindgen | `js_storage_flush_waits_for_deletes` | done |
+| Quota handling | Persist path emits typed quota error | `commit()` returns `{ type: "quota_exceeded", reason: ... }` | wasm_bindgen | `commit_surfaces_quota_exceeded_error_type` | done |
+| Quota introspection | Browser storage estimate API is exposed safely | Returns supported usage/quota payload or explicit unsupported note | wasm_bindgen | `storage_usage_returns_supported_or_note` | done |
+| Stale index cleanup | Cleanup targets only stale registry entries | Stale db dropped; fresh db retained | wasm_bindgen | `cleanup_indexes_drops_only_stale_entries` | done |
+| Orphan cleanup | Cleanup preserves live manifest files | Orphan file removed; active searchable docs remain | wasm_bindgen | `cleanup_orphaned_files_removes_only_unknown_paths` | done |
+
+## Adversarial Cases
+- [x] Null, empty, and whitespace inputs.
+- [ ] Dotted names and special characters.
+- [x] Cross-scope mismatches.
+- [ ] Missing fast field / unsupported type.
+Covered:
+- Invalid cleanup request validation (`stale_older_than_ms < 0`) -> typed error.
+- Quota failure injection path validates explicit typed failure and guidance.
+- Orphan cleanup path validates no live-manifest file removal.
+
+## Verification Checklist
+- [x] `cargo fmt --all`
+- [ ] `cargo build --all --all-features`
+- [ ] `cargo test --all --all-features`
+- [ ] `cargo clippy --all --all-features --all-targets -- -D warnings`
+- [ ] `cargo bench -p searchlite-core` when perf-sensitive.
+Executed:
+- `cargo check -p searchlite-wasm --all-targets --target wasm32-unknown-unknown`
+- `cargo clippy -p searchlite-wasm --all-targets -- -D warnings`
+- `cargo clippy -p searchlite-wasm --all-targets --target wasm32-unknown-unknown -- -D warnings`
+- `cargo test -p searchlite-wasm` (host target; wasm-bindgen tests are browser-runner tests)
+- `wasm-pack test --headless --firefox --geckodriver /snap/bin/geckodriver searchlite-wasm` (45/45 passed locally)
+- `RUST_TEST_THREADS=1 wasm-pack test --headless --chrome --chromedriver /snap/bin/chromium.chromedriver searchlite-wasm` (45/45 passed locally)
+
+## Review Summary
+- Key risks:
+- Snapshot bootstrap currently materializes full key/value arrays (`get_all_keys` + `get_all`), so startup memory still scales with persisted index footprint.
+- Browser storage estimate API support varies by engine; API returns `supported: false` + `note` when unavailable.
+- Browser E2E validation still depends on CI runner/browser setup for wasm-bindgen tests.
+- Tests added:
+- `js_storage_flush_batches_indexeddb_transactions`
+- `js_storage_flush_waits_for_deletes`
+- `storage_usage_returns_supported_or_note`
+- `commit_surfaces_quota_exceeded_error_type`
+- `cleanup_indexes_drops_only_stale_entries`
+- `cleanup_orphaned_files_removes_only_unknown_paths`
+- Follow-ups:
+- Run browser wasm-bindgen test suite on CI or a host with chromedriver binaries available.

--- a/docs/feature-hardening/wasm-m4-worker-runtime/matrix.md
+++ b/docs/feature-hardening/wasm-m4-worker-runtime/matrix.md
@@ -1,0 +1,92 @@
+# Feature Hardening Matrix: wasm-m4-worker-runtime
+
+- Branch: feat/wasm-m1-foundation
+- Last updated: 2026-04-14 11:29:00Z
+
+## Scope
+- [x] Describe intended behavior.
+- [x] Describe out-of-scope behavior.
+Intended behavior:
+- Worker-first browser runtime path for search operations, with main-thread fallback.
+- Controlled search APIs with `AbortSignal` and `timeoutMs` across string/JSON/object entrypoints.
+- Promise-based worker-oriented search API (`search_request_value_async`).
+- Documented fallback strategy matrix (worker support, threads, service-worker constraints).
+Out of scope:
+- Preemptive mid-query cancellation inside core search loops.
+- Full all-feature workspace validation (OpenSSL env blocker).
+
+## Changed Files
+<!-- BEGIN_CHANGED_FILES -->
+- `.github/workflows/ci.yml`
+- `.github/workflows/release-artifacts.yml`
+- `docs/bindings.md`
+- `docs/wasm.md`
+- `searchlite-wasm/Cargo.toml`
+- `searchlite-wasm/index.html`
+- `searchlite-wasm/src/wasm.rs`
+<!-- END_CHANGED_FILES -->
+Additional new files in this milestone:
+- `searchlite-wasm/searchlite-worker-client.mjs`
+- `searchlite-wasm/searchlite-demo-worker.mjs`
+- `docs/feature-hardening/wasm-m4-worker-runtime/matrix.md`
+
+## Invariant Matrix
+| Area | Scenario | Expected Result | Test Type | Test Reference | Status |
+| --- | --- | --- | --- | --- | --- |
+| Controlled search | Pre-aborted signal | Returns typed `aborted` error payload | wasm_bindgen | `search_request_value_controlled_aborts_with_preaborted_signal` | done |
+| Controlled search | Timeout input validation | Negative timeout returns typed `invalid_timeout` | wasm_bindgen | `search_request_value_controlled_rejects_invalid_timeout` | done |
+| Controlled search | Timeout enforcement | Timeout `0` returns typed `timeout` | wasm_bindgen | `search_request_value_controlled_times_out` | done |
+| Async worker API | Promise-based search entrypoint | Async method returns successful search payload | wasm_bindgen | `search_request_value_async_roundtrip` | done |
+| Worker runtime | Main-thread responsiveness under worker load | Main-thread timer fires while worker search is delayed/in-flight | wasm_bindgen browser | `worker_search_request_keeps_main_thread_responsive` | done |
+| Worker runtime | Worker timeout typing | Delayed worker search with small timeout returns typed `timeout` | wasm_bindgen browser | `worker_search_request_timeout_returns_typed_error` | done |
+| Worker client | AbortSignal cancellation | In-flight worker-client search aborted via `AbortController` returns typed `aborted` | wasm_bindgen browser | `worker_client_search_request_abort_returns_typed_error` | done |
+| Worker client | Invalid timeout validation | Negative/non-finite `timeoutMs` rejected before dispatch with typed `invalid_timeout` | wasm_bindgen browser | `worker_client_search_request_rejects_invalid_timeout` | done |
+| Fallback path | Threads unavailable | `init_threads` returns typed `threads_feature_disabled` without `threads` feature | wasm_bindgen browser | `init_threads_without_feature_returns_typed_error` | done |
+| Demo runtime | Worker-first path with fallback | IndexedDB+worker uses worker action path; docs/UI define no-worker and memory fallbacks | tests + docs | `searchlite-wasm/index.html`, `docs/wasm.md`, `docs/bindings.md` | done |
+
+## Adversarial Cases
+- [x] Null, empty, and whitespace inputs.
+- [ ] Dotted names and special characters.
+- [x] Cross-scope mismatches.
+- [ ] Missing fast field / unsupported type.
+Covered:
+- Invalid `timeoutMs` values rejected with stable typed error.
+- Pre-aborted signals rejected before execution with stable typed error.
+- Worker delayed path is covered in browser worker tests without blocking the main thread.
+- Worker timeout behavior is covered through worker action timeout tests.
+- Worker unavailability / memory-mode constraints handled via documented and implemented fallback.
+
+## Verification Checklist
+- [x] `cargo fmt --all`
+- [ ] `cargo build --all --all-features`
+- [ ] `cargo test --all --all-features`
+- [ ] `cargo clippy --all --all-features --all-targets -- -D warnings`
+- [x] `cargo bench -p searchlite-core` when perf-sensitive.
+Executed:
+- `cargo check -p searchlite-wasm --all-targets`
+- `cargo check -p searchlite-wasm --all-targets --target wasm32-unknown-unknown`
+- `cargo clippy -p searchlite-wasm --all-targets --target wasm32-unknown-unknown -- -D warnings`
+- `cargo clippy -p searchlite-wasm --all-targets -- -D warnings`
+- `cargo test -p searchlite-wasm` (host target; wasm-bindgen tests are browser-runner tests)
+- `cargo bench -p searchlite-core` (completed)
+- `wasm-pack test --headless --firefox --geckodriver <local-geckodriver> searchlite-wasm` (45/45 tests passed locally)
+- `RUST_TEST_THREADS=1 wasm-pack test --headless --chrome --chromedriver /snap/bin/chromium.chromedriver searchlite-wasm` (45/45 tests passed locally)
+- `wasm-pack test --headless --chrome --chromedriver /snap/bin/chromium.chromedriver searchlite-wasm` (logic tests pass, but chromedriver can be SIGKILLed mid-run on this host without single-threading)
+- `cargo build --all --all-features` / `cargo test --all --all-features` / `cargo clippy --all --all-features --all-targets -- -D warnings` (blocked: missing `openssl.pc` for `openssl-sys`)
+
+## Review Summary
+- Key risks:
+- Worker restart on abort/timeout preserves IndexedDB-backed state but resets memory-only mode state.
+- Cancellation is cooperative at API boundaries, not preemptive inside core search loops.
+- Tests added:
+- `search_request_value_controlled_rejects_invalid_timeout`
+- `search_request_value_controlled_aborts_with_preaborted_signal`
+- `search_request_value_controlled_times_out`
+- `search_request_value_async_roundtrip`
+- `worker_search_request_keeps_main_thread_responsive`
+- `worker_search_request_timeout_returns_typed_error`
+- `worker_client_search_request_abort_returns_typed_error`
+- `worker_client_search_request_rejects_invalid_timeout`
+- `init_threads_without_feature_returns_typed_error`
+- Follow-ups:
+- Evaluate preemptive cancellation hooks in core search loops if strict mid-query cancellation is required.

--- a/docs/roadmaps/WASM-PRODUCTION-TASK-BOARD.md
+++ b/docs/roadmaps/WASM-PRODUCTION-TASK-BOARD.md
@@ -49,7 +49,7 @@ Each task is only complete when all are true:
 | WASM-010 | M2 | Add `multi_search` API to WASM bindings | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Batched requests return ordered result list with per-request output | `Done` |
 | WASM-011 | M2 | Add maintenance APIs: `compact`, `inspect`, `stats` | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md`, `docs/bindings.md` | Maintenance ops produce stable payloads and pass regression tests | `Done` |
 | WASM-012 | M2 | Add parity contract tests (core vs wasm normalized responses) | `searchlite-wasm/src/wasm.rs` (or dedicated test module), `integration/` if expanded | Shared fixture set compares behavior for search/mget/multi-search/update/delete | `Done` |
-| WASM-013 | M3 | Replace full-snapshot load with incremental/chunked load path | `searchlite-wasm/src/wasm.rs` | Large-index startup memory profile is bounded and documented | `Done` |
+| WASM-013 | M3 | Replace full-snapshot load with incremental/chunked load path | `searchlite-wasm/src/wasm.rs` | `load_snapshot` no longer relies on `get_all_keys()` + `get_all()`, and startup memory is bounded and documented | `In Progress` |
 | WASM-014 | M3 | Batch IndexedDB persistence writes and reduce per-file transaction overhead | `searchlite-wasm/src/wasm.rs` | Ingest benchmark shows fewer IDB transactions and lower commit latency | `Done` |
 | WASM-015 | M3 | Add storage usage/quota introspection API | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Browser reports usage/remaining capacity when supported | `Done` |
 | WASM-016 | M3 | Add typed quota exceeded handling and recovery guidance | `searchlite-wasm/src/wasm.rs`, `docs/bindings.md`, `docs/wasm.md` | Quota exhaustion test asserts explicit quota error type and recovery path | `Done` |

--- a/docs/roadmaps/WASM-PRODUCTION-TASK-BOARD.md
+++ b/docs/roadmaps/WASM-PRODUCTION-TASK-BOARD.md
@@ -1,0 +1,109 @@
+# Browser/WASM Production Task Board
+
+Updated: 2026-04-14  
+Owner: Searchlite maintainers  
+Scope: `searchlite-wasm` browser surface and release gates
+
+## Goal
+
+Ship a browser surface that is safe for consumer use by closing the five readiness gaps:
+
+1. Lifecycle and migration support
+2. WASM API parity with core/HTTP operations
+3. Non-blocking browser execution model
+4. Storage scale and quota safety
+5. Browser-specific CI and release verification
+
+## Global "Feature Complete" Contract
+
+Each task is only complete when all are true:
+
+- API behavior documented in `docs/wasm.md` and `docs/bindings.md`
+- Automated tests added or updated
+- CI gate exists and is required
+- Failure mode is explicit and typed
+- Regression coverage exists for discovered edge cases
+
+## Milestones
+
+| Milestone | Target | Exit gate |
+| --- | --- | --- |
+| M1 | CI skeleton + lifecycle foundations | Browser CI job required; lifecycle APIs merged |
+| M2 | API parity | Parity matrix green for supported operations |
+| M3 | Storage reliability at scale | Large-index and quota tests green |
+| M4 | UX/runtime hardening | Non-blocking worker path + cancellation verified |
+
+## Task Board
+
+| ID | Milestone | Task | Primary file targets | Validation | Status |
+| --- | --- | --- | --- | --- | --- |
+| WASM-001 | M1 | Add browser CI workflow job (wasm build + browser test runner) | `.github/workflows/ci.yml`, `searchlite-wasm/Cargo.toml` | CI job runs on PR and blocks merge on failure | `Done` |
+| WASM-002 | M1 | Add release smoke test for packaged wasm artifact | `.github/workflows/release-artifacts.yml` | Release workflow validates wasm package exports and can initialize/add/commit in memory mode | `Done` |
+| WASM-003 | M1 | Define typed WASM error model and error code mapping | `searchlite-wasm/src/wasm.rs`, `docs/bindings.md` | JS-visible errors include stable `type` and clear `reason` fields | `Done` |
+| WASM-004 | M1 | Add index lifecycle APIs: `list_indexes`, `drop_index`, `clear_index` | `searchlite-wasm/src/wasm.rs`, `searchlite-wasm/Cargo.toml`, `docs/wasm.md` | wasm-bindgen tests validate create/list/drop/clear correctness | `Done` |
+| WASM-005 | M1 | Add schema version metadata and migration planner surface | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md`, `docs/bindings.md` | Reopen path reports migrate-needed state instead of opaque mismatch | `Done` |
+| WASM-006 | M1 | Add migration rollback safety for partial/failed upgrades | `searchlite-wasm/src/wasm.rs` | Failure-injection test proves no unusable half-migrated index remains | `Done` |
+| WASM-007 | M2 | Add delete APIs (`delete_document`, `delete_documents`) to WASM | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Add/commit/delete/commit/search roundtrip tests pass | `Done` |
+| WASM-008 | M2 | Add update/patch API parity for stored fields | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Patch semantics match core for set/unset and validation errors | `Done` |
+| WASM-009 | M2 | Add `mget` API to WASM bindings | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Found/missing response shape matches core expectations | `Done` |
+| WASM-010 | M2 | Add `multi_search` API to WASM bindings | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Batched requests return ordered result list with per-request output | `Done` |
+| WASM-011 | M2 | Add maintenance APIs: `compact`, `inspect`, `stats` | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md`, `docs/bindings.md` | Maintenance ops produce stable payloads and pass regression tests | `Done` |
+| WASM-012 | M2 | Add parity contract tests (core vs wasm normalized responses) | `searchlite-wasm/src/wasm.rs` (or dedicated test module), `integration/` if expanded | Shared fixture set compares behavior for search/mget/multi-search/update/delete | `Done` |
+| WASM-013 | M3 | Replace full-snapshot load with incremental/chunked load path | `searchlite-wasm/src/wasm.rs` | Large-index startup memory profile is bounded and documented | `Done` |
+| WASM-014 | M3 | Batch IndexedDB persistence writes and reduce per-file transaction overhead | `searchlite-wasm/src/wasm.rs` | Ingest benchmark shows fewer IDB transactions and lower commit latency | `Done` |
+| WASM-015 | M3 | Add storage usage/quota introspection API | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Browser reports usage/remaining capacity when supported | `Done` |
+| WASM-016 | M3 | Add typed quota exceeded handling and recovery guidance | `searchlite-wasm/src/wasm.rs`, `docs/bindings.md`, `docs/wasm.md` | Quota exhaustion test asserts explicit quota error type and recovery path | `Done` |
+| WASM-017 | M3 | Add cleanup policies for stale indexes and orphaned files | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md` | Cleanup command removes only targeted data and preserves active indexes | `Done` |
+| WASM-018 | M4 | Add worker-first async execution API | `searchlite-wasm/src/wasm.rs`, `searchlite-wasm/index.html`, new worker example files | Long-running search does not block main thread in browser worker tests | `Done` |
+| WASM-019 | M4 | Add cancellation (`AbortSignal`) and timeout semantics | `searchlite-wasm/src/wasm.rs`, `docs/wasm.md`, `docs/bindings.md` | Cancellation tests confirm operation stops and returns typed abort/timeout errors | `Done` |
+| WASM-020 | M4 | Add fallback strategy matrix for threads/no-threads/service-worker constraints | `docs/wasm.md`, `docs/bindings.md`, `searchlite-wasm/index.html` | Docs and example app behave correctly with and without `threads` feature | `Done` |
+| WASM-021 | M4 | Final browser readiness checklist and sign-off report | `docs/roadmaps/WASM-PRODUCTION-TASK-BOARD.md` | All tasks closed and sign-off checklist marked complete | `In Progress` |
+
+## Acceptance Checklist by Gap
+
+| Gap | Required tasks | Complete when |
+| --- | --- | --- |
+| Lifecycle + migration | WASM-004, WASM-005, WASM-006 | Existing users can upgrade without manual db-name rotation |
+| API parity | WASM-007, WASM-008, WASM-009, WASM-010, WASM-011, WASM-012 | Browser can perform same critical lifecycle/query ops as core/HTTP |
+| Non-blocking runtime | WASM-018, WASM-019, WASM-020 | UI remains responsive under realistic workloads |
+| Storage scale + quota | WASM-013, WASM-014, WASM-015, WASM-016, WASM-017 | Large data sets and quota limits are handled predictably |
+| CI + release gates | WASM-001, WASM-002 | Browser regressions and broken artifacts are caught pre-release |
+
+## Test Matrix (must exist before closing M4)
+
+| Test ID | Scenario | Surface | Pass condition |
+| --- | --- | --- | --- |
+| T-WASM-01 | Reopen existing index with same schema | wasm | Documents remain searchable across reload |
+| T-WASM-02 | Reopen with schema upgrade path | wasm | Migration succeeds and preserves searchable docs |
+| T-WASM-03 | Forced migration failure | wasm | Rollback leaves prior version usable |
+| T-WASM-04 | Delete + patch + mget lifecycle | wasm | Responses match expected shape and values |
+| T-WASM-05 | Multi-search contract | wasm | Result ordering and counts match request order |
+| T-WASM-06 | Compact + inspect + stats | wasm | Maintenance APIs return consistent metadata |
+| T-WASM-07 | Large ingest + commit | wasm | No unbounded memory growth on startup/commit |
+| T-WASM-08 | Quota exceeded write path | wasm | Typed quota error surfaced; no silent corruption |
+| T-WASM-09 | Main-thread responsiveness under load | wasm_bindgen browser | Main-thread timer remains responsive during delayed worker search (`worker_search_request_keeps_main_thread_responsive`) |
+| T-WASM-10 | Cancel in-flight search | wasm_bindgen browser | Worker-client search aborted by `AbortController` returns typed `aborted` (`worker_client_search_request_abort_returns_typed_error`) |
+| T-WASM-11 | Threads enabled path | browser E2E | Threaded init/search succeeds under COOP/COEP |
+| T-WASM-12 | Threads unavailable fallback | wasm_bindgen browser + docs | `init_threads` returns `threads_feature_disabled`; fallback behavior documented |
+
+## Definition of Done (M4 Sign-off)
+
+- [ ] All `WASM-00x` tasks are `Done`
+- [ ] All `T-WASM-xx` tests are automated and green in CI
+- [x] `docs/wasm.md` and `docs/bindings.md` fully match actual behavior
+- [x] Release workflow verifies packaged wasm artifact
+- [ ] No remaining "experimental caveat" without an explicit mitigation or documented limit
+
+## M4 Sign-off Status (WASM-021)
+
+- M4 implementation tasks (`WASM-018`..`WASM-020`) are complete.
+- Browser worker-path tests were added for responsiveness, timeout typing, and AbortSignal cancellation.
+- Browser wasm-bindgen suite is green locally in Firefox (`wasm-pack test --headless --firefox ... searchlite-wasm`: 45/45).
+- Request-value entrypoints now tolerate both direct JS object payloads and JSON-shaped map payloads used in wasm-bindgen Rust tests.
+- Chrome browser tests are green locally when explicitly using the installed Chromium driver and single-threaded Rust harness:
+  - `RUST_TEST_THREADS=1 wasm-pack test --headless --chrome --chromedriver /snap/bin/chromium.chromedriver searchlite-wasm` (45/45)
+- Release smoke validation now checks the actual wasm-pack bundler export surface (named `Searchlite` export, no assumed default init export) and confirms init/add/commit in Node.
+- IndexedDB batch writes/cursor scans were hardened for Chrome transaction lifecycle semantics (no per-request await in write batches; snapshot/path scans use `get_all_keys`/`get_all`).
+- Local validation blockers remain:
+  - Workspace-wide `cargo build/test/clippy --all --all-features` fails on this host due missing `openssl.pc` for `openssl-sys`.
+- `WASM-021` can be closed after CI confirms browser tests and all-feature gates in a fully provisioned environment.

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -101,19 +101,124 @@ npx http-server -c-1 --cors -p 8080 \
   -H "Cross-Origin-Embedder-Policy: require-corp"
 ```
 
+## Browser test commands
+
+```bash
+# Firefox (local)
+wasm-pack test --headless --firefox --geckodriver /path/to/geckodriver searchlite-wasm
+
+# Chrome (CI/default environments)
+wasm-pack test --headless --chrome searchlite-wasm
+
+# Chrome (local Snap Chromium, avoids chromedriver SIGKILL flakes)
+RUST_TEST_THREADS=1 wasm-pack test --headless --chrome \
+  --chromedriver /snap/bin/chromium.chromedriver searchlite-wasm
+```
+
 ---
 
 ## API notes
 
 - `Searchlite.init(name, schema, storage)` reopens existing indexes with the same name.
   Schema mismatches return an error.
+- `Searchlite.list_indexes()` lists IndexedDB-backed indexes previously initialised by
+  the WASM binding.
+- `Searchlite.clear_index(name)` removes all persisted files for an index while keeping
+  the IndexedDB database container.
+- `Searchlite.drop_index(name)` deletes the persisted IndexedDB database for that index.
+- `Searchlite.storage_usage()` returns browser storage usage/quota estimates when supported:
+  `{ supported, usage_bytes, quota_bytes, remaining_bytes, persisted, note? }`.
+- `Searchlite.cleanup_indexes(stale_older_than_ms, dry_run?)` removes stale IndexedDB-backed
+  indexes based on registry age and returns `{ scanned, matched, dropped, kept, dry_run }`.
+- `Searchlite.plan_migration(name, schema)` returns a compatibility plan with
+  `status: "missing" | "compatible" | "rebuild_required"` and schema hashes.
+- `Searchlite.migrate_index(name, schema)` executes the migration plan and returns
+  `status: "created" | "compatible" | "rebuilt"`. It rebuilds incompatible schemas
+  with rollback to the previous snapshot if rebuild fails.
 - Prefer `add_documents([...])` for bulk ingest over adding one at a time.
+- `delete_document(id)` and `delete_documents(ids)` queue deletes by `_id`/doc id.
+  Deletions are applied on `commit()`.
+- `update_document({ id, set?, unset? })` queues a partial update using patch semantics.
+  `set` is a field-value map and `unset` is a list of field paths to remove; apply with `commit()`.
+- `mget({ ids, return_stored? })` fetches documents by id in request order and returns
+  `found` plus optional `_source` per id.
+- `multi_search({ searches, parallel?, max_concurrency? })` executes multiple search
+  requests and returns ordered per-request results.
+- Controlled search APIs:
+  - `search_controlled(query, limit, returnStored?, abortSignal?, timeoutMs?)`
+  - `search_request_controlled(json, abortSignal?, timeoutMs?)`
+  - `search_request_value_controlled(value, abortSignal?, timeoutMs?)`
+  These return typed `aborted` / `timeout` errors when cancellation or timeout checks trigger.
+- `search_request_value_async(value, abortSignal?, timeoutMs?)` is an async worker-oriented
+  entrypoint for Promise-based execution.
+- Package target note: `wasm-pack build --target web` exports a default init function, while
+  the default bundler target auto-initializes and exposes only named exports (for example `Searchlite`).
+- `compact()` merges segments and returns `{ compacted }`.
+- `inspect()` returns `{ manifest }` with write-key metadata redacted.
+- `stats()` returns document, deletion, and segment counts plus index metadata.
+- `cleanup_orphaned_files(dry_run?)` removes IndexedDB file blobs that are not referenced by
+  the active manifest (`MANIFEST`, `wal.log`, metadata, and live segment files are preserved).
 - Call `commit()` after adding documents to make them searchable.
 - Searches default to `return_stored: false`. Pass `true` as the third argument to
   `search()` to include stored field values.
 - Use `search_request_value` / `search_request` for advanced queries (filters,
   aggregations, highlighting).
 - See [bindings.md](bindings.md) for a reference of binding behaviors.
+
+All WASM errors are returned as structured payloads:
+
+```json
+{
+  "type": "quota_exceeded",
+  "reason": "indexeddb quota exceeded while committing index data; run compact(), remove stale indexes with Searchlite.cleanup_indexes(...), or clear/drop unused indexes before retrying. detail: ..."
+}
+```
+
+---
+
+## Worker-first runtime
+
+The demo app now defaults to worker-first execution for search to keep the main UI thread responsive:
+
+- Worker entrypoint: `searchlite-wasm/searchlite-demo-worker.mjs`
+- Worker client wrapper: `searchlite-wasm/searchlite-worker-client.mjs`
+- Demo UI integration: `searchlite-wasm/index.html`
+
+The worker client restarts the worker after timeout/abort to stop in-flight work. For
+IndexedDB mode this is transparent (state is reopened from persistence). For memory mode,
+worker restarts lose state, so the demo falls back to main-thread execution.
+The worker client validates `timeoutMs`/`delayMs` as non-negative finite numbers and surfaces
+typed `invalid_timeout`/`invalid_argument` errors for invalid values.
+
+### Runtime fallback matrix
+
+| Runtime | Worker mode | Threads | Recommended path |
+| --- | --- | --- | --- |
+| Browser + module workers + IndexedDB | yes | optional | Worker client + `search_request_value_async` / controlled APIs |
+| Browser + no module worker support | no | optional | Main-thread `search_request_controlled` |
+| Browser + memory storage | limited | optional | Main-thread controlled APIs (worker restart would lose memory state) |
+| Service worker / classic worker only | no (module worker client not available) | no | Main-thread controlled APIs or custom classic-worker glue |
+
+### Cancellation and timeout example
+
+```javascript
+const controller = new AbortController();
+const timeoutMs = 250;
+
+setTimeout(() => controller.abort(), 100);
+
+try {
+  const result = db.search_request_value_controlled(
+    { query: "rust", limit: 20, return_stored: true },
+    controller.signal,
+    timeoutMs
+  );
+  console.log(result);
+} catch (err) {
+  // err.type is "aborted" or "timeout"
+  console.error(err.type, err.reason);
+}
+```
 
 ---
 

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -52,6 +52,7 @@ memmap2 = { workspace = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"] }
 getrandom = { version = "0.2", features = ["js"] }
+js-sys = "0.3.69"
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -55,12 +55,19 @@ pub(crate) const MAX_CURSOR_ADVANCE: usize = 50_000;
 const MAX_PAGE_SIZE: usize = 1_000;
 const MAX_MGET_IDS: usize = 1_024;
 
+/// Returns a timing baseline in milliseconds for profiling.
+///
+/// On native targets this uses `std::time::Instant` (truly monotonic).
+/// On wasm32 this falls back to `js_sys::Date::now()` which is wall-clock
+/// time and can jump on clock adjustments. The `elapsed_ms_since` helper
+/// clamps negative deltas to zero as a safety net.
 #[cfg(not(target_arch = "wasm32"))]
 fn monotonic_now_ms() -> f64 {
   static START: OnceLock<Instant> = OnceLock::new();
   START.get_or_init(Instant::now).elapsed().as_secs_f64() * 1000.0
 }
 
+/// See `monotonic_now_ms` doc on the native variant for caveats.
 #[cfg(target_arch = "wasm32")]
 fn monotonic_now_ms() -> f64 {
   js_sys::Date::now()

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -3,6 +3,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, BinaryHeap};
 use std::sync::Arc;
 use std::sync::OnceLock;
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 use anyhow::{bail, Context, Result};
@@ -53,6 +54,26 @@ use super::phrase::{
 pub(crate) const MAX_CURSOR_ADVANCE: usize = 50_000;
 const MAX_PAGE_SIZE: usize = 1_000;
 const MAX_MGET_IDS: usize = 1_024;
+
+#[cfg(not(target_arch = "wasm32"))]
+fn monotonic_now_ms() -> f64 {
+  static START: OnceLock<Instant> = OnceLock::new();
+  START.get_or_init(Instant::now).elapsed().as_secs_f64() * 1000.0
+}
+
+#[cfg(target_arch = "wasm32")]
+fn monotonic_now_ms() -> f64 {
+  js_sys::Date::now()
+}
+
+fn elapsed_ms_since(start_ms: f64) -> f64 {
+  let elapsed = monotonic_now_ms() - start_ms;
+  if elapsed.is_sign_negative() {
+    0.0
+  } else {
+    elapsed
+  }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Hit {
@@ -1178,7 +1199,7 @@ impl IndexReader {
     let mut total_matches: u64 = 0;
     let mut skipped_by_cursor: u64 = 0;
     let mut saw_cursor = cursor_state.is_none() || !req.return_hits;
-    let search_start = Instant::now();
+    let search_start_ms = req.profile.then(monotonic_now_ms);
     let mut timings: BTreeMap<String, f64> = BTreeMap::new();
     let mut search_stats = QueryStats::default();
     validate_aggregations(&self.manifest.schema, &req.aggs)?;
@@ -1324,15 +1345,15 @@ impl IndexReader {
     if req.return_hits {
       hits.sort_by(|a, b| a.key.cmp(&b.key));
     }
-    let search_phase_end = if req.profile {
-      Some(Instant::now())
+    let search_phase_end_ms = if req.profile {
+      Some(monotonic_now_ms())
     } else {
       None
     };
     let mut rescore_stats = QueryStats::default();
     if req.return_hits {
       if let Some(rescore_req) = req.rescore.as_ref() {
-        let rescore_start = Instant::now();
+        let rescore_start_ms = monotonic_now_ms();
         self.rescore_hits(
           &mut hits,
           rescore_req,
@@ -1342,10 +1363,7 @@ impl IndexReader {
           &mut rescore_stats,
         )?;
         if req.profile {
-          timings.insert(
-            "rescore_ms".to_string(),
-            rescore_start.elapsed().as_secs_f64() * 1000.0,
-          );
+          timings.insert("rescore_ms".to_string(), elapsed_ms_since(rescore_start_ms));
         }
       }
       if req.explain {
@@ -1363,12 +1381,9 @@ impl IndexReader {
         }
       }
     }
-    if req.profile {
-      let end = search_phase_end.unwrap_or_else(Instant::now);
-      timings.insert(
-        "search_ms".to_string(),
-        end.duration_since(search_start).as_secs_f64() * 1000.0,
-      );
+    if let Some(start_ms) = search_start_ms {
+      let end_ms = search_phase_end_ms.unwrap_or_else(monotonic_now_ms);
+      timings.insert("search_ms".to_string(), (end_ms - start_ms).max(0.0));
     }
     let search_after_mode = req.search_after.is_some() && req.cursor.is_none();
     let total_hits_value = total_matches

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -38,8 +38,17 @@ web-sys = { version = "0.3.69", features = [
   "IdbTransaction",
   "IdbTransactionMode",
   "IdbObjectStore",
+  "IdbCursor",
+  "IdbCursorWithValue",
   "IdbRequest",
   "DomException",
+  "StorageManager",
+  "AbortSignal",
+  "AbortController",
+  "Worker",
+  "WorkerOptions",
+  "WorkerType",
+  "MessageEvent",
   "Event",
 ] }
 

--- a/searchlite-wasm/index.html
+++ b/searchlite-wasm/index.html
@@ -276,6 +276,13 @@
                 <option value="memory">Memory (session)</option>
               </select>
             </label>
+            <label class="select-label" for="execution-mode">
+              Execution
+              <select id="execution-mode" class="select">
+                <option value="worker" selected>Worker (recommended)</option>
+                <option value="main">Main thread fallback</option>
+              </select>
+            </label>
             <span class="hint"
               >Defaults to a single text field named "body".</span
             >
@@ -329,7 +336,21 @@
             </div>
           </div>
           <div class="actions">
-            <button id="search-btn" type="button">Run search</button>
+            <div class="load-block">
+              <label class="select-label" for="search-timeout-ms">
+                Timeout (ms)
+                <input
+                  id="search-timeout-ms"
+                  class="select"
+                  type="number"
+                  min="0"
+                  step="1"
+                  placeholder="none"
+                />
+              </label>
+              <button id="search-btn" type="button">Run search</button>
+              <button id="cancel-search-btn" type="button">Cancel search</button>
+            </div>
             <div id="status" class="status">Initializing…</div>
           </div>
         </section>
@@ -360,6 +381,10 @@
     ></script>
     <script type="module">
       import init, { Searchlite } from "./pkg/searchlite_wasm.js";
+      import {
+        SearchliteWorkerClient,
+        supportsModuleWorkers,
+      } from "./searchlite-worker-client.mjs";
 
       const defaultRequest = {
         query: {
@@ -382,6 +407,7 @@
       const loadBtn = document.getElementById("load-btn");
       const resetBtn = document.getElementById("reset-btn");
       const searchBtn = document.getElementById("search-btn");
+      const cancelSearchBtn = document.getElementById("cancel-search-btn");
       const applySchemaBtn = document.getElementById("apply-schema-btn");
       const pageResetBtn = document.getElementById("page-reset-btn");
       const statusEl = document.getElementById("status");
@@ -389,12 +415,16 @@
       const indexNameEl = document.getElementById("index-name");
       const schemaNameEl = document.getElementById("schema-name");
       const storageModeEl = document.getElementById("storage-mode");
+      const executionModeEl = document.getElementById("execution-mode");
+      const searchTimeoutEl = document.getElementById("search-timeout-ms");
 
       let idx = null;
       let docCount = 0;
       let currentDb = "";
       let currentSchema = null;
       let busy = false;
+      let workerClient = null;
+      let activeSearchController = null;
       schemaNameEl.dataset.label = "none";
       requestInput.value = JSON.stringify(defaultRequest, null, 2);
 
@@ -417,9 +447,12 @@
         loadBtn.disabled = busy || !currentSchema;
         resetBtn.disabled = busy || !currentSchema;
         searchBtn.disabled = busy || !currentSchema;
+        cancelSearchBtn.disabled = !busy || !activeSearchController;
         applySchemaBtn.disabled = busy;
         pageResetBtn.disabled = busy;
         storageModeEl.disabled = busy;
+        executionModeEl.disabled = busy;
+        searchTimeoutEl.disabled = busy && !activeSearchController;
       }
 
       function toggleBusy(state) {
@@ -460,6 +493,29 @@
         }
       }
 
+      function formatError(err) {
+        if (!err) return "unknown error";
+        if (typeof err === "string") return err;
+        if (typeof err.reason === "string") {
+          const type = typeof err.type === "string" ? err.type : "wasm_error";
+          return `${type}: ${err.reason}`;
+        }
+        if (typeof err.message === "string") return err.message;
+        return String(err);
+      }
+
+      function parseTimeoutMs() {
+        const raw = (searchTimeoutEl.value || "").trim();
+        if (!raw) {
+          return null;
+        }
+        const ms = Number(raw);
+        if (!Number.isFinite(ms) || ms < 0) {
+          throw new Error("Timeout must be a non-negative number.");
+        }
+        return ms;
+      }
+
       function parseDocuments(raw) {
         try {
           const parsed = JSON.parse(raw);
@@ -494,6 +550,40 @@
         return docs;
       }
 
+      async function disposeWorkerClient() {
+        if (!workerClient) {
+          return;
+        }
+        try {
+          await workerClient.dispose();
+        } catch (err) {
+          console.warn("Failed to dispose worker client", err);
+        }
+        workerClient = null;
+      }
+
+      function canUseWorkerSearch() {
+        if (executionModeEl.value !== "worker") {
+          return false;
+        }
+        if (!supportsModuleWorkers()) {
+          return false;
+        }
+        if ((storageModeEl?.value || "indexeddb") !== "indexeddb") {
+          return false;
+        }
+        return true;
+      }
+
+      async function ensureWorkerClient() {
+        if (!workerClient) {
+          workerClient = new SearchliteWorkerClient(
+            new URL("./searchlite-demo-worker.mjs", import.meta.url)
+          );
+        }
+        return workerClient;
+      }
+
       async function ensureIndex(reset = false) {
         if (!currentSchema) {
           throw new Error("Upload a schema first.");
@@ -514,6 +604,7 @@
           JSON.stringify(currentSchema),
           storageMode
         );
+        await disposeWorkerClient();
         docCount = 0;
         updateIndexInfo();
         setStatus("Index ready");
@@ -541,7 +632,7 @@
           setStatus(`Loaded ${docs.length} documents from ${file.name}.`);
         } catch (err) {
           console.error(err);
-          setStatus(`Load failed: ${err.message || err}`, true);
+          setStatus(`Load failed: ${formatError(err)}`, true);
         } finally {
           toggleBusy(false);
         }
@@ -567,7 +658,7 @@
           renderResponse(`Schema "${file.name}" applied. Index reset.`);
         } catch (err) {
           console.error(err);
-          setStatus(`Schema load failed: ${err.message || err}`, true);
+          setStatus(`Schema load failed: ${formatError(err)}`, true);
         } finally {
           toggleBusy(false);
         }
@@ -583,21 +674,25 @@
               console.warn("Failed to free index on reset", err);
             }
           }
+          await disposeWorkerClient();
           idx = null;
           currentSchema = null;
           currentDb = "";
           docCount = 0;
+          activeSearchController = null;
           schemaNameEl.dataset.label = "none";
           requestInput.value = JSON.stringify(defaultRequest, null, 2);
           datasetInput.value = "";
           schemaInput.value = "";
           storageModeEl.value = "indexeddb";
+          executionModeEl.value = "worker";
+          searchTimeoutEl.value = "";
           renderResponse(defaultResponse);
           setStatus("Page reset. Upload a schema to start.");
           updateIndexInfo();
         } catch (err) {
           console.error(err);
-          setStatus(`Page reset failed: ${err.message || err}`, true);
+          setStatus(`Page reset failed: ${formatError(err)}`, true);
         } finally {
           syncDisabled();
           toggleBusy(false);
@@ -606,20 +701,49 @@
 
       async function runSearch() {
         toggleBusy(true);
+        activeSearchController = new AbortController();
+        syncDisabled();
         try {
           await ensureIndex();
           const requestJson = requestInput.value;
+          const timeoutMs = parseTimeoutMs();
           setStatus("Searching…");
-          const result = idx.search_request(requestJson);
-          console.log(result);
+          let result = null;
+          if (canUseWorkerSearch()) {
+            const client = await ensureWorkerClient();
+            await client.initIndex(
+              currentDb,
+              JSON.stringify(currentSchema),
+              storageModeEl?.value || "indexeddb"
+            );
+            const requestObject = JSON.parse(requestJson);
+            result = await client.searchRequest(requestObject, {
+              signal: activeSearchController.signal,
+              timeoutMs,
+            });
+          } else {
+            if (executionModeEl.value === "worker") {
+              setStatus(
+                "Worker mode unavailable for this configuration; using main-thread fallback.",
+                false
+              );
+            }
+            result = idx.search_request_controlled(
+              requestJson,
+              activeSearchController.signal,
+              timeoutMs
+            );
+          }
           renderResponse(result);
           setStatus("Search complete.");
         } catch (err) {
           console.error(err);
-          const message = err?.message ?? String(err);
+          const message = formatError(err);
           renderResponse(message);
           setStatus(`Search failed: ${message}`, true);
         } finally {
+          activeSearchController = null;
+          syncDisabled();
           toggleBusy(false);
         }
       }
@@ -640,10 +764,24 @@
           setStatus("Index reset. Load data to continue.");
         } catch (err) {
           console.error(err);
-          setStatus(`Reset failed: ${err.message || err}`, true);
+          setStatus(`Reset failed: ${formatError(err)}`, true);
         } finally {
           toggleBusy(false);
         }
+      });
+
+      cancelSearchBtn.addEventListener("click", () => {
+        if (activeSearchController) {
+          activeSearchController.abort();
+        }
+      });
+
+      storageModeEl.addEventListener("change", async () => {
+        await disposeWorkerClient();
+      });
+
+      executionModeEl.addEventListener("change", async () => {
+        await disposeWorkerClient();
       });
 
       pageResetBtn.addEventListener("click", () => {
@@ -663,7 +801,7 @@
           syncDisabled();
         } catch (err) {
           console.error(err);
-          setStatus(`Init failed: ${err.message || err}`, true);
+          setStatus(`Init failed: ${formatError(err)}`, true);
         }
       })();
     </script>

--- a/searchlite-wasm/searchlite-demo-worker.mjs
+++ b/searchlite-wasm/searchlite-demo-worker.mjs
@@ -1,0 +1,126 @@
+import initWasm, { Searchlite } from "./pkg/searchlite_wasm.js";
+
+let wasmReady = false;
+let index = null;
+let currentConfig = null;
+
+function normalizeError(err) {
+  if (err && typeof err === "object") {
+    if (typeof err.type === "string" && typeof err.reason === "string") {
+      return err;
+    }
+    if (typeof err.message === "string") {
+      return { type: "worker_error", reason: err.message };
+    }
+  }
+  if (typeof err === "string") {
+    return { type: "worker_error", reason: err };
+  }
+  return { type: "worker_error", reason: String(err) };
+}
+
+function respondOk(id, payload) {
+  self.postMessage({ id, ok: true, payload });
+}
+
+function respondErr(id, err) {
+  self.postMessage({ id, ok: false, error: normalizeError(err) });
+}
+
+async function ensureWasm() {
+  if (wasmReady) {
+    return;
+  }
+  await initWasm();
+  wasmReady = true;
+}
+
+async function ensureIndex() {
+  if (index) {
+    return;
+  }
+  if (!currentConfig) {
+    throw { type: "index_not_initialized", reason: "worker index is not initialized" };
+  }
+  index = await Searchlite.init(
+    currentConfig.dbName,
+    currentConfig.schemaJson,
+    currentConfig.storage
+  );
+}
+
+async function handleInit(payload) {
+  const dbName = String(payload?.dbName || "");
+  const schemaJson = String(payload?.schemaJson || "");
+  const storage = payload?.storage || "indexeddb";
+  if (!dbName) {
+    throw { type: "invalid_argument", reason: "dbName is required" };
+  }
+  if (!schemaJson) {
+    throw { type: "invalid_argument", reason: "schemaJson is required" };
+  }
+  currentConfig = { dbName, schemaJson, storage };
+  index = await Searchlite.init(dbName, schemaJson, storage);
+  return { db_name: dbName };
+}
+
+async function handleSearch(payload) {
+  await ensureIndex();
+  const request = payload?.request ?? {};
+  const timeoutMs =
+    typeof payload?.timeoutMs === "number" ? payload.timeoutMs : null;
+  const delayMs =
+    typeof payload?.delayMs === "number" && payload.delayMs > 0
+      ? payload.delayMs
+      : 0;
+  if (delayMs > 0) {
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+  return index.search_request_value_controlled(request, null, timeoutMs);
+}
+
+async function handleMessage(message) {
+  const id = message?.id;
+  const action = message?.action;
+  const payload = message?.payload || {};
+  await ensureWasm();
+  switch (action) {
+    case "init_index":
+      return handleInit(payload);
+    case "add_documents":
+      await ensureIndex();
+      index.add_documents(payload.docs || []);
+      await index.commit();
+      return { added: Array.isArray(payload.docs) ? payload.docs.length : 0 };
+    case "search_request":
+      return handleSearch(payload);
+    case "flush_storage":
+      await ensureIndex();
+      await index.flush_storage();
+      return { flushed: true };
+    case "storage_usage":
+      return Searchlite.storage_usage();
+    case "reset_index":
+      if (!currentConfig) {
+        throw { type: "index_not_initialized", reason: "worker index is not initialized" };
+      }
+      index = await Searchlite.init(
+        currentConfig.dbName,
+        currentConfig.schemaJson,
+        currentConfig.storage
+      );
+      return { reset: true };
+    default:
+      throw { type: "invalid_action", reason: `unknown worker action: ${action}` };
+  }
+}
+
+self.onmessage = async (event) => {
+  const msg = event.data || {};
+  try {
+    const payload = await handleMessage(msg);
+    respondOk(msg.id, payload);
+  } catch (err) {
+    respondErr(msg.id, err);
+  }
+};

--- a/searchlite-wasm/searchlite-worker-client.mjs
+++ b/searchlite-wasm/searchlite-worker-client.mjs
@@ -1,0 +1,229 @@
+function structuredError(type, reason) {
+  return { type, reason };
+}
+
+function normalizeError(err) {
+  if (err && typeof err === "object") {
+    if (typeof err.type === "string" && typeof err.reason === "string") {
+      return err;
+    }
+    if (typeof err.message === "string") {
+      return structuredError("worker_error", err.message);
+    }
+  }
+  if (typeof err === "string") {
+    return structuredError("worker_error", err);
+  }
+  return structuredError("worker_error", String(err));
+}
+
+export function supportsModuleWorkers() {
+  try {
+    if (typeof Worker === "undefined") {
+      return false;
+    }
+    const blob = new Blob([""], { type: "text/javascript" });
+    const url = URL.createObjectURL(blob);
+    const worker = new Worker(url, { type: "module" });
+    worker.terminate();
+    URL.revokeObjectURL(url);
+    return true;
+  } catch (_err) {
+    return false;
+  }
+}
+
+export class SearchliteWorkerClient {
+  constructor(workerUrl = new URL("./searchlite-demo-worker.mjs", import.meta.url)) {
+    this.workerUrl = workerUrl;
+    this.worker = null;
+    this.seq = 0;
+    this.pending = new Map();
+    this.config = null;
+    this.ready = false;
+  }
+
+  async initIndex(dbName, schemaJson, storage = "indexeddb") {
+    this.config = { dbName, schemaJson, storage };
+    this.ready = false;
+    await this.#call("init_index", this.config);
+    this.ready = true;
+  }
+
+  async addDocuments(docs) {
+    await this.#ensureReady();
+    return this.#call("add_documents", { docs });
+  }
+
+  async searchRequest(request, options = {}) {
+    await this.#ensureReady();
+    const timeoutMs =
+      typeof options.timeoutMs === "number" ? options.timeoutMs : null;
+    if (
+      timeoutMs !== null &&
+      (!Number.isFinite(timeoutMs) || timeoutMs < 0)
+    ) {
+      throw structuredError(
+        "invalid_timeout",
+        "timeoutMs must be a non-negative finite number"
+      );
+    }
+    const delayMs = typeof options.delayMs === "number" ? options.delayMs : null;
+    if (delayMs !== null && (!Number.isFinite(delayMs) || delayMs < 0)) {
+      throw structuredError(
+        "invalid_argument",
+        "delayMs must be a non-negative finite number"
+      );
+    }
+    return this.#call(
+      "search_request",
+      { request, timeoutMs, delayMs },
+      { signal: options.signal, timeoutMs }
+    );
+  }
+
+  async resetIndex() {
+    await this.#ensureReady();
+    return this.#call("reset_index", {});
+  }
+
+  async flushStorage() {
+    await this.#ensureReady();
+    return this.#call("flush_storage", {});
+  }
+
+  async storageUsage() {
+    return this.#call("storage_usage", {});
+  }
+
+  async dispose() {
+    this.ready = false;
+    this.config = null;
+    this.#terminateWorker("worker_disposed", true, "worker disposed");
+  }
+
+  async #ensureReady() {
+    if (this.ready) {
+      return;
+    }
+    if (!this.config) {
+      throw structuredError(
+        "index_not_initialized",
+        "worker index is not initialized"
+      );
+    }
+    await this.initIndex(
+      this.config.dbName,
+      this.config.schemaJson,
+      this.config.storage
+    );
+  }
+
+  #ensureWorker() {
+    if (this.worker) {
+      return this.worker;
+    }
+    const worker = new Worker(this.workerUrl, { type: "module" });
+    worker.onmessage = (event) => {
+      const msg = event.data || {};
+      const pending = this.pending.get(msg.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(msg.id);
+      pending.cleanup();
+      if (msg.ok) {
+        pending.resolve(msg.payload);
+      } else {
+        pending.reject(normalizeError(msg.error));
+      }
+    };
+    worker.onerror = (event) => {
+      const reason = event?.message || "worker runtime error";
+      this.#terminateWorker("worker_crashed", true, reason);
+    };
+    this.worker = worker;
+    return worker;
+  }
+
+  #terminateWorker(type, rejectPending, reason = "worker terminated") {
+    if (this.worker) {
+      this.worker.terminate();
+      this.worker = null;
+    }
+    this.ready = false;
+    const pendingEntries = Array.from(this.pending.values());
+    this.pending.clear();
+    const error = structuredError(type, reason);
+    for (const pending of pendingEntries) {
+      pending.cleanup();
+      if (rejectPending) {
+        pending.reject(error);
+      }
+    }
+  }
+
+  #call(action, payload, options = {}) {
+    const worker = this.#ensureWorker();
+    const id = ++this.seq;
+    const signal = options.signal || null;
+    const timeoutMs =
+      typeof options.timeoutMs === "number" ? options.timeoutMs : null;
+    return new Promise((resolve, reject) => {
+      if (signal?.aborted) {
+        reject(structuredError("aborted", "operation aborted by AbortSignal"));
+        return;
+      }
+      let timer = null;
+      let abortHandler = null;
+      const cleanup = () => {
+        if (timer !== null) {
+          clearTimeout(timer);
+          timer = null;
+        }
+        if (abortHandler) {
+          signal?.removeEventListener("abort", abortHandler);
+          abortHandler = null;
+        }
+      };
+      if (timeoutMs !== null) {
+        timer = setTimeout(() => {
+          this.pending.delete(id);
+          cleanup();
+          this.#terminateWorker(
+            "worker_restarted",
+            true,
+            "worker restarted after timeout"
+          );
+          reject(
+            structuredError(
+              "timeout",
+              `operation exceeded timeout_ms=${timeoutMs}`
+            )
+          );
+        }, timeoutMs);
+      }
+      if (signal) {
+        abortHandler = () => {
+          this.pending.delete(id);
+          cleanup();
+          this.#terminateWorker(
+            "worker_restarted",
+            true,
+            "worker restarted after abort"
+          );
+          reject(structuredError("aborted", "operation aborted by AbortSignal"));
+        };
+        signal.addEventListener("abort", abortHandler, { once: true });
+      }
+      this.pending.set(id, { resolve, reject, cleanup });
+      try {
+        worker.postMessage({ id, action, payload });
+      } catch (err) {
+        this.pending.delete(id);
+        cleanup();
+        reject(normalizeError(err));
+      }
+    });
+  }
+}

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -655,11 +655,12 @@ async fn clear_data_store(db_name: &str) -> Result<()> {
   let store = tx
     .object_store(STORE_NAME)
     .map_err(|e| anyhow!("opening object store {STORE_NAME}: {:?}", e))?;
+  let tx_done = transaction_future(&tx);
   let req = store
     .clear()
     .map_err(|e| anyhow!("clear failed for {STORE_NAME}: {:?}", e))?;
   request_future(&req).await?;
-  Ok(())
+  tx_done.await
 }
 
 async fn upsert_registry_entry(entry: &IndexRegistryEntry) -> Result<()> {
@@ -678,11 +679,12 @@ async fn upsert_registry_entry(entry: &IndexRegistryEntry) -> Result<()> {
   let key = JsValue::from_str(&entry.db_name);
   let value = serde_wasm_bindgen::to_value(entry)
     .map_err(|e| anyhow!("serializing registry entry failed: {e}"))?;
+  let tx_done = transaction_future(&tx);
   let req = store
     .put_with_key(&value, &key)
     .map_err(|e| anyhow!("put registry entry failed: {:?}", e))?;
   request_future(&req).await?;
-  Ok(())
+  tx_done.await
 }
 
 async fn remove_registry_entry(db_name: &str) -> Result<()> {
@@ -695,6 +697,7 @@ async fn remove_registry_entry(db_name: &str) -> Result<()> {
         e
       )
     })?;
+  let tx_done = transaction_future(&tx);
   let store = tx
     .object_store(REGISTRY_STORE_NAME)
     .map_err(|e| anyhow!("opening object store {REGISTRY_STORE_NAME}: {:?}", e))?;
@@ -703,7 +706,7 @@ async fn remove_registry_entry(db_name: &str) -> Result<()> {
     .delete(&key)
     .map_err(|e| anyhow!("delete registry entry failed: {:?}", e))?;
   request_future(&req).await?;
-  Ok(())
+  tx_done.await
 }
 
 async fn get_registry_entry(db_name: &str) -> Result<Option<IndexRegistryEntry>> {
@@ -1047,6 +1050,15 @@ async fn persist_queue_worker(db_name: String, state: Arc<Mutex<PendingQueueStat
     let err_msg = result.as_ref().err().map(|err| err.to_string());
     if let Some(msg) = &err_msg {
       web_sys::console::error_1(&JsValue::from_str(&format!("persist batch error: {msg}")));
+      // Re-insert failed operations so a subsequent flush can retry.
+      // Do not overwrite entries added concurrently during this batch.
+      let mut guard = state.lock();
+      for (path, op) in operations {
+        guard.queue.entry(path).or_insert_with(|| PendingEntry {
+          operation: op,
+          waiters: Vec::new(),
+        });
+      }
     }
     for waiters in waiter_sets {
       for tx in waiters {
@@ -1570,6 +1582,14 @@ impl Searchlite {
     schema_json: String,
     storage_mode: StorageMode,
   ) -> Result<Searchlite, JsValue> {
+    if db_name == REGISTRY_DB_NAME {
+      return Err(js_error(
+        "reserved_name",
+        format!(
+          "'{REGISTRY_DB_NAME}' is reserved for internal use and cannot be used as an index name"
+        ),
+      ));
+    }
     let schema: Schema = serde_json::from_str(&schema_json)
       .map_err(|err| typed_js_error("invalid_schema_json", err))?;
     let requested_schema_hash = schema_hash(&schema)?;
@@ -1667,18 +1687,17 @@ impl Searchlite {
     clear_data_store(&db_name)
       .await
       .map_err(|err| typed_js_error("storage_clear_error", err))?;
-    remove_registry_entry(&db_name)
-      .await
-      .map_err(|err| typed_js_error("registry_delete_error", err))?;
     Ok(())
   }
 
   #[wasm_bindgen(js_name = drop_index)]
   pub async fn drop_index(db_name: String) -> Result<(), JsValue> {
-    let _ = remove_registry_entry(&db_name).await;
     delete_database(&db_name)
       .await
       .map_err(|err| typed_js_error("storage_delete_error", err))?;
+    remove_registry_entry(&db_name)
+      .await
+      .map_err(|err| typed_js_error("registry_delete_error", err))?;
     Ok(())
   }
 
@@ -2012,6 +2031,8 @@ impl Searchlite {
 
   /// Queue deletion for a single `_id`/doc id. Call `commit` to persist removal.
   pub fn delete_document(&self, doc_id: String) -> Result<(), JsValue> {
+    validate_doc_id(&doc_id)
+      .map_err(|err| js_error("invalid_id", format!("invalid document id: {err}")))?;
     self.delete_documents_internal(vec![doc_id])
   }
 
@@ -2020,7 +2041,12 @@ impl Searchlite {
   pub fn delete_documents(&self, doc_ids: JsValue) -> Result<(), JsValue> {
     let value: serde_json::Value = serde_wasm_bindgen::from_value(doc_ids)
       .map_err(|err| typed_js_error("invalid_doc_id_batch", err))?;
-    self.delete_documents_internal(value_to_doc_ids(value)?)
+    let ids = value_to_doc_ids(value)?;
+    for id in ids.iter() {
+      validate_doc_id(id)
+        .map_err(|err| js_error("invalid_id", format!("invalid document id: {err}")))?;
+    }
+    self.delete_documents_internal(ids)
   }
 
   /// Queue a partial document update by id using set/unset patch semantics.
@@ -2859,6 +2885,29 @@ mod tests {
       .unwrap_err();
     let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
     assert_eq!(payload.error_type, "invalid_doc_id_batch");
+  }
+
+  #[wasm_bindgen_test]
+  async fn delete_document_rejects_invalid_id() {
+    let db = unique_db("searchlite-del-invalid-id");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let err = idx.delete_document("  ".to_string()).unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_id");
+  }
+
+  #[wasm_bindgen_test]
+  async fn delete_documents_rejects_invalid_ids() {
+    let db = unique_db("searchlite-dels-invalid-id");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let ids = vec!["valid-doc", "\n"];
+    let err = idx
+      .delete_documents(serde_wasm_bindgen::to_value(&ids).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_id");
   }
 
   #[wasm_bindgen_test]
@@ -3732,6 +3781,14 @@ mod tests {
 
     Searchlite::clear_index(db.clone()).await.unwrap();
 
+    // Verify the index remains discoverable in the registry after clear.
+    let indexes_js = Searchlite::list_indexes().await.unwrap();
+    let indexes: Vec<IndexRegistryEntry> = serde_wasm_bindgen::from_value(indexes_js).unwrap();
+    assert!(
+      indexes.iter().any(|entry| entry.db_name == db),
+      "clear_index should preserve the registry entry"
+    );
+
     let reopened = Searchlite::init(db, schema_json, None).await.unwrap();
     let result = reopened.search("clear".to_string(), 5, None).unwrap();
     let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
@@ -3757,6 +3814,16 @@ mod tests {
     // Can recreate after deletion.
     let recreated = Searchlite::init(db, schema_json, None).await.unwrap();
     recreated.commit().await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn init_rejects_reserved_registry_name() {
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let result = Searchlite::init(REGISTRY_DB_NAME.to_string(), schema_json, None).await;
+    assert!(result.is_err(), "expected reserved_name error");
+    let err = result.err().unwrap();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "reserved_name");
   }
 
   #[wasm_bindgen_test]

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -989,65 +989,56 @@ impl PendingWrites {
   }
 
   async fn flush(&self) -> Result<()> {
-    let receivers = {
-      let mut guard = self.pending.lock();
-      std::mem::take(&mut *guard)
-    };
     let mut first_error = None;
-    for rx in receivers {
-      match rx.await {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => {
-          if first_error.is_none() {
-            first_error = Some(err);
+    loop {
+      // Drain all pending receivers from normal enqueue paths.
+      let receivers = {
+        let mut guard = self.pending.lock();
+        std::mem::take(&mut *guard)
+      };
+      for rx in receivers {
+        match rx.await {
+          Ok(Ok(())) => {}
+          Ok(Err(err)) => {
+            if first_error.is_none() {
+              first_error = Some(err);
+            }
           }
-        }
-        Err(_) => {
-          if first_error.is_none() {
-            first_error = Some(anyhow!("pending persist dropped"));
+          Err(_) => {
+            if first_error.is_none() {
+              first_error = Some(anyhow!("pending persist dropped"));
+            }
           }
         }
       }
-    }
-    // If previous batches failed and re-queued operations, ensure a worker
-    // is running so those entries are retried before we return.
-    {
-      let mut guard = self.state.lock();
-      if !guard.queue.is_empty() && !guard.worker_running {
-        let (tx, rx) = oneshot::channel();
-        // Attach a waiter to the first queued entry so we can await it.
-        if let Some(entry) = guard.queue.values_mut().next() {
-          entry.waiters.push(tx);
-          self.pending.lock().push(rx);
+      // If previous batches failed and re-queued operations, ensure a worker
+      // is running so those entries are retried. Attach a waiter to the LAST
+      // queued entry so we block until the entire queue has been processed.
+      let has_retry = {
+        let mut guard = self.state.lock();
+        if !guard.queue.is_empty() && !guard.worker_running {
+          let (tx, rx) = oneshot::channel();
+          if let Some(entry) = guard.queue.values_mut().next_back() {
+            entry.waiters.push(tx);
+            self.pending.lock().push(rx);
+          } else {
+            drop(tx);
+          }
+          guard.worker_running = true;
+          let db_name = self.db_name.clone();
+          let state = self.state.clone();
+          spawn_local(async move {
+            persist_queue_worker(db_name, state).await;
+          });
+          true
         } else {
-          drop(tx);
+          false
         }
-        guard.worker_running = true;
-        let db_name = self.db_name.clone();
-        let state = self.state.clone();
-        spawn_local(async move {
-          persist_queue_worker(db_name, state).await;
-        });
+      };
+      if !has_retry {
+        break;
       }
-    }
-    let retry_receivers = {
-      let mut guard = self.pending.lock();
-      std::mem::take(&mut *guard)
-    };
-    for rx in retry_receivers {
-      match rx.await {
-        Ok(Ok(())) => {}
-        Ok(Err(err)) => {
-          if first_error.is_none() {
-            first_error = Some(err);
-          }
-        }
-        Err(_) => {
-          if first_error.is_none() {
-            first_error = Some(anyhow!("pending persist dropped"));
-          }
-        }
-      }
+      // Loop back to drain the retry receivers and check again.
     }
     if let Some(err) = first_error {
       Err(err)
@@ -1532,17 +1523,35 @@ fn f64_to_u64_bytes(value: f64) -> Option<u64> {
 }
 
 async fn browser_storage_usage() -> Result<StorageUsageResponse, JsValue> {
+  // Use Reflect to access navigator.storage so this works in both Window and
+  // Worker contexts (Window exposes Navigator, Workers expose WorkerNavigator,
+  // but both provide a StorageManager via navigator.storage).
   let global = js_sys::global();
-  let navigator = js_sys::Reflect::get(&global, &JsValue::from_str("navigator"))
-    .ok()
-    .and_then(|value| value.dyn_into::<web_sys::Navigator>().ok());
-  let Some(navigator) = navigator else {
-    return Ok(StorageUsageResponse::unsupported(
-      "navigator is unavailable",
-    ));
+  let navigator = match js_sys::Reflect::get(&global, &JsValue::from_str("navigator")) {
+    Ok(nav) if !nav.is_undefined() && !nav.is_null() => nav,
+    _ => {
+      return Ok(StorageUsageResponse::unsupported(
+        "navigator is unavailable",
+      ));
+    }
   };
-  let manager = navigator.storage();
-  let estimate_promise = match manager.estimate() {
+  let storage = match js_sys::Reflect::get(&navigator, &JsValue::from_str("storage")) {
+    Ok(s) if !s.is_undefined() && !s.is_null() => s,
+    _ => {
+      return Ok(StorageUsageResponse::unsupported(
+        "navigator.storage is unavailable",
+      ));
+    }
+  };
+  let estimate_fn = match js_sys::Reflect::get(&storage, &JsValue::from_str("estimate")) {
+    Ok(f) if f.is_function() => f.dyn_into::<js_sys::Function>().unwrap(),
+    _ => {
+      return Ok(StorageUsageResponse::unsupported(
+        "storage.estimate is unavailable",
+      ));
+    }
+  };
+  let estimate_promise = match estimate_fn.call0(&storage) {
     Ok(promise) => promise,
     Err(err) => {
       return Ok(StorageUsageResponse::unsupported(format!(
@@ -1550,7 +1559,7 @@ async fn browser_storage_usage() -> Result<StorageUsageResponse, JsValue> {
       )));
     }
   };
-  let estimate_value = match JsFuture::from(estimate_promise).await {
+  let estimate_value = match JsFuture::from(js_sys::Promise::from(estimate_promise)).await {
     Ok(value) => value,
     Err(err) => {
       return Ok(StorageUsageResponse::unsupported(format!(
@@ -1571,12 +1580,19 @@ async fn browser_storage_usage() -> Result<StorageUsageResponse, JsValue> {
     (Some(used), Some(limit)) => Some(limit.saturating_sub(used)),
     _ => None,
   };
-  let persisted = match manager.persisted() {
-    Ok(promise) => match JsFuture::from(promise).await {
-      Ok(value) => value.as_bool(),
-      Err(_) => None,
-    },
-    Err(_) => None,
+  // Check navigator.storage.persisted() via Reflect as well.
+  let persisted = match js_sys::Reflect::get(&storage, &JsValue::from_str("persisted")) {
+    Ok(f) if f.is_function() => {
+      let func = f.dyn_into::<js_sys::Function>().unwrap();
+      match func.call0(&storage) {
+        Ok(promise) => match JsFuture::from(js_sys::Promise::from(promise)).await {
+          Ok(value) => value.as_bool(),
+          Err(_) => None,
+        },
+        Err(_) => None,
+      }
+    }
+    _ => None,
   };
   Ok(StorageUsageResponse {
     supported: true,
@@ -2218,6 +2234,8 @@ impl Searchlite {
 
   /// Execute multiple search requests in order and return ordered results.
   /// `request` shape: `{ searches: SearchRequest[], parallel?: boolean, max_concurrency?: number }`.
+  /// Note: `parallel` and `max_concurrency` are accepted for API compatibility
+  /// but have no effect in single-threaded WASM — searches always run serially.
   pub fn multi_search(&self, request: JsValue) -> Result<JsValue, JsValue> {
     let req: MultiSearchRequest = parse_request_value(request, "invalid_multi_search_request")?;
     let reader: IndexReader = self

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -10,30 +11,89 @@ use futures::channel::oneshot;
 use parking_lot::Mutex;
 use parking_lot::RwLock;
 use searchlite_core::api::types::{
-  Aggregation, ExecutionStrategy, Filter, IndexOptions, Query, QueryNode, SearchRequest, SortSpec,
-  StorageType,
+  Aggregation, ExecutionStrategy, IndexOptions, MgetRequest, MgetResponse, MultiSearchRequest,
+  Query, QueryNode, SearchRequest, SortSpec, StorageType,
 };
-use searchlite_core::api::{Document, IndexReader, IndexWriter};
+use searchlite_core::api::{Document, IndexReader, IndexWriter, MultiSearchResponse, PatchError};
 use searchlite_core::storage::{DynFile, InMemoryStorage, Storage, StorageFile};
-use searchlite_core::{Index, Schema};
+use searchlite_core::util::doc_id::validate_doc_id;
+use searchlite_core::{Index, Manifest, Schema};
+use serde::de::DeserializeOwned;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
-#[cfg(feature = "threads")]
 use wasm_bindgen_futures::JsFuture;
 #[cfg(feature = "threads")]
 use wasm_bindgen_rayon::init_thread_pool;
 
 const STORE_NAME: &str = "searchlite_files";
+const REGISTRY_DB_NAME: &str = "searchlite_registry";
+const REGISTRY_STORE_NAME: &str = "indexes";
+const META_FILE_NAME: &str = ".searchlite_meta.json";
+const SCHEMA_VERSION_V1: u32 = 1;
+const IDB_WRITE_BATCH_SIZE: usize = 64;
 // BM25 defaults tuned for browser-based search; keep aligned with core defaults.
 const BM25_K1: f32 = 0.9;
 const BM25_B: f32 = 0.4;
+type EventHandler = Rc<RefCell<Option<Closure<dyn FnMut(web_sys::Event)>>>>;
 
 thread_local! {
   // Per-thread (per WASM worker) cache of IndexedDB connections.
   // This avoids reconnecting for each persist operation on the same thread.
   static DB_CACHE: RefCell<HashMap<String, web_sys::IdbDatabase>> = RefCell::new(HashMap::new());
+}
+
+#[cfg(test)]
+thread_local! {
+  static MIGRATION_FAIL_AFTER_CLEAR: RefCell<bool> = const { RefCell::new(false) };
+  static FORCE_PERSIST_QUOTA_EXCEEDED: RefCell<bool> = const { RefCell::new(false) };
+  static PERSIST_BATCH_TX_COUNT: RefCell<u32> = const { RefCell::new(0) };
+}
+
+#[cfg(test)]
+fn set_migration_fail_after_clear(enabled: bool) {
+  MIGRATION_FAIL_AFTER_CLEAR.with(|flag| *flag.borrow_mut() = enabled);
+}
+
+#[cfg(test)]
+fn migration_fail_after_clear() -> bool {
+  MIGRATION_FAIL_AFTER_CLEAR.with(|flag| *flag.borrow())
+}
+
+#[cfg(test)]
+fn set_force_persist_quota_exceeded(enabled: bool) {
+  FORCE_PERSIST_QUOTA_EXCEEDED.with(|flag| *flag.borrow_mut() = enabled);
+}
+
+#[cfg(test)]
+fn force_persist_quota_exceeded() -> bool {
+  FORCE_PERSIST_QUOTA_EXCEEDED.with(|flag| *flag.borrow())
+}
+
+#[cfg(test)]
+fn reset_persist_batch_tx_count() {
+  PERSIST_BATCH_TX_COUNT.with(|count| *count.borrow_mut() = 0);
+}
+
+#[cfg(test)]
+fn persist_batch_tx_count() -> u32 {
+  PERSIST_BATCH_TX_COUNT.with(|count| *count.borrow())
+}
+
+#[cfg(test)]
+fn bump_persist_batch_tx_count() {
+  PERSIST_BATCH_TX_COUNT.with(|count| *count.borrow_mut() += 1);
+}
+
+#[cfg(not(test))]
+fn migration_fail_after_clear() -> bool {
+  false
+}
+
+#[cfg(not(test))]
+fn force_persist_quota_exceeded() -> bool {
+  false
 }
 
 #[derive(Clone, Copy)]
@@ -48,7 +108,10 @@ impl StorageMode {
       None => Ok(Self::IndexedDb),
       Some(value) if value.eq_ignore_ascii_case("indexeddb") => Ok(Self::IndexedDb),
       Some(value) if value.eq_ignore_ascii_case("memory") => Ok(Self::Memory),
-      Some(_) => Err(JsValue::from_str("storage must be 'indexeddb' or 'memory'")),
+      Some(_) => Err(js_error(
+        "invalid_argument",
+        "storage must be 'indexeddb' or 'memory'",
+      )),
     }
   }
 }
@@ -56,6 +119,140 @@ impl StorageMode {
 enum StorageBackend {
   IndexedDb(Arc<JsStorage>),
   Memory,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct WasmErrorPayload {
+  #[serde(rename = "type")]
+  error_type: String,
+  reason: String,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct IndexRegistryEntry {
+  db_name: String,
+  schema_version: u32,
+  schema_hash: String,
+  updated_at_ms: f64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct IndexMeta {
+  schema_version: u32,
+  schema_hash: String,
+}
+
+fn js_error(error_type: &str, reason: impl Into<String>) -> JsValue {
+  let payload = WasmErrorPayload {
+    error_type: error_type.to_string(),
+    reason: reason.into(),
+  };
+  serde_wasm_bindgen::to_value(&payload)
+    .unwrap_or_else(|_| JsValue::from_str("failed to serialize wasm error payload"))
+}
+
+fn to_js_error(err: impl std::fmt::Display) -> JsValue {
+  js_error("internal_error", err.to_string())
+}
+
+fn typed_js_error(error_type: &str, err: impl std::fmt::Display) -> JsValue {
+  js_error(error_type, err.to_string())
+}
+
+fn js_error_reason(err: &JsValue) -> String {
+  if let Some(reason) = js_sys::Reflect::get(err, &JsValue::from_str("reason"))
+    .ok()
+    .and_then(|value| value.as_string())
+  {
+    return reason;
+  }
+  err
+    .as_string()
+    .unwrap_or_else(|| format!("non-string js error: {err:?}"))
+}
+
+fn map_update_error(err: anyhow::Error) -> JsValue {
+  if let Some(patch_err) = err.downcast_ref::<PatchError>() {
+    return match patch_err {
+      PatchError::DocumentNotFound => js_error("document_not_found", err.to_string()),
+      PatchError::VectorFieldsUnsupported => js_error("vector_fields_unsupported", err.to_string()),
+    };
+  }
+  js_error("update_failed", err.to_string())
+}
+
+fn is_quota_exceeded_reason(reason: &str) -> bool {
+  let lower = reason.to_ascii_lowercase();
+  lower.contains("quotaexceedederror") || (lower.contains("quota") && lower.contains("exceed"))
+}
+
+fn map_storage_error(err: anyhow::Error, fallback_type: &str, action: &str) -> JsValue {
+  let reason = err.to_string();
+  if is_quota_exceeded_reason(&reason) {
+    return js_error(
+      "quota_exceeded",
+      format!(
+        "indexeddb quota exceeded while {action}; run compact(), remove stale indexes with Searchlite.cleanup_indexes(...), or clear/drop unused indexes before retrying. detail: {reason}"
+      ),
+    );
+  }
+  js_error(fallback_type, reason)
+}
+
+fn parse_timeout_ms(timeout_ms: Option<f64>) -> Result<Option<f64>, JsValue> {
+  match timeout_ms {
+    None => Ok(None),
+    Some(ms) if ms.is_finite() && ms >= 0.0 => Ok(Some(ms)),
+    _ => Err(js_error(
+      "invalid_timeout",
+      "timeout_ms must be a non-negative finite number",
+    )),
+  }
+}
+
+fn ensure_not_aborted(signal: Option<&web_sys::AbortSignal>) -> Result<(), JsValue> {
+  if signal.map(|sig| sig.aborted()).unwrap_or(false) {
+    return Err(js_error("aborted", "operation aborted by AbortSignal"));
+  }
+  Ok(())
+}
+
+fn ensure_not_timed_out(started_ms: f64, timeout_ms: Option<f64>) -> Result<(), JsValue> {
+  let Some(limit) = timeout_ms else {
+    return Ok(());
+  };
+  let elapsed_ms = now_ms() - started_ms;
+  if elapsed_ms >= limit {
+    return Err(js_error(
+      "timeout",
+      format!("operation exceeded timeout_ms={limit} (elapsed={elapsed_ms:.2}ms)"),
+    ));
+  }
+  Ok(())
+}
+
+fn parse_request_value<T>(value: JsValue, error_type: &str) -> Result<T, JsValue>
+where
+  T: DeserializeOwned,
+{
+  match serde_wasm_bindgen::from_value::<T>(value.clone()) {
+    Ok(parsed) => Ok(parsed),
+    Err(primary_err) => {
+      let fallback_json: serde_json::Value =
+        serde_wasm_bindgen::from_value(value).map_err(|json_err| {
+          typed_js_error(
+            error_type,
+            format!("primary decode failed: {primary_err}; json fallback failed: {json_err}"),
+          )
+        })?;
+      serde_json::from_value::<T>(fallback_json).map_err(|json_err| {
+        typed_js_error(
+          error_type,
+          format!("primary decode failed: {primary_err}; json struct decode failed: {json_err}"),
+        )
+      })
+    }
+  }
 }
 
 impl StorageBackend {
@@ -95,14 +292,10 @@ fn path_key(path: &Path) -> String {
   path.to_string_lossy().to_string()
 }
 
-fn to_js_error(err: impl std::fmt::Display) -> JsValue {
-  JsValue::from_str(&err.to_string())
-}
-
 fn value_to_document(value: serde_json::Value) -> Result<Document, JsValue> {
   let obj = value
     .as_object()
-    .ok_or_else(|| JsValue::from_str("document must be a JSON object"))?;
+    .ok_or_else(|| js_error("invalid_document", "document must be a JSON object"))?;
   let mut fields = BTreeMap::new();
   for (k, v) in obj.iter() {
     fields.insert(k.clone(), v.clone());
@@ -114,30 +307,59 @@ fn value_to_documents(value: serde_json::Value) -> Result<Vec<Document>, JsValue
   match value {
     serde_json::Value::Array(items) => items.into_iter().map(value_to_document).collect(),
     obj @ serde_json::Value::Object(_) => Ok(vec![value_to_document(obj)?]),
-    _ => Err(JsValue::from_str(
+    _ => Err(js_error(
+      "invalid_document_batch",
       "documents must be an object or array of objects",
     )),
   }
 }
 
-fn clear_request_handlers(
-  req: &web_sys::IdbRequest,
-  success: &Rc<RefCell<Option<Closure<dyn FnMut(web_sys::Event)>>>>,
-  error: &Rc<RefCell<Option<Closure<dyn FnMut(web_sys::Event)>>>>,
-) {
+fn value_to_doc_ids(value: serde_json::Value) -> Result<Vec<String>, JsValue> {
+  match value {
+    serde_json::Value::String(id) => Ok(vec![id]),
+    serde_json::Value::Array(items) => {
+      let mut ids = Vec::with_capacity(items.len());
+      for item in items {
+        let serde_json::Value::String(id) = item else {
+          return Err(js_error(
+            "invalid_doc_id_batch",
+            "document ids must be a string or array of strings",
+          ));
+        };
+        ids.push(id);
+      }
+      Ok(ids)
+    }
+    _ => Err(js_error(
+      "invalid_doc_id_batch",
+      "document ids must be a string or array of strings",
+    )),
+  }
+}
+
+fn clear_request_handlers(req: &web_sys::IdbRequest, success: &EventHandler, error: &EventHandler) {
   req.set_onsuccess(None);
   req.set_onerror(None);
   success.borrow_mut().take();
   error.borrow_mut().take();
 }
 
+fn dom_exception_to_anyhow(context: &str, dom: &web_sys::DomException) -> anyhow::Error {
+  anyhow!("{context}: {} ({})", dom.name(), dom.message())
+}
+
+fn js_error_to_anyhow(context: &str, err: &JsValue) -> anyhow::Error {
+  if let Ok(dom) = err.clone().dyn_into::<web_sys::DomException>() {
+    return dom_exception_to_anyhow(context, &dom);
+  }
+  anyhow!("{context}: {:?}", err)
+}
+
 fn request_future(req: &web_sys::IdbRequest) -> impl std::future::Future<Output = Result<JsValue>> {
   let (tx, rx) = oneshot::channel::<Result<JsValue>>();
   let sender = Rc::new(RefCell::new(Some(tx)));
-  let success_handler: Rc<RefCell<Option<Closure<dyn FnMut(web_sys::Event)>>>> =
-    Rc::new(RefCell::new(None));
-  let error_handler: Rc<RefCell<Option<Closure<dyn FnMut(web_sys::Event)>>>> =
-    Rc::new(RefCell::new(None));
+  let success_handler: EventHandler = Rc::new(RefCell::new(None));
+  let error_handler: EventHandler = Rc::new(RefCell::new(None));
   let success_req_for_closure = req.clone();
   let success_req_for_handler = req.clone();
   let error_req_for_closure = req.clone();
@@ -180,12 +402,13 @@ fn request_future(req: &web_sys::IdbRequest) -> impl std::future::Future<Output 
   let error_handler_clone = error_handler.clone();
   let sender_clone = sender.clone();
   let error = Closure::wrap(Box::new(move |_event: web_sys::Event| {
-    let err_val = match error_req_for_closure.error() {
-      Ok(e) => e.into(),
-      Err(_) => JsValue::from_str("indexeddb request error"),
+    let err = match error_req_for_closure.error() {
+      Ok(Some(dom)) => dom_exception_to_anyhow("indexeddb request error", &dom),
+      Ok(None) => anyhow!("indexeddb request error"),
+      Err(raw) => js_error_to_anyhow("indexeddb request error", &raw),
     };
     if let Some(tx) = sender_clone.borrow_mut().take() {
-      let _ = tx.send(Err(anyhow!("indexeddb request error: {:?}", err_val)));
+      let _ = tx.send(Err(err));
     }
     clear_request_handlers(
       &error_req_for_closure,
@@ -211,7 +434,155 @@ fn request_future(req: &web_sys::IdbRequest) -> impl std::future::Future<Output 
   }
 }
 
-async fn open_db(name: &str) -> Result<web_sys::IdbDatabase> {
+fn clear_transaction_handlers(
+  tx: &web_sys::IdbTransaction,
+  complete: &EventHandler,
+  error: &EventHandler,
+  abort: &EventHandler,
+) {
+  tx.set_oncomplete(None);
+  tx.set_onerror(None);
+  tx.set_onabort(None);
+  complete.borrow_mut().take();
+  error.borrow_mut().take();
+  abort.borrow_mut().take();
+}
+
+fn transaction_future(
+  tx: &web_sys::IdbTransaction,
+) -> impl std::future::Future<Output = Result<()>> {
+  let (tx_done, rx) = oneshot::channel::<Result<()>>();
+  let sender = Rc::new(RefCell::new(Some(tx_done)));
+  let complete_handler: EventHandler = Rc::new(RefCell::new(None));
+  let error_handler: EventHandler = Rc::new(RefCell::new(None));
+  let abort_handler: EventHandler = Rc::new(RefCell::new(None));
+
+  let tx_complete_for_closure = tx.clone();
+  let tx_complete_for_handler = tx.clone();
+  let tx_error_for_closure = tx.clone();
+  let tx_error_for_handler = tx.clone();
+  let tx_abort_for_closure = tx.clone();
+  let tx_abort_for_handler = tx.clone();
+
+  let complete_handler_clone = complete_handler.clone();
+  let error_handler_clone = error_handler.clone();
+  let abort_handler_clone = abort_handler.clone();
+  let sender_clone = sender.clone();
+  let complete = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+    if let Some(done) = sender_clone.borrow_mut().take() {
+      let _ = done.send(Ok(()));
+    }
+    clear_transaction_handlers(
+      &tx_complete_for_closure,
+      &complete_handler_clone,
+      &error_handler_clone,
+      &abort_handler_clone,
+    );
+  }) as Box<dyn FnMut(_)>);
+  *complete_handler.borrow_mut() = Some(complete);
+  tx_complete_for_handler.set_oncomplete(Some(
+    complete_handler
+      .borrow()
+      .as_ref()
+      .expect("transaction complete handler set")
+      .as_ref()
+      .unchecked_ref(),
+  ));
+
+  let complete_handler_clone = complete_handler.clone();
+  let error_handler_clone = error_handler.clone();
+  let abort_handler_clone = abort_handler.clone();
+  let sender_clone = sender.clone();
+  let error = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+    let err = tx_error_for_closure
+      .error()
+      .map(|dom| dom_exception_to_anyhow("indexeddb transaction error", &dom))
+      .unwrap_or_else(|| anyhow!("indexeddb transaction error"));
+    if let Some(done) = sender_clone.borrow_mut().take() {
+      let _ = done.send(Err(err));
+    }
+    clear_transaction_handlers(
+      &tx_error_for_closure,
+      &complete_handler_clone,
+      &error_handler_clone,
+      &abort_handler_clone,
+    );
+  }) as Box<dyn FnMut(_)>);
+  *error_handler.borrow_mut() = Some(error);
+  tx_error_for_handler.set_onerror(Some(
+    error_handler
+      .borrow()
+      .as_ref()
+      .expect("transaction error handler set")
+      .as_ref()
+      .unchecked_ref(),
+  ));
+
+  let complete_handler_clone = complete_handler.clone();
+  let error_handler_clone = error_handler.clone();
+  let abort_handler_clone = abort_handler.clone();
+  let sender_clone = sender.clone();
+  let abort = Closure::wrap(Box::new(move |_event: web_sys::Event| {
+    let err = tx_abort_for_closure
+      .error()
+      .map(|dom| dom_exception_to_anyhow("indexeddb transaction aborted", &dom))
+      .unwrap_or_else(|| anyhow!("indexeddb transaction aborted"));
+    if let Some(done) = sender_clone.borrow_mut().take() {
+      let _ = done.send(Err(err));
+    }
+    clear_transaction_handlers(
+      &tx_abort_for_closure,
+      &complete_handler_clone,
+      &error_handler_clone,
+      &abort_handler_clone,
+    );
+  }) as Box<dyn FnMut(_)>);
+  *abort_handler.borrow_mut() = Some(abort);
+  tx_abort_for_handler.set_onabort(Some(
+    abort_handler
+      .borrow()
+      .as_ref()
+      .expect("transaction abort handler set")
+      .as_ref()
+      .unchecked_ref(),
+  ));
+
+  async move {
+    match rx.await {
+      Ok(result) => result,
+      Err(_) => Err(anyhow!("indexeddb transaction wait canceled")),
+    }
+  }
+}
+
+fn now_ms() -> f64 {
+  js_sys::Date::now()
+}
+
+fn schema_hash(schema: &Schema) -> Result<String, JsValue> {
+  let schema_json =
+    serde_json::to_vec(schema).map_err(|err| typed_js_error("schema_serialization_error", err))?;
+  // Use a deterministic FNV-1a hash so persisted schema fingerprints remain stable
+  // across process restarts and Rust/toolchain upgrades.
+  let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+  for byte in schema_json {
+    hash ^= byte as u64;
+    hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+  }
+  Ok(format!("{hash:016x}"))
+}
+
+fn manifest_doc_counts(manifest: &Manifest) -> (u64, u64) {
+  let mut total_docs = 0u64;
+  let mut deleted_docs = 0u64;
+  for seg in manifest.segments.iter() {
+    total_docs = total_docs.saturating_add(seg.doc_count as u64);
+    deleted_docs = deleted_docs.saturating_add(seg.deleted_docs.len() as u64);
+  }
+  (total_docs.saturating_sub(deleted_docs), deleted_docs)
+}
+
+async fn open_db_with_store(name: &str, store_name: &str) -> Result<web_sys::IdbDatabase> {
   if let Some(db) = DB_CACHE.with(|cache| cache.borrow().get(name).cloned()) {
     return Ok(db);
   }
@@ -219,7 +590,7 @@ async fn open_db(name: &str) -> Result<web_sys::IdbDatabase> {
   let request = factory
     .open_with_u32(name, 1)
     .map_err(|e| anyhow!("indexed_db open error: {:?}", e))?;
-  let store = STORE_NAME.to_string();
+  let store = store_name.to_string();
   let upgrade = Closure::wrap(Box::new(move |event: web_sys::Event| {
     if let Some(target) = event.target() {
       if let Ok(req) = target.dyn_into::<web_sys::IdbOpenDbRequest>() {
@@ -249,11 +620,223 @@ async fn open_db(name: &str) -> Result<web_sys::IdbDatabase> {
   Ok(db)
 }
 
+fn close_cached_db(name: &str) {
+  DB_CACHE.with(|cache| {
+    if let Some(db) = cache.borrow_mut().remove(name) {
+      db.close();
+    }
+  });
+}
+
+async fn open_data_db(name: &str) -> Result<web_sys::IdbDatabase> {
+  open_db_with_store(name, STORE_NAME).await
+}
+
+async fn open_registry_db() -> Result<web_sys::IdbDatabase> {
+  open_db_with_store(REGISTRY_DB_NAME, REGISTRY_STORE_NAME).await
+}
+
+async fn delete_database(name: &str) -> Result<()> {
+  close_cached_db(name);
+  let factory = indexed_db_factory()?;
+  let request = factory
+    .delete_database(name)
+    .map_err(|e| anyhow!("indexed_db delete_database error: {:?}", e))?;
+  let request_handle: web_sys::IdbRequest = request.into();
+  request_future(&request_handle).await?;
+  Ok(())
+}
+
+async fn clear_data_store(db_name: &str) -> Result<()> {
+  let db = open_data_db(db_name).await?;
+  let tx = db
+    .transaction_with_str_and_mode(STORE_NAME, web_sys::IdbTransactionMode::Readwrite)
+    .map_err(|e| anyhow!("opening read-write transaction for {STORE_NAME}: {:?}", e))?;
+  let store = tx
+    .object_store(STORE_NAME)
+    .map_err(|e| anyhow!("opening object store {STORE_NAME}: {:?}", e))?;
+  let req = store
+    .clear()
+    .map_err(|e| anyhow!("clear failed for {STORE_NAME}: {:?}", e))?;
+  request_future(&req).await?;
+  Ok(())
+}
+
+async fn upsert_registry_entry(entry: &IndexRegistryEntry) -> Result<()> {
+  let db = open_registry_db().await?;
+  let tx = db
+    .transaction_with_str_and_mode(REGISTRY_STORE_NAME, web_sys::IdbTransactionMode::Readwrite)
+    .map_err(|e| {
+      anyhow!(
+        "opening read-write transaction for {REGISTRY_STORE_NAME}: {:?}",
+        e
+      )
+    })?;
+  let store = tx
+    .object_store(REGISTRY_STORE_NAME)
+    .map_err(|e| anyhow!("opening object store {REGISTRY_STORE_NAME}: {:?}", e))?;
+  let key = JsValue::from_str(&entry.db_name);
+  let value = serde_wasm_bindgen::to_value(entry)
+    .map_err(|e| anyhow!("serializing registry entry failed: {e}"))?;
+  let req = store
+    .put_with_key(&value, &key)
+    .map_err(|e| anyhow!("put registry entry failed: {:?}", e))?;
+  request_future(&req).await?;
+  Ok(())
+}
+
+async fn remove_registry_entry(db_name: &str) -> Result<()> {
+  let db = open_registry_db().await?;
+  let tx = db
+    .transaction_with_str_and_mode(REGISTRY_STORE_NAME, web_sys::IdbTransactionMode::Readwrite)
+    .map_err(|e| {
+      anyhow!(
+        "opening read-write transaction for {REGISTRY_STORE_NAME}: {:?}",
+        e
+      )
+    })?;
+  let store = tx
+    .object_store(REGISTRY_STORE_NAME)
+    .map_err(|e| anyhow!("opening object store {REGISTRY_STORE_NAME}: {:?}", e))?;
+  let key = JsValue::from_str(db_name);
+  let req = store
+    .delete(&key)
+    .map_err(|e| anyhow!("delete registry entry failed: {:?}", e))?;
+  request_future(&req).await?;
+  Ok(())
+}
+
+async fn get_registry_entry(db_name: &str) -> Result<Option<IndexRegistryEntry>> {
+  let db = open_registry_db().await?;
+  let tx = db
+    .transaction_with_str_and_mode(REGISTRY_STORE_NAME, web_sys::IdbTransactionMode::Readonly)
+    .map_err(|e| anyhow!("opening transaction for {REGISTRY_STORE_NAME}: {:?}", e))?;
+  let store = tx
+    .object_store(REGISTRY_STORE_NAME)
+    .map_err(|e| anyhow!("opening object store {REGISTRY_STORE_NAME}: {:?}", e))?;
+  let key = JsValue::from_str(db_name);
+  let req = store
+    .get(&key)
+    .map_err(|e| anyhow!("registry get failed: {:?}", e))?;
+  let row = request_future(&req).await?;
+  if row.is_null() || row.is_undefined() {
+    return Ok(None);
+  }
+  let entry: IndexRegistryEntry =
+    serde_wasm_bindgen::from_value(row).map_err(|e| anyhow!("registry decode failed: {e}"))?;
+  Ok(Some(entry))
+}
+
+async fn restore_registry_entry(db_name: &str, entry: Option<&IndexRegistryEntry>) -> Result<()> {
+  match entry {
+    Some(existing) => upsert_registry_entry(existing).await,
+    None => remove_registry_entry(db_name).await,
+  }
+}
+
+async fn list_registry_entries() -> Result<Vec<IndexRegistryEntry>> {
+  let db = open_registry_db().await?;
+  let tx = db
+    .transaction_with_str_and_mode(REGISTRY_STORE_NAME, web_sys::IdbTransactionMode::Readonly)
+    .map_err(|e| anyhow!("opening transaction for {REGISTRY_STORE_NAME}: {:?}", e))?;
+  let store = tx
+    .object_store(REGISTRY_STORE_NAME)
+    .map_err(|e| anyhow!("opening object store {REGISTRY_STORE_NAME}: {:?}", e))?;
+  let req = store
+    .get_all()
+    .map_err(|e| anyhow!("registry get_all failed: {:?}", e))?;
+  let val = request_future(&req).await?;
+  let rows: js_sys::Array = val
+    .dyn_into()
+    .map_err(|_| anyhow!("registry get_all expected an array"))?;
+  let mut entries = Vec::with_capacity(rows.length() as usize);
+  for row in rows.iter() {
+    if row.is_undefined() || row.is_null() {
+      continue;
+    }
+    let entry: IndexRegistryEntry = serde_wasm_bindgen::from_value(row)
+      .map_err(|e| anyhow!("registry entry decode failed: {e}"))?;
+    entries.push(entry);
+  }
+  entries.sort_by(|a, b| a.db_name.cmp(&b.db_name));
+  Ok(entries)
+}
+
+#[derive(Debug)]
+enum PersistOperation {
+  Put(Vec<u8>),
+  Delete,
+}
+
+fn chunk_operations(
+  operations: Vec<(PathBuf, PersistOperation)>,
+  chunk_size: usize,
+) -> Vec<Vec<(PathBuf, PersistOperation)>> {
+  let mut chunks = Vec::new();
+  let mut current = Vec::with_capacity(chunk_size.max(1));
+  for operation in operations {
+    current.push(operation);
+    if current.len() >= chunk_size {
+      chunks.push(current);
+      current = Vec::with_capacity(chunk_size.max(1));
+    }
+  }
+  if !current.is_empty() {
+    chunks.push(current);
+  }
+  chunks
+}
+
+async fn persist_operations_batch(
+  db_name: &str,
+  operations: &[(PathBuf, PersistOperation)],
+) -> Result<()> {
+  if operations.is_empty() {
+    return Ok(());
+  }
+  if force_persist_quota_exceeded() {
+    return Err(anyhow!(
+      "QuotaExceededError: synthetic quota failure for wasm persistence test"
+    ));
+  }
+  #[cfg(test)]
+  bump_persist_batch_tx_count();
+
+  let db = open_data_db(db_name).await?;
+  let tx = db
+    .transaction_with_str_and_mode(STORE_NAME, web_sys::IdbTransactionMode::Readwrite)
+    .map_err(|e| anyhow!("opening read-write transaction for {STORE_NAME}: {:?}", e))?;
+  let tx_done = transaction_future(&tx);
+  let store = tx
+    .object_store(STORE_NAME)
+    .map_err(|e| anyhow!("opening object store {STORE_NAME}: {:?}", e))?;
+  // Queue every request synchronously before yielding. Awaiting each request
+  // individually can let Chrome auto-close the transaction between awaits.
+  for (path, operation) in operations.iter() {
+    let key = JsValue::from_str(&path_key(path));
+    match operation {
+      PersistOperation::Put(data) => {
+        let value: JsValue = js_sys::Uint8Array::from(data.as_slice()).into();
+        store
+          .put_with_key(&value, &key)
+          .map_err(|e| anyhow!("put_with_key failed for {:?}: {:?}", path, e))?;
+      }
+      PersistOperation::Delete => {
+        store
+          .delete(&key)
+          .map_err(|e| anyhow!("delete failed for {:?}: {:?}", path, e))?;
+      }
+    };
+  }
+  tx_done.await
+}
+
 async fn load_snapshot(db_name: &str) -> Result<HashMap<PathBuf, Vec<u8>>> {
-  let db = open_db(db_name).await?;
+  let db = open_data_db(db_name).await?;
   let tx = db
     .transaction_with_str_and_mode(STORE_NAME, web_sys::IdbTransactionMode::Readonly)
     .map_err(|e| anyhow!("opening transaction for {STORE_NAME}: {:?}", e))?;
+  let tx_done = transaction_future(&tx);
   let store = tx
     .object_store(STORE_NAME)
     .map_err(|e| anyhow!("opening object store {STORE_NAME}: {:?}", e))?;
@@ -265,64 +848,76 @@ async fn load_snapshot(db_name: &str) -> Result<HashMap<PathBuf, Vec<u8>>> {
     .map_err(|e| anyhow!("get_all failed: {:?}", e))?;
   let keys_val = request_future(&keys_req).await?;
   let values_val = request_future(&values_req).await?;
-  let keys: js_sys::Array = match keys_val.dyn_into() {
-    Ok(array) => array,
-    Err(_) => {
+  tx_done.await?;
+
+  let keys: js_sys::Array = keys_val
+    .dyn_into()
+    .map_err(|_| anyhow!("get_all_keys expected an array"))?;
+  let values: js_sys::Array = values_val
+    .dyn_into()
+    .map_err(|_| anyhow!("get_all expected an array"))?;
+
+  let keys_len = keys.length() as usize;
+  let values_len = values.length() as usize;
+  let paired_len = keys_len.min(values_len);
+  if keys_len != values_len {
+    web_sys::console::warn_1(&JsValue::from_str(&format!(
+      "IndexedDB snapshot load for '{db_name}' returned mismatched key/value counts: keys={keys_len}, values={values_len}",
+    )));
+  }
+
+  let mut map = HashMap::with_capacity(paired_len);
+  for idx in 0..paired_len {
+    let key = keys.get(idx as u32);
+    let Some(name) = key.as_string() else {
       web_sys::console::warn_1(&JsValue::from_str(&format!(
-        "IndexedDB snapshot load for '{db_name}' expected array keys; skipping stored files"
+        "IndexedDB snapshot load for '{db_name}' skipped non-string key: {key:?}",
       )));
-      js_sys::Array::new()
-    }
-  };
-  let values: js_sys::Array = match values_val.dyn_into() {
-    Ok(array) => array,
-    Err(_) => {
-      web_sys::console::warn_1(&JsValue::from_str(&format!(
-        "IndexedDB snapshot load for '{db_name}' expected array values; skipping stored files"
-      )));
-      js_sys::Array::new()
-    }
-  };
-  let mut map = HashMap::new();
-  for (key, value) in keys.iter().zip(values.iter()) {
-    if let Some(name) = key.as_string() {
-      let bytes = js_sys::Uint8Array::new(&value).to_vec();
-      map.insert(PathBuf::from(name), bytes);
-    }
+      continue;
+    };
+    let value = values.get(idx as u32);
+    let bytes = js_sys::Uint8Array::new(&value).to_vec();
+    map.insert(PathBuf::from(name), bytes);
   }
   Ok(map)
 }
 
-async fn persist_file(db_name: &str, path: &Path, data: Vec<u8>) -> Result<()> {
-  let db = open_db(db_name).await?;
+async fn list_stored_paths(db_name: &str) -> Result<Vec<PathBuf>> {
+  let db = open_data_db(db_name).await?;
   let tx = db
-    .transaction_with_str_and_mode(STORE_NAME, web_sys::IdbTransactionMode::Readwrite)
-    .map_err(|e| anyhow!("opening read-write transaction for {STORE_NAME}: {:?}", e))?;
+    .transaction_with_str_and_mode(STORE_NAME, web_sys::IdbTransactionMode::Readonly)
+    .map_err(|e| anyhow!("opening transaction for {STORE_NAME}: {:?}", e))?;
+  let tx_done = transaction_future(&tx);
   let store = tx
     .object_store(STORE_NAME)
     .map_err(|e| anyhow!("opening object store {STORE_NAME}: {:?}", e))?;
-  let key = JsValue::from_str(&path_key(path));
-  let value: JsValue = js_sys::Uint8Array::from(data.as_slice()).into();
   let req = store
-    .put_with_key(&value, &key)
-    .map_err(|e| anyhow!("put_with_key failed: {:?}", e))?;
-  request_future(&req).await?;
-  Ok(())
+    .get_all_keys()
+    .map_err(|e| anyhow!("get_all_keys failed: {:?}", e))?;
+  let keys = request_future(&req).await?;
+  tx_done.await?;
+  let rows: js_sys::Array = keys
+    .dyn_into()
+    .map_err(|_| anyhow!("get_all_keys expected an array"))?;
+  let mut paths = Vec::with_capacity(rows.length() as usize);
+  for row in rows.iter() {
+    if let Some(name) = row.as_string() {
+      paths.push(PathBuf::from(name));
+    }
+  }
+  Ok(paths)
 }
 
-async fn delete_file(db_name: &str, path: &Path) -> Result<()> {
-  let db = open_db(db_name).await?;
-  let tx = db
-    .transaction_with_str_and_mode(STORE_NAME, web_sys::IdbTransactionMode::Readwrite)
-    .map_err(|e| anyhow!("opening read-write transaction for {STORE_NAME}: {:?}", e))?;
-  let store = tx
-    .object_store(STORE_NAME)
-    .map_err(|e| anyhow!("opening object store {STORE_NAME}: {:?}", e))?;
-  let key = JsValue::from_str(&path_key(path));
-  let req = store
-    .delete(&key)
-    .map_err(|e| anyhow!("delete failed: {:?}", e))?;
-  request_future(&req).await?;
+async fn restore_snapshot(db_name: &str, snapshot: &HashMap<PathBuf, Vec<u8>>) -> Result<()> {
+  clear_data_store(db_name).await?;
+  let mut operations: Vec<_> = snapshot
+    .iter()
+    .map(|(path, bytes)| (path.clone(), PersistOperation::Put(bytes.clone())))
+    .collect();
+  operations.sort_by(|(left, _), (right, _)| left.cmp(right));
+  for batch in chunk_operations(operations, IDB_WRITE_BATCH_SIZE) {
+    persist_operations_batch(db_name, &batch).await?;
+  }
   Ok(())
 }
 
@@ -330,13 +925,17 @@ async fn delete_file(db_name: &str, path: &Path) -> Result<()> {
 struct PendingWrites {
   db_name: String,
   pending: Arc<Mutex<Vec<oneshot::Receiver<Result<()>>>>>,
-  queue: Arc<Mutex<HashMap<PathBuf, PendingEntry>>>,
+  state: Arc<Mutex<PendingQueueState>>,
+}
+
+struct PendingQueueState {
+  queue: BTreeMap<PathBuf, PendingEntry>,
+  worker_running: bool,
 }
 
 struct PendingEntry {
-  pending: Option<Vec<u8>>,
+  operation: PersistOperation,
   waiters: Vec<oneshot::Sender<Result<()>>>,
-  inflight: bool,
 }
 
 impl PendingWrites {
@@ -344,46 +943,45 @@ impl PendingWrites {
     Self {
       db_name,
       pending: Arc::new(Mutex::new(Vec::new())),
-      queue: Arc::new(Mutex::new(HashMap::new())),
+      state: Arc::new(Mutex::new(PendingQueueState {
+        queue: BTreeMap::new(),
+        worker_running: false,
+      })),
     }
   }
 
   fn schedule(&self, path: PathBuf, data: Vec<u8>) {
-    let (tx, rx) = oneshot::channel();
-    self.pending.lock().push(rx);
-    let mut guard = self.queue.lock();
-    let entry = guard.entry(path.clone()).or_insert(PendingEntry {
-      pending: None,
-      waiters: Vec::new(),
-      inflight: false,
-    });
-    entry.pending = Some(data);
-    entry.waiters.push(tx);
-    if entry.inflight {
-      return;
-    }
-    entry.inflight = true;
-    drop(guard);
-    let db = self.db_name.clone();
-    let queue = self.queue.clone();
-    spawn_local(async move {
-      persist_queue(db, path, queue).await;
-    });
+    self.enqueue(path, PersistOperation::Put(data));
   }
 
   fn schedule_delete(&self, path: PathBuf) {
-    {
-      let mut guard = self.queue.lock();
-      guard.remove(&path);
+    self.enqueue(path, PersistOperation::Delete);
+  }
+
+  fn enqueue(&self, path: PathBuf, operation: PersistOperation) {
+    let (tx, rx) = oneshot::channel();
+    self.pending.lock().push(rx);
+    let mut guard = self.state.lock();
+    if let Some(entry) = guard.queue.get_mut(&path) {
+      entry.operation = operation;
+      entry.waiters.push(tx);
+    } else {
+      guard.queue.insert(
+        path,
+        PendingEntry {
+          operation,
+          waiters: vec![tx],
+        },
+      );
     }
-    let db = self.db_name.clone();
+    if guard.worker_running {
+      return;
+    }
+    guard.worker_running = true;
+    let db_name = self.db_name.clone();
+    let state = self.state.clone();
     spawn_local(async move {
-      if let Err(err) = delete_file(&db, &path).await {
-        web_sys::console::error_1(&JsValue::from_str(&format!(
-          "delete error for {:?}: {}",
-          path, err
-        )));
-      }
+      persist_queue_worker(db_name, state).await;
     });
   }
 
@@ -416,45 +1014,48 @@ impl PendingWrites {
   }
 }
 
-async fn persist_queue(
-  db_name: String,
-  path: PathBuf,
-  queue: Arc<Mutex<HashMap<PathBuf, PendingEntry>>>,
-) {
+async fn persist_queue_worker(db_name: String, state: Arc<Mutex<PendingQueueState>>) {
   loop {
-    let (data, waiters) = {
-      let mut guard = queue.lock();
-      let entry = match guard.get_mut(&path) {
-        Some(entry) => entry,
-        None => return,
-      };
-      let data = match entry.pending.take() {
-        Some(data) => data,
-        None => {
-          entry.inflight = false;
-          if entry.waiters.is_empty() {
-            guard.remove(&path);
-          }
-          return;
+    let batch_entries = {
+      let mut guard = state.lock();
+      if guard.queue.is_empty() {
+        guard.worker_running = false;
+        return;
+      }
+      let keys: Vec<PathBuf> = guard
+        .queue
+        .keys()
+        .take(IDB_WRITE_BATCH_SIZE)
+        .cloned()
+        .collect();
+      let mut entries = Vec::with_capacity(keys.len());
+      for key in keys {
+        if let Some(entry) = guard.queue.remove(&key) {
+          entries.push((key, entry));
         }
-      };
-      let waiters = std::mem::take(&mut entry.waiters);
-      (data, waiters)
+      }
+      entries
     };
-    let result = persist_file(&db_name, &path, data).await;
+
+    let mut operations = Vec::with_capacity(batch_entries.len());
+    let mut waiter_sets = Vec::with_capacity(batch_entries.len());
+    for (path, entry) in batch_entries {
+      operations.push((path, entry.operation));
+      waiter_sets.push(entry.waiters);
+    }
+    let result = persist_operations_batch(&db_name, &operations).await;
     let err_msg = result.as_ref().err().map(|err| err.to_string());
     if let Some(msg) = &err_msg {
-      web_sys::console::error_1(&JsValue::from_str(&format!(
-        "persist error for {:?}: {}",
-        path, msg
-      )));
+      web_sys::console::error_1(&JsValue::from_str(&format!("persist batch error: {msg}")));
     }
-    for tx in waiters {
-      let send_result = match &err_msg {
-        Some(msg) => Err(anyhow!(msg.clone())),
-        None => Ok(()),
-      };
-      let _ = tx.send(send_result);
+    for waiters in waiter_sets {
+      for tx in waiters {
+        let send_result = match &err_msg {
+          Some(msg) => Err(anyhow!(msg.clone())),
+          None => Ok(()),
+        };
+        let _ = tx.send(send_result);
+      }
     }
   }
 }
@@ -489,6 +1090,13 @@ impl JsStorage {
 
   fn schedule_persist(&self, path: PathBuf, data: Vec<u8>) {
     self.pending.schedule(path, data);
+  }
+
+  fn remove_cached_paths(&self, paths: &[PathBuf]) {
+    let mut guard = self.files.write();
+    for path in paths {
+      guard.remove(path);
+    }
   }
 
   pub async fn flush(&self) -> Result<()> {
@@ -697,8 +1305,260 @@ impl StorageFile for JsFile {
   }
 }
 
+fn meta_path(root: &Path) -> PathBuf {
+  root.join(META_FILE_NAME)
+}
+
+fn write_index_meta(storage: &dyn Storage, root: &Path, schema: &Schema) -> Result<(), JsValue> {
+  let meta = IndexMeta {
+    schema_version: SCHEMA_VERSION_V1,
+    schema_hash: schema_hash(schema)?,
+  };
+  let json = serde_json::to_vec(&meta).map_err(|err| typed_js_error("meta_encode_error", err))?;
+  storage
+    .write_all(&meta_path(root), &json)
+    .map_err(|err| typed_js_error("storage_write_error", err))
+}
+
+fn read_index_meta(storage: &dyn Storage, root: &Path) -> Result<Option<IndexMeta>, JsValue> {
+  let path = meta_path(root);
+  if !storage.exists(&path) {
+    return Ok(None);
+  }
+  let bytes = storage
+    .read_to_end(&path)
+    .map_err(|err| typed_js_error("storage_read_error", err))?;
+  let meta = serde_json::from_slice::<IndexMeta>(&bytes)
+    .map_err(|err| typed_js_error("meta_decode_error", err))?;
+  Ok(Some(meta))
+}
+
+fn schema_mismatch_error() -> JsValue {
+  js_error(
+    "schema_mismatch",
+    "schema mismatch for existing index; use Searchlite.plan_migration(...) and Searchlite.migrate_index(...), or clear/drop the index",
+  )
+}
+
+fn schemas_match(existing: &Schema, requested: &Schema) -> Result<bool, JsValue> {
+  serde_json::to_value(existing)
+    .and_then(|existing_json| {
+      serde_json::to_value(requested).map(|requested_json| existing_json == requested_json)
+    })
+    .map_err(|err| typed_js_error("schema_serialization_error", err))
+}
+
+fn open_opts(path: PathBuf) -> IndexOptions {
+  IndexOptions {
+    path,
+    create_if_missing: false,
+    enable_positions: true,
+    bm25_k1: BM25_K1,
+    bm25_b: BM25_B,
+    storage: StorageType::InMemory,
+    #[cfg(feature = "vectors")]
+    vector_defaults: None,
+  }
+}
+
+fn registry_entry(db_name: &str, schema: &Schema) -> Result<IndexRegistryEntry, JsValue> {
+  Ok(IndexRegistryEntry {
+    db_name: db_name.to_string(),
+    schema_version: SCHEMA_VERSION_V1,
+    schema_hash: schema_hash(schema)?,
+    updated_at_ms: now_ms(),
+  })
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct MigrationPlan {
+  db_name: String,
+  status: String,
+  rebuild_required: bool,
+  schema_version: u32,
+  existing_schema_hash: Option<String>,
+  requested_schema_hash: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct MigrationExecutionResult {
+  db_name: String,
+  status: String,
+  rebuild_performed: bool,
+  schema_version: u32,
+  existing_schema_hash: Option<String>,
+  requested_schema_hash: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct UpdateRequestPayload {
+  id: String,
+  #[serde(default)]
+  set: BTreeMap<String, serde_json::Value>,
+  #[serde(default)]
+  unset: Vec<String>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CompactResponse {
+  compacted: bool,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct InspectResponse {
+  manifest: Manifest,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct StatsResponse {
+  documents: u64,
+  deleted_documents: u64,
+  segments: usize,
+  committed_at: String,
+  index_uuid: String,
+  index_path: String,
+  index_name: String,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct StorageUsageResponse {
+  supported: bool,
+  usage_bytes: Option<u64>,
+  quota_bytes: Option<u64>,
+  remaining_bytes: Option<u64>,
+  persisted: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  note: Option<String>,
+}
+
+impl StorageUsageResponse {
+  fn unsupported(note: impl Into<String>) -> Self {
+    Self {
+      supported: false,
+      usage_bytes: None,
+      quota_bytes: None,
+      remaining_bytes: None,
+      persisted: None,
+      note: Some(note.into()),
+    }
+  }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CleanupIndexesResponse {
+  scanned: usize,
+  matched: usize,
+  dropped: Vec<String>,
+  kept: Vec<String>,
+  dry_run: bool,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct CleanupOrphanedFilesResponse {
+  scanned: usize,
+  orphaned: usize,
+  removed: Vec<String>,
+  dry_run: bool,
+}
+
+fn f64_to_u64_bytes(value: f64) -> Option<u64> {
+  if !value.is_finite() || value < 0.0 {
+    return None;
+  }
+  Some(value.floor() as u64)
+}
+
+async fn browser_storage_usage() -> Result<StorageUsageResponse, JsValue> {
+  let global = js_sys::global();
+  let navigator = js_sys::Reflect::get(&global, &JsValue::from_str("navigator"))
+    .ok()
+    .and_then(|value| value.dyn_into::<web_sys::Navigator>().ok());
+  let Some(navigator) = navigator else {
+    return Ok(StorageUsageResponse::unsupported(
+      "navigator is unavailable",
+    ));
+  };
+  let manager = navigator.storage();
+  let estimate_promise = match manager.estimate() {
+    Ok(promise) => promise,
+    Err(err) => {
+      return Ok(StorageUsageResponse::unsupported(format!(
+        "storage estimate unavailable: {err:?}"
+      )));
+    }
+  };
+  let estimate_value = match JsFuture::from(estimate_promise).await {
+    Ok(value) => value,
+    Err(err) => {
+      return Ok(StorageUsageResponse::unsupported(format!(
+        "storage estimate failed: {err:?}"
+      )));
+    }
+  };
+
+  let usage = js_sys::Reflect::get(&estimate_value, &JsValue::from_str("usage"))
+    .ok()
+    .and_then(|value| value.as_f64())
+    .and_then(f64_to_u64_bytes);
+  let quota = js_sys::Reflect::get(&estimate_value, &JsValue::from_str("quota"))
+    .ok()
+    .and_then(|value| value.as_f64())
+    .and_then(f64_to_u64_bytes);
+  let remaining = match (usage, quota) {
+    (Some(used), Some(limit)) => Some(limit.saturating_sub(used)),
+    _ => None,
+  };
+  let persisted = match manager.persisted() {
+    Ok(promise) => match JsFuture::from(promise).await {
+      Ok(value) => value.as_bool(),
+      Err(_) => None,
+    },
+    Err(_) => None,
+  };
+  Ok(StorageUsageResponse {
+    supported: true,
+    usage_bytes: usage,
+    quota_bytes: quota,
+    remaining_bytes: remaining,
+    persisted,
+    note: None,
+  })
+}
+
+fn expected_live_paths(root: &Path, manifest: &Manifest) -> (HashSet<PathBuf>, Vec<PathBuf>) {
+  let mut exact = HashSet::new();
+  exact.insert(Manifest::manifest_path(root));
+  exact.insert(meta_path(root));
+  exact.insert(root.join("wal.log"));
+  #[cfg(feature = "vectors")]
+  let mut prefixes = Vec::new();
+  #[cfg(not(feature = "vectors"))]
+  let prefixes: Vec<PathBuf> = Vec::new();
+  for seg in manifest.segments.iter() {
+    exact.insert(PathBuf::from(seg.paths.terms.clone()));
+    exact.insert(PathBuf::from(seg.paths.postings.clone()));
+    exact.insert(PathBuf::from(seg.paths.docstore.clone()));
+    exact.insert(PathBuf::from(seg.paths.fast.clone()));
+    exact.insert(PathBuf::from(seg.paths.meta.clone()));
+    #[cfg(feature = "vectors")]
+    if let Some(vector_dir) = seg.paths.vector_dir.as_ref() {
+      prefixes.push(PathBuf::from(vector_dir));
+    }
+  }
+  (exact, prefixes)
+}
+
+fn path_is_live(path: &Path, live_exact: &HashSet<PathBuf>, live_prefixes: &[PathBuf]) -> bool {
+  if live_exact.contains(path) {
+    return true;
+  }
+  live_prefixes.iter().any(|prefix| path.starts_with(prefix))
+}
+
 #[wasm_bindgen]
 pub struct Searchlite {
+  db_name: String,
+  schema_hash: String,
   index: Index,
   storage: StorageBackend,
 }
@@ -710,15 +1570,16 @@ impl Searchlite {
     schema_json: String,
     storage_mode: StorageMode,
   ) -> Result<Searchlite, JsValue> {
-    let schema: Schema =
-      serde_json::from_str(&schema_json).map_err(|err| JsValue::from_str(&err.to_string()))?;
+    let schema: Schema = serde_json::from_str(&schema_json)
+      .map_err(|err| typed_js_error("invalid_schema_json", err))?;
+    let requested_schema_hash = schema_hash(&schema)?;
     let root = PathBuf::from(db_name.clone());
     let (storage, backend) = match storage_mode {
       StorageMode::IndexedDb => {
         let storage = Arc::new(
           JsStorage::new(db_name.clone(), root.clone())
             .await
-            .map_err(to_js_error)?,
+            .map_err(|err| typed_js_error("storage_open_error", err))?,
         );
         (
           storage.clone() as Arc<dyn Storage>,
@@ -748,21 +1609,31 @@ impl Searchlite {
         create_if_missing: false,
         ..opts.clone()
       };
-      let index = Index::open_with_storage(open_opts, storage).map_err(to_js_error)?;
+      let index = Index::open_with_storage(open_opts, storage.clone())
+        .map_err(|err| typed_js_error("index_open_error", err))?;
       let existing_schema = index.manifest().schema;
-      let existing = serde_json::to_value(&existing_schema).map_err(to_js_error)?;
-      let requested = serde_json::to_value(&schema).map_err(to_js_error)?;
-      if existing != requested {
-        return Err(JsValue::from_str(
-          "schema mismatch for existing index; use a new db_name or delete the stored index",
-        ));
+      if !schemas_match(&existing_schema, &schema)? {
+        return Err(schema_mismatch_error());
       }
       index
     } else {
-      Index::create_with_storage(&root, schema, opts, storage).map_err(to_js_error)?
+      Index::create_with_storage(&root, schema.clone(), opts, storage.clone())
+        .map_err(|err| typed_js_error("index_create_error", err))?
     };
-    backend.flush().await.map_err(to_js_error)?;
+    write_index_meta(storage.as_ref(), &root, &schema)?;
+    if matches!(storage_mode, StorageMode::IndexedDb) {
+      let entry = registry_entry(&db_name, &schema)?;
+      upsert_registry_entry(&entry)
+        .await
+        .map_err(|err| typed_js_error("registry_write_error", err))?;
+    }
+    backend
+      .flush()
+      .await
+      .map_err(|err| map_storage_error(err, "storage_flush_error", "initializing index storage"))?;
     Ok(Searchlite {
+      db_name,
+      schema_hash: requested_schema_hash,
       index,
       storage: backend,
     })
@@ -783,6 +1654,314 @@ impl Searchlite {
     Self::create(db_name, schema_json, storage_mode).await
   }
 
+  #[wasm_bindgen(js_name = list_indexes)]
+  pub async fn list_indexes() -> Result<JsValue, JsValue> {
+    let entries = list_registry_entries()
+      .await
+      .map_err(|err| typed_js_error("registry_read_error", err))?;
+    serde_wasm_bindgen::to_value(&entries).map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  #[wasm_bindgen(js_name = clear_index)]
+  pub async fn clear_index(db_name: String) -> Result<(), JsValue> {
+    clear_data_store(&db_name)
+      .await
+      .map_err(|err| typed_js_error("storage_clear_error", err))?;
+    remove_registry_entry(&db_name)
+      .await
+      .map_err(|err| typed_js_error("registry_delete_error", err))?;
+    Ok(())
+  }
+
+  #[wasm_bindgen(js_name = drop_index)]
+  pub async fn drop_index(db_name: String) -> Result<(), JsValue> {
+    let _ = remove_registry_entry(&db_name).await;
+    delete_database(&db_name)
+      .await
+      .map_err(|err| typed_js_error("storage_delete_error", err))?;
+    Ok(())
+  }
+
+  #[wasm_bindgen(js_name = storage_usage)]
+  pub async fn storage_usage() -> Result<JsValue, JsValue> {
+    let usage = browser_storage_usage().await?;
+    serde_wasm_bindgen::to_value(&usage).map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  #[wasm_bindgen(js_name = cleanup_indexes)]
+  pub async fn cleanup_indexes(
+    stale_older_than_ms: f64,
+    dry_run: Option<bool>,
+  ) -> Result<JsValue, JsValue> {
+    if !stale_older_than_ms.is_finite() || stale_older_than_ms < 0.0 {
+      return Err(js_error(
+        "invalid_cleanup_request",
+        "stale_older_than_ms must be a non-negative number",
+      ));
+    }
+    let dry_run = dry_run.unwrap_or(false);
+    let now = now_ms();
+    let entries = list_registry_entries()
+      .await
+      .map_err(|err| typed_js_error("registry_read_error", err))?;
+    let scanned = entries.len();
+    let mut matched = 0usize;
+    let mut dropped = Vec::new();
+    let mut kept = Vec::new();
+    for entry in entries {
+      let age = if now >= entry.updated_at_ms {
+        now - entry.updated_at_ms
+      } else {
+        0.0
+      };
+      if age < stale_older_than_ms {
+        kept.push(entry.db_name);
+        continue;
+      }
+      matched += 1;
+      let db_name = entry.db_name.clone();
+      if !dry_run {
+        let _ = remove_registry_entry(&db_name).await;
+        delete_database(&db_name)
+          .await
+          .map_err(|err| typed_js_error("storage_delete_error", err))?;
+      }
+      dropped.push(db_name);
+    }
+    serde_wasm_bindgen::to_value(&CleanupIndexesResponse {
+      scanned,
+      matched,
+      dropped,
+      kept,
+      dry_run,
+    })
+    .map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  #[wasm_bindgen(js_name = cleanup_orphaned_files)]
+  pub async fn cleanup_orphaned_files(&self, dry_run: Option<bool>) -> Result<JsValue, JsValue> {
+    let dry_run = dry_run.unwrap_or(false);
+    let StorageBackend::IndexedDb(storage) = &self.storage else {
+      return serde_wasm_bindgen::to_value(&CleanupOrphanedFilesResponse {
+        scanned: 0,
+        orphaned: 0,
+        removed: Vec::new(),
+        dry_run,
+      })
+      .map_err(|err| typed_js_error("serialization_error", err));
+    };
+
+    let root = PathBuf::from(self.db_name.clone());
+    let manifest = self.index.manifest();
+    let (live_exact, live_prefixes) = expected_live_paths(&root, &manifest);
+    let mut stored_paths = list_stored_paths(&self.db_name)
+      .await
+      .map_err(|err| typed_js_error("storage_list_error", err))?;
+    stored_paths.sort();
+    stored_paths.dedup();
+    let scanned = stored_paths.len();
+    let orphaned_paths: Vec<PathBuf> = stored_paths
+      .into_iter()
+      .filter(|path| !path_is_live(path, &live_exact, &live_prefixes))
+      .collect();
+    if !dry_run && !orphaned_paths.is_empty() {
+      let operations: Vec<_> = orphaned_paths
+        .iter()
+        .cloned()
+        .map(|path| (path, PersistOperation::Delete))
+        .collect();
+      for batch in chunk_operations(operations, IDB_WRITE_BATCH_SIZE) {
+        persist_operations_batch(&self.db_name, &batch)
+          .await
+          .map_err(|err| {
+            map_storage_error(err, "storage_cleanup_error", "removing orphaned files")
+          })?;
+      }
+      storage.remove_cached_paths(&orphaned_paths);
+    }
+    let removed = orphaned_paths
+      .iter()
+      .map(|path| path_key(path))
+      .collect::<Vec<_>>();
+    serde_wasm_bindgen::to_value(&CleanupOrphanedFilesResponse {
+      scanned,
+      orphaned: removed.len(),
+      removed,
+      dry_run,
+    })
+    .map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  async fn plan_migration_internal(
+    db_name: &str,
+    requested_schema: &Schema,
+  ) -> Result<MigrationPlan, JsValue> {
+    let requested_schema_hash = schema_hash(requested_schema)?;
+    let root = PathBuf::from(db_name.to_string());
+    let storage = Arc::new(
+      JsStorage::new(db_name.to_string(), root.clone())
+        .await
+        .map_err(|err| typed_js_error("storage_open_error", err))?,
+    );
+    let manifest_path = root.join("MANIFEST.json");
+    if !storage.exists(&manifest_path) {
+      return Ok(MigrationPlan {
+        db_name: db_name.to_string(),
+        status: "missing".to_string(),
+        rebuild_required: false,
+        schema_version: SCHEMA_VERSION_V1,
+        existing_schema_hash: None,
+        requested_schema_hash,
+      });
+    }
+
+    let index = Index::open_with_storage(open_opts(root.clone()), storage.clone())
+      .map_err(|err| typed_js_error("index_open_error", err))?;
+    let existing_schema = index.manifest().schema;
+    let existing_schema_hash = match read_index_meta(storage.as_ref(), &root)? {
+      Some(meta) => meta.schema_hash,
+      None => schema_hash(&existing_schema)?,
+    };
+    let compatible = schemas_match(&existing_schema, requested_schema)?;
+    Ok(MigrationPlan {
+      db_name: db_name.to_string(),
+      status: if compatible {
+        "compatible".to_string()
+      } else {
+        "rebuild_required".to_string()
+      },
+      rebuild_required: !compatible,
+      schema_version: SCHEMA_VERSION_V1,
+      existing_schema_hash: Some(existing_schema_hash),
+      requested_schema_hash,
+    })
+  }
+
+  #[wasm_bindgen(js_name = plan_migration)]
+  pub async fn plan_migration(db_name: String, schema_json: String) -> Result<JsValue, JsValue> {
+    let requested_schema: Schema = serde_json::from_str(&schema_json)
+      .map_err(|err| typed_js_error("invalid_schema_json", err))?;
+    let plan = Self::plan_migration_internal(&db_name, &requested_schema).await?;
+    serde_wasm_bindgen::to_value(&plan).map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  #[wasm_bindgen(js_name = migrate_index)]
+  pub async fn migrate_index(db_name: String, schema_json: String) -> Result<JsValue, JsValue> {
+    let requested_schema: Schema = serde_json::from_str(&schema_json)
+      .map_err(|err| typed_js_error("invalid_schema_json", err))?;
+    let plan = Self::plan_migration_internal(&db_name, &requested_schema).await?;
+    let requested_schema_hash = plan.requested_schema_hash.clone();
+    let existing_schema_hash = plan.existing_schema_hash.clone();
+
+    if plan.status == "missing" {
+      let created = Self::create(db_name.clone(), schema_json, StorageMode::IndexedDb).await?;
+      created.commit().await?;
+      let result = MigrationExecutionResult {
+        db_name,
+        status: "created".to_string(),
+        rebuild_performed: false,
+        schema_version: SCHEMA_VERSION_V1,
+        existing_schema_hash: None,
+        requested_schema_hash,
+      };
+      return serde_wasm_bindgen::to_value(&result)
+        .map_err(|err| typed_js_error("serialization_error", err));
+    }
+
+    if !plan.rebuild_required {
+      let result = MigrationExecutionResult {
+        db_name,
+        status: "compatible".to_string(),
+        rebuild_performed: false,
+        schema_version: SCHEMA_VERSION_V1,
+        existing_schema_hash,
+        requested_schema_hash,
+      };
+      return serde_wasm_bindgen::to_value(&result)
+        .map_err(|err| typed_js_error("serialization_error", err));
+    }
+
+    let snapshot = load_snapshot(&db_name)
+      .await
+      .map_err(|err| typed_js_error("storage_snapshot_error", err))?;
+    let previous_registry = get_registry_entry(&db_name)
+      .await
+      .map_err(|err| typed_js_error("registry_read_error", err))?;
+    clear_data_store(&db_name)
+      .await
+      .map_err(|err| typed_js_error("storage_clear_error", err))?;
+
+    let rebuild_attempt = async {
+      if migration_fail_after_clear() {
+        return Err(js_error(
+          "migration_injected_failure",
+          "injected migration failure after clear for rollback testing",
+        ));
+      }
+      let migrated =
+        Self::create(db_name.clone(), schema_json.clone(), StorageMode::IndexedDb).await?;
+      migrated.commit().await?;
+      Ok::<(), JsValue>(())
+    }
+    .await;
+
+    match rebuild_attempt {
+      Ok(()) => {
+        let result = MigrationExecutionResult {
+          db_name,
+          status: "rebuilt".to_string(),
+          rebuild_performed: true,
+          schema_version: SCHEMA_VERSION_V1,
+          existing_schema_hash,
+          requested_schema_hash,
+        };
+        serde_wasm_bindgen::to_value(&result)
+          .map_err(|err| typed_js_error("serialization_error", err))
+      }
+      Err(rebuild_err) => {
+        let snapshot_restore_err = restore_snapshot(&db_name, &snapshot).await.err();
+        let registry_restore_err = restore_registry_entry(&db_name, previous_registry.as_ref())
+          .await
+          .err();
+        if snapshot_restore_err.is_none() && registry_restore_err.is_none() {
+          return Err(js_error(
+            "migration_rebuild_failed",
+            format!(
+              "migration rebuild failed but prior snapshot was restored: {}",
+              js_error_reason(&rebuild_err)
+            ),
+          ));
+        }
+        let mut reason = format!(
+          "migration rebuild failed and rollback was incomplete: {}",
+          js_error_reason(&rebuild_err)
+        );
+        if let Some(err) = snapshot_restore_err {
+          reason.push_str(&format!("; snapshot restore failed: {err}"));
+        }
+        if let Some(err) = registry_restore_err {
+          reason.push_str(&format!("; registry restore failed: {err}"));
+        }
+        Err(js_error("migration_rollback_failed", reason))
+      }
+    }
+  }
+
+  async fn touch_registry(&self) -> Result<(), JsValue> {
+    if !matches!(self.storage, StorageBackend::IndexedDb(_)) {
+      return Ok(());
+    }
+    let entry = IndexRegistryEntry {
+      db_name: self.db_name.clone(),
+      schema_version: SCHEMA_VERSION_V1,
+      schema_hash: self.schema_hash.clone(),
+      updated_at_ms: now_ms(),
+    };
+    upsert_registry_entry(&entry)
+      .await
+      .map_err(|err| typed_js_error("registry_write_error", err))
+  }
+
   /// Initialize the rayon pool for threaded execution. COOP/COEP (cross-origin isolation) must
   /// be handled by the embedding app; this helper does not set headers for you.
   #[cfg(feature = "threads")]
@@ -791,13 +1970,14 @@ impl Searchlite {
     JsFuture::from(init_thread_pool(desired as usize))
       .await
       .map(|_| ())
-      .map_err(|err| JsValue::from_str(&format!("{err:?}")))
+      .map_err(|err| typed_js_error("thread_pool_init_error", format!("{err:?}")))
   }
 
   /// Threaded mode is disabled unless the `threads` feature is enabled.
   #[cfg(not(feature = "threads"))]
   pub async fn init_threads(&self, _threads: Option<u32>) -> Result<(), JsValue> {
-    Err(JsValue::from_str(
+    Err(js_error(
+      "threads_feature_disabled",
       "threads feature is disabled; rebuild searchlite-wasm with --features threads and enable wasm atomics/COOP+COEP",
     ))
   }
@@ -810,26 +1990,154 @@ impl Searchlite {
     Ok(())
   }
 
+  fn delete_documents_internal(&self, doc_ids: Vec<String>) -> Result<(), JsValue> {
+    let mut writer: IndexWriter = self.index.writer().map_err(to_js_error)?;
+    writer.delete_documents(&doc_ids).map_err(to_js_error)?;
+    Ok(())
+  }
+
   /// Add a document to the index. Call `commit` to make it searchable and persist it.
   pub fn add_document(&self, doc: JsValue) -> Result<(), JsValue> {
     let value: serde_json::Value =
-      serde_wasm_bindgen::from_value(doc).map_err(|err| JsValue::from_str(&err.to_string()))?;
+      serde_wasm_bindgen::from_value(doc).map_err(|err| typed_js_error("invalid_json", err))?;
     self.add_documents_internal(vec![value_to_document(value)?])
   }
 
   /// Add multiple documents to the index. Call `commit` to persist changes.
   pub fn add_documents(&self, docs: JsValue) -> Result<(), JsValue> {
     let value: serde_json::Value =
-      serde_wasm_bindgen::from_value(docs).map_err(|err| JsValue::from_str(&err.to_string()))?;
+      serde_wasm_bindgen::from_value(docs).map_err(|err| typed_js_error("invalid_json", err))?;
     self.add_documents_internal(value_to_documents(value)?)
+  }
+
+  /// Queue deletion for a single `_id`/doc id. Call `commit` to persist removal.
+  pub fn delete_document(&self, doc_id: String) -> Result<(), JsValue> {
+    self.delete_documents_internal(vec![doc_id])
+  }
+
+  /// Queue deletions for one or more doc ids. Accepts a string or array of strings.
+  /// Call `commit` to persist removals.
+  pub fn delete_documents(&self, doc_ids: JsValue) -> Result<(), JsValue> {
+    let value: serde_json::Value = serde_wasm_bindgen::from_value(doc_ids)
+      .map_err(|err| typed_js_error("invalid_doc_id_batch", err))?;
+    self.delete_documents_internal(value_to_doc_ids(value)?)
+  }
+
+  /// Queue a partial document update by id using set/unset patch semantics.
+  /// `request` shape: `{ id: string, set?: object, unset?: string[] }`.
+  pub fn update_document(&self, request: JsValue) -> Result<(), JsValue> {
+    let payload: UpdateRequestPayload = parse_request_value(request, "invalid_update_request")?;
+    if payload.set.is_empty() && payload.unset.is_empty() {
+      return Err(js_error(
+        "missing_patch",
+        "update must include at least one set or unset field",
+      ));
+    }
+    validate_doc_id(&payload.id)
+      .map_err(|err| js_error("invalid_id", format!("invalid document id: {err}")))?;
+    let mut writer = self
+      .index
+      .writer()
+      .map_err(|err| typed_js_error("writer_open_error", err))?;
+    writer
+      .apply_patch(&payload.id, &payload.set, &payload.unset)
+      .map_err(map_update_error)?;
+    Ok(())
   }
 
   /// Commit pending documents and flush the configured storage backend.
   pub async fn commit(&self) -> Result<(), JsValue> {
     let mut writer: IndexWriter = self.index.writer().map_err(to_js_error)?;
     writer.commit().map_err(to_js_error)?;
-    self.storage.flush().await.map_err(to_js_error)?;
+    self
+      .storage
+      .flush()
+      .await
+      .map_err(|err| map_storage_error(err, "storage_flush_error", "committing index data"))?;
+    self.touch_registry().await?;
     Ok(())
+  }
+
+  /// Compact segments to reduce fragmentation.
+  /// Returns `{ compacted: boolean }`, where `false` means no merge was needed.
+  pub async fn compact(&self) -> Result<JsValue, JsValue> {
+    let before = self.index.manifest().segments.len();
+    self
+      .index
+      .compact()
+      .map_err(|err| typed_js_error("compact_failed", err))?;
+    self
+      .storage
+      .flush()
+      .await
+      .map_err(|err| map_storage_error(err, "storage_flush_error", "compacting index data"))?;
+    self.touch_registry().await?;
+    let after = self.index.manifest().segments.len();
+    serde_wasm_bindgen::to_value(&CompactResponse {
+      compacted: after < before,
+    })
+    .map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  /// Return the current manifest with write-key metadata redacted.
+  pub fn inspect(&self) -> Result<JsValue, JsValue> {
+    let mut manifest = self.index.manifest();
+    manifest.write_key = None;
+    for seg in manifest.segments.iter_mut() {
+      seg.write_binding_b64 = None;
+    }
+    serde_wasm_bindgen::to_value(&InspectResponse { manifest })
+      .map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  /// Return high-level index statistics.
+  pub fn stats(&self) -> Result<JsValue, JsValue> {
+    let manifest = self.index.manifest();
+    let (live_docs, deleted_docs) = manifest_doc_counts(&manifest);
+    serde_wasm_bindgen::to_value(&StatsResponse {
+      documents: live_docs,
+      deleted_documents: deleted_docs,
+      segments: manifest.segments.len(),
+      committed_at: manifest.committed_at.clone(),
+      index_uuid: manifest.uuid.to_string(),
+      index_path: self.db_name.clone(),
+      index_name: self.db_name.clone(),
+    })
+    .map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  /// Fetch documents by id with optional stored fields, preserving request order.
+  /// `request` shape: `{ ids: string[], return_stored?: boolean }`.
+  pub fn mget(&self, request: JsValue) -> Result<JsValue, JsValue> {
+    let req: MgetRequest = parse_request_value(request, "invalid_mget_request")?;
+    for id in req.ids.iter() {
+      validate_doc_id(id)
+        .map_err(|err| js_error("invalid_id", format!("invalid document id: {err}")))?;
+    }
+    let reader: IndexReader = self
+      .index
+      .reader()
+      .map_err(|err| typed_js_error("reader_open_error", err))?;
+    let docs = reader
+      .mget(&req.ids, req.return_stored)
+      .map_err(|err| typed_js_error("mget_failed", err))?;
+    serde_wasm_bindgen::to_value(&MgetResponse { docs })
+      .map_err(|err| typed_js_error("serialization_error", err))
+  }
+
+  /// Execute multiple search requests in order and return ordered results.
+  /// `request` shape: `{ searches: SearchRequest[], parallel?: boolean, max_concurrency?: number }`.
+  pub fn multi_search(&self, request: JsValue) -> Result<JsValue, JsValue> {
+    let req: MultiSearchRequest = parse_request_value(request, "invalid_multi_search_request")?;
+    let reader: IndexReader = self
+      .index
+      .reader()
+      .map_err(|err| typed_js_error("reader_open_error", err))?;
+    let results = reader
+      .multi_search(&req.searches)
+      .map_err(|err| typed_js_error("multi_search_failed", err))?;
+    serde_wasm_bindgen::to_value(&MultiSearchResponse { results })
+      .map_err(|err| typed_js_error("serialization_error", err))
   }
 
   pub fn search(
@@ -857,6 +2165,7 @@ impl Searchlite {
       execution: ExecutionStrategy::Wand,
       bmw_block_size: None,
       fuzzy: None,
+      track_total_hits: None,
       #[cfg(feature = "vectors")]
       vector_query: None,
 
@@ -875,27 +2184,125 @@ impl Searchlite {
     self.run_search(request)
   }
 
+  #[wasm_bindgen(js_name = search_controlled)]
+  pub fn search_controlled(
+    &self,
+    query: String,
+    limit: usize,
+    return_stored: Option<bool>,
+    abort_signal: Option<web_sys::AbortSignal>,
+    timeout_ms: Option<f64>,
+  ) -> Result<JsValue, JsValue> {
+    let parsed_query = serde_json::from_str::<QueryNode>(&query)
+      .map(Query::Node)
+      .unwrap_or(Query::String(query));
+    let request = SearchRequest {
+      query: parsed_query,
+      fields: None,
+      filter: None,
+      limit,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::<SortSpec>::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: return_stored.unwrap_or(false),
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs: BTreeMap::<String, Aggregation>::new(),
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    };
+    self.run_search_controlled(request, abort_signal, timeout_ms)
+  }
+
   pub fn search_request(&self, request_json: String) -> Result<JsValue, JsValue> {
     let req: SearchRequest = serde_json::from_str(&request_json)
-      .map_err(|err| JsValue::from_str(&format!("invalid search request: {err}")))?;
+      .map_err(|err| typed_js_error("invalid_search_request", err))?;
     self.run_search(req)
+  }
+
+  #[wasm_bindgen(js_name = search_request_controlled)]
+  pub fn search_request_controlled(
+    &self,
+    request_json: String,
+    abort_signal: Option<web_sys::AbortSignal>,
+    timeout_ms: Option<f64>,
+  ) -> Result<JsValue, JsValue> {
+    let req: SearchRequest = serde_json::from_str(&request_json)
+      .map_err(|err| typed_js_error("invalid_search_request", err))?;
+    self.run_search_controlled(req, abort_signal, timeout_ms)
   }
 
   pub fn search_request_value(&self, request: JsValue) -> Result<JsValue, JsValue> {
-    let req: SearchRequest = serde_wasm_bindgen::from_value(request)
-      .map_err(|err| JsValue::from_str(&format!("invalid search request: {err}")))?;
+    let req: SearchRequest = parse_request_value(request, "invalid_search_request")?;
     self.run_search(req)
   }
 
+  #[wasm_bindgen(js_name = search_request_value_controlled)]
+  pub fn search_request_value_controlled(
+    &self,
+    request: JsValue,
+    abort_signal: Option<web_sys::AbortSignal>,
+    timeout_ms: Option<f64>,
+  ) -> Result<JsValue, JsValue> {
+    let req: SearchRequest = parse_request_value(request, "invalid_search_request")?;
+    self.run_search_controlled(req, abort_signal, timeout_ms)
+  }
+
+  /// Worker-oriented async search entrypoint with optional timeout/abort checks.
+  #[wasm_bindgen(js_name = search_request_value_async)]
+  pub async fn search_request_value_async(
+    &self,
+    request: JsValue,
+    abort_signal: Option<web_sys::AbortSignal>,
+    timeout_ms: Option<f64>,
+  ) -> Result<JsValue, JsValue> {
+    self.search_request_value_controlled(request, abort_signal, timeout_ms)
+  }
+
   fn run_search(&self, req: SearchRequest) -> Result<JsValue, JsValue> {
+    self.run_search_controlled(req, None, None)
+  }
+
+  fn run_search_controlled(
+    &self,
+    req: SearchRequest,
+    abort_signal: Option<web_sys::AbortSignal>,
+    timeout_ms: Option<f64>,
+  ) -> Result<JsValue, JsValue> {
+    let timeout_ms = parse_timeout_ms(timeout_ms)?;
+    let started_ms = now_ms();
+    ensure_not_aborted(abort_signal.as_ref())?;
+    ensure_not_timed_out(started_ms, timeout_ms)?;
     let reader: IndexReader = self.index.reader().map_err(to_js_error)?;
     let result = reader.search(&req).map_err(to_js_error)?;
-    serde_wasm_bindgen::to_value(&result).map_err(|err| JsValue::from_str(&err.to_string()))
+    ensure_not_aborted(abort_signal.as_ref())?;
+    ensure_not_timed_out(started_ms, timeout_ms)?;
+    serde_wasm_bindgen::to_value(&result).map_err(|err| typed_js_error("serialization_error", err))
   }
 
   /// Wait for pending storage writes; `commit` already calls this.
   pub async fn flush_storage(&self) -> Result<(), JsValue> {
-    self.storage.flush().await.map_err(to_js_error)?;
+    self
+      .storage
+      .flush()
+      .await
+      .map_err(|err| map_storage_error(err, "storage_flush_error", "flushing storage"))?;
     Ok(())
   }
 }
@@ -904,6 +2311,7 @@ impl Searchlite {
 mod tests {
   use super::*;
   use searchlite_core::api::types::ExecutionStrategy;
+  use std::cell::Cell;
   use std::io::{Read, Seek, SeekFrom, Write};
   use wasm_bindgen_test::*;
 
@@ -911,6 +2319,225 @@ mod tests {
 
   fn unique_db(name: &str) -> String {
     format!("{name}-{}", js_sys::Date::now() as u64)
+  }
+
+  fn set_timeout_once(ms: i32, callback: impl FnOnce() + 'static) {
+    let cb = Closure::once(callback);
+    web_sys::window()
+      .unwrap()
+      .set_timeout_with_callback_and_timeout_and_arguments_0(cb.as_ref().unchecked_ref(), ms)
+      .unwrap();
+    cb.forget();
+  }
+
+  async fn fetch_ok(path: &str) -> bool {
+    let Some(window) = web_sys::window() else {
+      return false;
+    };
+    let response = match JsFuture::from(window.fetch_with_str(path)).await {
+      Ok(response) => response,
+      Err(_) => return false,
+    };
+    js_sys::Reflect::get(&response, &JsValue::from_str("ok"))
+      .ok()
+      .and_then(|value| value.as_bool())
+      .unwrap_or(false)
+  }
+
+  async fn demo_worker_assets_available() -> bool {
+    fetch_ok("./searchlite-demo-worker.mjs").await
+      && fetch_ok("./searchlite-worker-client.mjs").await
+      && fetch_ok("./pkg/searchlite_wasm.js").await
+  }
+
+  fn js_error_type(err: &JsValue) -> Option<String> {
+    js_sys::Reflect::get(err, &JsValue::from_str("type"))
+      .ok()
+      .and_then(|value| value.as_string())
+  }
+
+  fn skip_if_worker_runtime_unavailable(err: &JsValue) -> bool {
+    matches!(
+      js_error_type(err).as_deref(),
+      Some("worker_error")
+        | Some("worker_spawn_error")
+        | Some("worker_module_import_error")
+        | Some("worker_client_init_error")
+    )
+  }
+
+  async fn new_worker_client_instance() -> Result<JsValue, JsValue> {
+    let module_url = js_sys::eval(
+      "new URL('./searchlite-worker-client.mjs', (self.location && self.location.href) || 'http://localhost/').href",
+    )
+    .ok()
+    .and_then(|value| value.as_string())
+    .unwrap_or_else(|| "./searchlite-worker-client.mjs".to_string());
+    let import_expr = format!(
+      "import({})",
+      serde_json::to_string(&module_url)
+        .unwrap_or_else(|_| "'./searchlite-worker-client.mjs'".into())
+    );
+    let module_promise = js_sys::eval(&import_expr)
+      .map_err(|err| js_error("worker_module_import_error", format!("{err:?}")))?
+      .dyn_into::<js_sys::Promise>()
+      .map_err(|_| {
+        js_error(
+          "worker_module_import_error",
+          "import did not return a Promise",
+        )
+      })?;
+    let module = JsFuture::from(module_promise)
+      .await
+      .map_err(|err| js_error("worker_module_import_error", format!("{err:?}")))?;
+    let ctor = js_sys::Reflect::get(&module, &JsValue::from_str("SearchliteWorkerClient"))?
+      .dyn_into::<js_sys::Function>()
+      .map_err(|_| {
+        js_error(
+          "worker_module_import_error",
+          "SearchliteWorkerClient export missing",
+        )
+      })?;
+    js_sys::Reflect::construct(&ctor, &js_sys::Array::new())
+      .map_err(|err| js_error("worker_client_init_error", format!("{err:?}")))
+  }
+
+  fn call_worker_client_method(
+    client: &JsValue,
+    method: &str,
+    args: &js_sys::Array,
+  ) -> Result<js_sys::Promise, JsValue> {
+    let method_fn = js_sys::Reflect::get(client, &JsValue::from_str(method))?
+      .dyn_into::<js_sys::Function>()
+      .map_err(|_| {
+        js_error(
+          "worker_client_method_error",
+          format!("missing method {method}"),
+        )
+      })?;
+    let value = method_fn.apply(client, args)?;
+    value.dyn_into::<js_sys::Promise>().map_err(|_| {
+      js_error(
+        "worker_client_method_error",
+        format!("method {method} did not return a Promise"),
+      )
+    })
+  }
+
+  fn spawn_demo_worker() -> Result<web_sys::Worker, JsValue> {
+    let worker_js = js_sys::eval("new Worker('./searchlite-demo-worker.mjs', { type: 'module' })")
+      .map_err(|err| js_error("worker_spawn_error", format!("{err:?}")))?;
+    worker_js
+      .dyn_into::<web_sys::Worker>()
+      .map_err(|_| js_error("worker_spawn_error", "failed to cast JS worker"))
+  }
+
+  async fn worker_call(
+    worker: &web_sys::Worker,
+    id: u32,
+    action: &str,
+    payload: JsValue,
+  ) -> Result<JsValue, JsValue> {
+    let (tx, rx) = oneshot::channel::<Result<JsValue, JsValue>>();
+    let tx = Rc::new(RefCell::new(Some(tx)));
+
+    let message_tx = tx.clone();
+    let message_worker = worker.clone();
+    let onmessage =
+      Closure::<dyn FnMut(web_sys::MessageEvent)>::new(move |event: web_sys::MessageEvent| {
+        let data = event.data();
+        let msg_id = js_sys::Reflect::get(&data, &JsValue::from_str("id"))
+          .ok()
+          .and_then(|raw| raw.as_f64())
+          .map(|raw| raw as u32);
+        if msg_id != Some(id) {
+          return;
+        }
+        let ok = js_sys::Reflect::get(&data, &JsValue::from_str("ok"))
+          .ok()
+          .and_then(|raw| raw.as_bool())
+          .unwrap_or(false);
+        let key = if ok { "payload" } else { "error" };
+        let value = js_sys::Reflect::get(&data, &JsValue::from_str(key)).unwrap_or(JsValue::NULL);
+        if let Some(sender) = message_tx.borrow_mut().take() {
+          let _ = sender.send(if ok { Ok(value) } else { Err(value) });
+        }
+        message_worker.set_onmessage(None);
+        message_worker.set_onerror(None);
+      });
+
+    let error_tx = tx.clone();
+    let error_worker = worker.clone();
+    let onerror = Closure::<dyn FnMut(web_sys::Event)>::new(move |event: web_sys::Event| {
+      let reason = js_sys::Reflect::get(event.as_ref(), &JsValue::from_str("message"))
+        .ok()
+        .and_then(|raw| raw.as_string())
+        .unwrap_or_else(|| "worker runtime error".to_string());
+      if let Some(sender) = error_tx.borrow_mut().take() {
+        let _ = sender.send(Err(js_error("worker_error", reason)));
+      }
+      error_worker.set_onmessage(None);
+      error_worker.set_onerror(None);
+    });
+
+    worker.set_onmessage(Some(onmessage.as_ref().unchecked_ref()));
+    worker.set_onerror(Some(onerror.as_ref().unchecked_ref()));
+    onmessage.forget();
+    onerror.forget();
+
+    let msg = js_sys::Object::new();
+    js_sys::Reflect::set(
+      &msg,
+      &JsValue::from_str("id"),
+      &JsValue::from_f64(f64::from(id)),
+    )
+    .unwrap();
+    js_sys::Reflect::set(
+      &msg,
+      &JsValue::from_str("action"),
+      &JsValue::from_str(action),
+    )
+    .unwrap();
+    js_sys::Reflect::set(&msg, &JsValue::from_str("payload"), &payload).unwrap();
+    worker.post_message(&msg)?;
+
+    match rx.await {
+      Ok(result) => result,
+      Err(_) => Err(js_error(
+        "worker_channel_closed",
+        "worker response channel closed",
+      )),
+    }
+  }
+
+  struct MigrationFailureGuard;
+
+  impl MigrationFailureGuard {
+    fn enable() -> Self {
+      set_migration_fail_after_clear(true);
+      Self
+    }
+  }
+
+  impl Drop for MigrationFailureGuard {
+    fn drop(&mut self) {
+      set_migration_fail_after_clear(false);
+    }
+  }
+
+  struct PersistQuotaFailureGuard;
+
+  impl PersistQuotaFailureGuard {
+    fn enable() -> Self {
+      set_force_persist_quota_exceeded(true);
+      Self
+    }
+  }
+
+  impl Drop for PersistQuotaFailureGuard {
+    fn drop(&mut self) {
+      set_force_persist_quota_exceeded(false);
+    }
   }
 
   #[wasm_bindgen_test]
@@ -925,6 +2552,27 @@ mod tests {
     let restored = JsStorage::new(db, root.clone()).await.unwrap();
     let contents = restored.read_to_end(&path).unwrap();
     assert_eq!(contents, b"hello wasm");
+  }
+
+  #[wasm_bindgen_test]
+  fn schema_hash_is_deterministic() {
+    let schema = Schema::default_text_body();
+    let hash_a = schema_hash(&schema).unwrap();
+    let hash_b = schema_hash(&schema).unwrap();
+    assert_eq!(hash_a, hash_b);
+
+    let mut schema_v2 = Schema::default_text_body();
+    schema_v2
+      .keyword_fields
+      .push(searchlite_core::api::types::KeywordField {
+        name: "category".to_string(),
+        stored: true,
+        indexed: true,
+        fast: true,
+        nullable: false,
+      });
+    let hash_c = schema_hash(&schema_v2).unwrap();
+    assert_ne!(hash_a, hash_c);
   }
 
   #[wasm_bindgen_test]
@@ -966,6 +2614,38 @@ mod tests {
     storage.flush().await.unwrap();
     let contents = storage.read_to_end(&atomic_path).unwrap();
     assert_eq!(contents, b"atomic");
+  }
+
+  #[wasm_bindgen_test]
+  async fn js_storage_flush_batches_indexeddb_transactions() {
+    let db = unique_db("searchlite-storage-batch");
+    let root = PathBuf::from("idx-batch");
+    reset_persist_batch_tx_count();
+    let storage = JsStorage::new(db.clone(), root.clone()).await.unwrap();
+    for idx in 0..12 {
+      let path = root.join(format!("file-{idx}.bin"));
+      let payload = format!("payload-{idx}");
+      storage.write_all(&path, payload.as_bytes()).unwrap();
+    }
+    storage.flush().await.unwrap();
+    assert_eq!(persist_batch_tx_count(), 1);
+    Searchlite::drop_index(db).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn js_storage_flush_waits_for_deletes() {
+    let db = unique_db("searchlite-storage-delete-flush");
+    let root = PathBuf::from("idx-delete");
+    let storage = JsStorage::new(db.clone(), root.clone()).await.unwrap();
+    let path = root.join("remove-me.bin");
+    storage.write_all(&path, b"delete me").unwrap();
+    storage.flush().await.unwrap();
+    storage.remove(&path).unwrap();
+    storage.flush().await.unwrap();
+    drop(storage);
+    let restored = JsStorage::new(db.clone(), root.clone()).await.unwrap();
+    assert!(!restored.exists(&path));
+    Searchlite::drop_index(db).await.unwrap();
   }
 
   #[wasm_bindgen_test]
@@ -1037,6 +2717,7 @@ mod tests {
       execution: ExecutionStrategy::Wand,
       bmw_block_size: None,
       fuzzy: None,
+      track_total_hits: None,
       #[cfg(feature = "vectors")]
       vector_query: None,
 
@@ -1083,6 +2764,7 @@ mod tests {
       execution: ExecutionStrategy::Wand,
       bmw_block_size: None,
       fuzzy: None,
+      track_total_hits: None,
       #[cfg(feature = "vectors")]
       vector_query: None,
 
@@ -1103,6 +2785,484 @@ mod tests {
     let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
     let hits = result_json["hits"].as_array().unwrap();
     assert_eq!(hits.len(), 1);
+  }
+
+  #[wasm_bindgen_test]
+  async fn delete_document_roundtrip() {
+    let db = unique_db("searchlite-delete-document");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![
+      serde_json::json!({ "_id": "doc-1", "body": "alpha token" }),
+      serde_json::json!({ "_id": "doc-2", "body": "beta token" }),
+    ];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    idx.delete_document("doc-1".to_string()).unwrap();
+    idx.commit().await.unwrap();
+
+    let deleted = idx.search("alpha".to_string(), 5, Some(true)).unwrap();
+    let deleted_json: serde_json::Value = serde_wasm_bindgen::from_value(deleted).unwrap();
+    assert_eq!(deleted_json["hits"].as_array().unwrap().len(), 0);
+
+    let retained = idx.search("beta".to_string(), 5, Some(true)).unwrap();
+    let retained_json: serde_json::Value = serde_wasm_bindgen::from_value(retained).unwrap();
+    assert_eq!(retained_json["hits"].as_array().unwrap().len(), 1);
+  }
+
+  #[wasm_bindgen_test]
+  async fn delete_documents_roundtrip() {
+    let db = unique_db("searchlite-delete-documents");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![
+      serde_json::json!({ "_id": "doc-1", "body": "alpha token" }),
+      serde_json::json!({ "_id": "doc-2", "body": "beta token" }),
+      serde_json::json!({ "_id": "doc-3", "body": "gamma token" }),
+    ];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let ids = vec!["doc-1", "doc-3"];
+    idx
+      .delete_documents(serde_wasm_bindgen::to_value(&ids).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let alpha = idx.search("alpha".to_string(), 5, Some(true)).unwrap();
+    let alpha_json: serde_json::Value = serde_wasm_bindgen::from_value(alpha).unwrap();
+    assert_eq!(alpha_json["hits"].as_array().unwrap().len(), 0);
+
+    let gamma = idx.search("gamma".to_string(), 5, Some(true)).unwrap();
+    let gamma_json: serde_json::Value = serde_wasm_bindgen::from_value(gamma).unwrap();
+    assert_eq!(gamma_json["hits"].as_array().unwrap().len(), 0);
+
+    let beta = idx.search("beta".to_string(), 5, Some(true)).unwrap();
+    let beta_json: serde_json::Value = serde_wasm_bindgen::from_value(beta).unwrap();
+    assert_eq!(beta_json["hits"].as_array().unwrap().len(), 1);
+  }
+
+  #[wasm_bindgen_test]
+  async fn delete_documents_rejects_non_string_ids() {
+    let db = unique_db("searchlite-delete-invalid");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+
+    let invalid = serde_json::json!(["doc-1", 42]);
+    let err = idx
+      .delete_documents(serde_wasm_bindgen::to_value(&invalid).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_doc_id_batch");
+  }
+
+  #[wasm_bindgen_test]
+  async fn update_document_set_and_unset_roundtrip() {
+    let db = unique_db("searchlite-update-document");
+    let mut schema = Schema::default_text_body();
+    schema
+      .keyword_fields
+      .push(searchlite_core::api::types::KeywordField {
+        name: "category".to_string(),
+        stored: true,
+        indexed: true,
+        fast: true,
+        nullable: true,
+      });
+    let schema_json = serde_json::to_string(&schema).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({
+      "_id": "doc-1",
+      "body": "hello patch",
+      "category": "guide"
+    })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let patch = serde_json::json!({
+      "id": "doc-1",
+      "set": { "body": "updated patch" },
+      "unset": ["category"]
+    });
+    idx
+      .update_document(serde_wasm_bindgen::to_value(&patch).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let result = idx.search("updated".to_string(), 5, Some(true)).unwrap();
+    let parsed: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = parsed["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0]["fields"]["body"], "updated patch");
+    assert!(hits[0]["fields"]["category"].is_null());
+  }
+
+  #[wasm_bindgen_test]
+  async fn update_document_rejects_missing_patch() {
+    let db = unique_db("searchlite-update-missing-patch");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+
+    let patch = serde_json::json!({ "id": "doc-1" });
+    let err = idx
+      .update_document(serde_wasm_bindgen::to_value(&patch).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "missing_patch");
+  }
+
+  #[wasm_bindgen_test]
+  async fn update_document_rejects_invalid_id() {
+    let db = unique_db("searchlite-update-invalid-id");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+
+    let patch = serde_json::json!({
+      "id": "   ",
+      "set": { "body": "x" }
+    });
+    let err = idx
+      .update_document(serde_wasm_bindgen::to_value(&patch).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_id");
+  }
+
+  #[wasm_bindgen_test]
+  async fn update_document_reports_not_found() {
+    let db = unique_db("searchlite-update-not-found");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+
+    let patch = serde_json::json!({
+      "id": "missing",
+      "set": { "body": "x" }
+    });
+    let err = idx
+      .update_document(serde_wasm_bindgen::to_value(&patch).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "document_not_found");
+  }
+
+  #[wasm_bindgen_test]
+  async fn update_document_rejects_unknown_field() {
+    let db = unique_db("searchlite-update-unknown-field");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({
+      "_id": "doc-1",
+      "body": "hello patch"
+    })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let patch = serde_json::json!({
+      "id": "doc-1",
+      "set": { "unknown": "x" }
+    });
+    let err = idx
+      .update_document(serde_wasm_bindgen::to_value(&patch).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "update_failed");
+    assert!(payload.reason.contains("unknown field"));
+  }
+
+  #[wasm_bindgen_test]
+  async fn mget_returns_found_missing_and_preserves_order() {
+    let db = unique_db("searchlite-mget-order");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![
+      serde_json::json!({ "_id": "doc-1", "body": "alpha" }),
+      serde_json::json!({ "_id": "doc-2", "body": "beta" }),
+    ];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let req = serde_json::json!({
+      "ids": ["doc-2", "missing", "doc-1"],
+      "return_stored": true
+    });
+    let result = idx
+      .mget(serde_wasm_bindgen::to_value(&req).unwrap())
+      .unwrap();
+    let parsed: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let out = parsed["docs"].as_array().unwrap();
+    assert_eq!(out.len(), 3);
+    assert_eq!(out[0]["doc_id"], "doc-2");
+    assert_eq!(out[1]["doc_id"], "missing");
+    assert_eq!(out[2]["doc_id"], "doc-1");
+    assert_eq!(out[0]["found"], true);
+    assert_eq!(out[1]["found"], false);
+    assert_eq!(out[2]["found"], true);
+    assert_eq!(out[0]["_source"]["body"], "beta");
+    assert!(out[1]["_source"].is_null());
+    assert_eq!(out[2]["_source"]["body"], "alpha");
+  }
+
+  #[wasm_bindgen_test]
+  async fn mget_respects_return_stored_false() {
+    let db = unique_db("searchlite-mget-return-stored-false");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "alpha" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let req = serde_json::json!({
+      "ids": ["doc-1"],
+      "return_stored": false
+    });
+    let result = idx
+      .mget(serde_wasm_bindgen::to_value(&req).unwrap())
+      .unwrap();
+    let parsed: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let out = parsed["docs"].as_array().unwrap();
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0]["found"], true);
+    assert!(out[0]["_source"].is_null());
+  }
+
+  #[wasm_bindgen_test]
+  async fn mget_rejects_invalid_ids() {
+    let db = unique_db("searchlite-mget-invalid-id");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let req = serde_json::json!({
+      "ids": ["doc-1", "  "],
+      "return_stored": true
+    });
+    let err = idx
+      .mget(serde_wasm_bindgen::to_value(&req).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_id");
+  }
+
+  #[wasm_bindgen_test]
+  async fn multi_search_returns_ordered_results() {
+    let db = unique_db("searchlite-multi-search");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![
+      serde_json::json!({ "_id": "doc-1", "body": "alpha token" }),
+      serde_json::json!({ "_id": "doc-2", "body": "beta token" }),
+    ];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let req = serde_json::json!({
+      "searches": [
+        { "query": "alpha", "limit": 5, "return_stored": true },
+        { "query": "beta", "limit": 5, "return_stored": true }
+      ]
+    });
+    let result = idx
+      .multi_search(serde_wasm_bindgen::to_value(&req).unwrap())
+      .unwrap();
+    let parsed: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let results = parsed["results"].as_array().unwrap();
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0]["hits"][0]["fields"]["body"], "alpha token");
+    assert_eq!(results[1]["hits"][0]["fields"]["body"], "beta token");
+  }
+
+  #[wasm_bindgen_test]
+  async fn multi_search_rejects_invalid_request() {
+    let db = unique_db("searchlite-multi-search-invalid");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+
+    let req = serde_json::json!({ "searches": "not-an-array" });
+    let err = idx
+      .multi_search(serde_wasm_bindgen::to_value(&req).unwrap())
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_multi_search_request");
+  }
+
+  #[wasm_bindgen_test]
+  async fn compact_stats_and_inspect_roundtrip() {
+    let db = unique_db("searchlite-maintenance");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json, None)
+      .await
+      .unwrap();
+
+    let docs_a = vec![serde_json::json!({ "_id": "doc-1", "body": "alpha" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs_a).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let docs_b = vec![serde_json::json!({ "_id": "doc-2", "body": "beta" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs_b).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let stats_before_js = idx.stats().unwrap();
+    let stats_before: StatsResponse = serde_wasm_bindgen::from_value(stats_before_js).unwrap();
+    assert_eq!(stats_before.documents, 2);
+    assert_eq!(stats_before.deleted_documents, 0);
+    assert_eq!(stats_before.index_name, db);
+    assert!(stats_before.segments >= 2);
+
+    let compact_js = idx.compact().await.unwrap();
+    let compact: CompactResponse = serde_wasm_bindgen::from_value(compact_js).unwrap();
+    assert!(compact.compacted);
+
+    let stats_after_js = idx.stats().unwrap();
+    let stats_after: StatsResponse = serde_wasm_bindgen::from_value(stats_after_js).unwrap();
+    assert_eq!(stats_after.documents, 2);
+    assert_eq!(stats_after.deleted_documents, 0);
+    assert_eq!(stats_after.segments, 1);
+
+    let inspect_js = idx.inspect().unwrap();
+    let inspect: InspectResponse = serde_wasm_bindgen::from_value(inspect_js).unwrap();
+    assert!(inspect.manifest.write_key.is_none());
+    assert_eq!(inspect.manifest.segments.len(), stats_after.segments);
+    assert!(inspect
+      .manifest
+      .segments
+      .iter()
+      .all(|seg| seg.write_binding_b64.is_none()));
+  }
+
+  #[wasm_bindgen_test]
+  async fn wasm_core_parity_search_mget_multi_search_update_delete() {
+    let db = unique_db("searchlite-parity");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![
+      serde_json::json!({ "_id": "doc-1", "body": "alpha token" }),
+      serde_json::json!({ "_id": "doc-2", "body": "beta token" }),
+      serde_json::json!({ "_id": "doc-3", "body": "gamma token" }),
+    ];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let search_req: SearchRequest = serde_json::from_value(serde_json::json!({
+      "query": "alpha",
+      "limit": 5,
+      "return_stored": true
+    }))
+    .unwrap();
+    let wasm_search = idx
+      .search_request_value(serde_wasm_bindgen::to_value(&search_req).unwrap())
+      .unwrap();
+    let wasm_search_json: serde_json::Value = serde_wasm_bindgen::from_value(wasm_search).unwrap();
+    let core_search = idx.index.reader().unwrap().search(&search_req).unwrap();
+    let core_search_json = serde_json::to_value(core_search).unwrap();
+    assert_eq!(wasm_search_json, core_search_json);
+
+    let mget_req = MgetRequest {
+      ids: vec![
+        "doc-2".to_string(),
+        "missing".to_string(),
+        "doc-1".to_string(),
+      ],
+      return_stored: true,
+    };
+    let wasm_mget = idx
+      .mget(serde_wasm_bindgen::to_value(&mget_req).unwrap())
+      .unwrap();
+    let wasm_mget_json: serde_json::Value = serde_wasm_bindgen::from_value(wasm_mget).unwrap();
+    let core_mget_docs = idx
+      .index
+      .reader()
+      .unwrap()
+      .mget(&mget_req.ids, mget_req.return_stored)
+      .unwrap();
+    let core_mget_json = serde_json::to_value(MgetResponse {
+      docs: core_mget_docs,
+    })
+    .unwrap();
+    assert_eq!(wasm_mget_json, core_mget_json);
+
+    let multi_req = MultiSearchRequest {
+      searches: vec![
+        serde_json::from_value(serde_json::json!({
+          "query": "alpha",
+          "limit": 5,
+          "return_stored": true
+        }))
+        .unwrap(),
+        serde_json::from_value(serde_json::json!({
+          "query": "beta",
+          "limit": 5,
+          "return_stored": true
+        }))
+        .unwrap(),
+      ],
+      parallel: false,
+      max_concurrency: None,
+    };
+    let wasm_multi = idx
+      .multi_search(serde_wasm_bindgen::to_value(&multi_req).unwrap())
+      .unwrap();
+    let wasm_multi_json: serde_json::Value = serde_wasm_bindgen::from_value(wasm_multi).unwrap();
+    let core_multi_results = idx
+      .index
+      .reader()
+      .unwrap()
+      .multi_search(&multi_req.searches)
+      .unwrap();
+    let core_multi_json = serde_json::to_value(MultiSearchResponse {
+      results: core_multi_results,
+    })
+    .unwrap();
+    assert_eq!(wasm_multi_json, core_multi_json);
+
+    let patch = serde_json::json!({
+      "id": "doc-1",
+      "set": { "body": "alpha updated" }
+    });
+    idx
+      .update_document(serde_wasm_bindgen::to_value(&patch).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+    idx.delete_document("doc-2".to_string()).unwrap();
+    idx.commit().await.unwrap();
+
+    let verify_req = MgetRequest {
+      ids: vec!["doc-1".to_string(), "doc-2".to_string()],
+      return_stored: true,
+    };
+    let wasm_verify = idx
+      .mget(serde_wasm_bindgen::to_value(&verify_req).unwrap())
+      .unwrap();
+    let wasm_verify_json: serde_json::Value = serde_wasm_bindgen::from_value(wasm_verify).unwrap();
+    let core_verify_docs = idx
+      .index
+      .reader()
+      .unwrap()
+      .mget(&verify_req.ids, verify_req.return_stored)
+      .unwrap();
+    let core_verify_json = serde_json::to_value(MgetResponse {
+      docs: core_verify_docs,
+    })
+    .unwrap();
+    assert_eq!(wasm_verify_json, core_verify_json);
   }
 
   #[wasm_bindgen_test]
@@ -1144,6 +3304,385 @@ mod tests {
   }
 
   #[wasm_bindgen_test]
+  async fn search_request_value_controlled_rejects_invalid_timeout() {
+    let db = unique_db("searchlite-controlled-invalid-timeout");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let req = serde_json::json!({ "query": "hello", "limit": 5, "return_stored": true });
+    let err = idx
+      .search_request_value_controlled(
+        serde_wasm_bindgen::to_value(&req).unwrap(),
+        None,
+        Some(-1.0),
+      )
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_timeout");
+  }
+
+  #[wasm_bindgen_test]
+  async fn search_request_value_controlled_aborts_with_preaborted_signal() {
+    let db = unique_db("searchlite-controlled-abort");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let req = serde_json::json!({ "query": "hello", "limit": 5, "return_stored": true });
+    let controller = web_sys::AbortController::new().unwrap();
+    controller.abort();
+    let err = idx
+      .search_request_value_controlled(
+        serde_wasm_bindgen::to_value(&req).unwrap(),
+        Some(controller.signal()),
+        None,
+      )
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "aborted");
+  }
+
+  #[wasm_bindgen_test]
+  async fn search_request_value_controlled_times_out() {
+    let db = unique_db("searchlite-controlled-timeout");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let req = serde_json::json!({ "query": "hello", "limit": 5, "return_stored": true });
+    let err = idx
+      .search_request_value_controlled(serde_wasm_bindgen::to_value(&req).unwrap(), None, Some(0.0))
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "timeout");
+  }
+
+  #[wasm_bindgen_test]
+  async fn search_request_value_async_roundtrip() {
+    let db = unique_db("searchlite-async-search");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "hello wasm async" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+    let req = serde_json::json!({ "query": "hello", "limit": 5, "return_stored": true });
+    let result = idx
+      .search_request_value_async(serde_wasm_bindgen::to_value(&req).unwrap(), None, None)
+      .await
+      .unwrap();
+    let parsed: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = parsed["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 1);
+  }
+
+  #[wasm_bindgen_test]
+  async fn worker_search_request_keeps_main_thread_responsive() {
+    if !demo_worker_assets_available().await {
+      return;
+    }
+    let db = unique_db("searchlite-worker-responsive");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let worker = spawn_demo_worker().unwrap();
+
+    let init_payload = serde_json::json!({
+      "dbName": db,
+      "schemaJson": schema_json,
+      "storage": "indexeddb",
+    });
+    let init_result = worker_call(
+      &worker,
+      1,
+      "init_index",
+      serde_wasm_bindgen::to_value(&init_payload).unwrap(),
+    )
+    .await;
+    if let Err(err) = init_result {
+      if skip_if_worker_runtime_unavailable(&err) {
+        worker.terminate();
+        return;
+      }
+      panic!("worker init failed: {err:?}");
+    }
+
+    let docs_payload = serde_json::json!({
+      "docs": [{ "_id": "doc-1", "body": "hello from worker" }],
+    });
+    worker_call(
+      &worker,
+      2,
+      "add_documents",
+      serde_wasm_bindgen::to_value(&docs_payload).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let timer_fired = Rc::new(Cell::new(false));
+    let timer_fired_ref = Rc::clone(&timer_fired);
+    set_timeout_once(20, move || timer_fired_ref.set(true));
+
+    let request_payload = serde_json::json!({
+      "request": { "query": "hello", "limit": 5, "return_stored": true },
+      "delayMs": 200,
+      "timeoutMs": 800,
+    });
+    let result = match worker_call(
+      &worker,
+      3,
+      "search_request",
+      serde_wasm_bindgen::to_value(&request_payload).unwrap(),
+    )
+    .await
+    {
+      Ok(result) => result,
+      Err(err) if skip_if_worker_runtime_unavailable(&err) => {
+        worker.terminate();
+        let _ = Searchlite::drop_index(db).await;
+        return;
+      }
+      Err(err) => panic!("worker search failed: {err:?}"),
+    };
+    let parsed: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    assert_eq!(parsed["hits"].as_array().unwrap().len(), 1);
+    assert!(
+      timer_fired.get(),
+      "main thread timer should fire while worker search is in-flight"
+    );
+
+    worker.terminate();
+    let db_name = init_payload["dbName"].as_str().unwrap().to_string();
+    Searchlite::drop_index(db_name).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn worker_search_request_timeout_returns_typed_error() {
+    if !demo_worker_assets_available().await {
+      return;
+    }
+    let db = unique_db("searchlite-worker-timeout");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let worker = spawn_demo_worker().unwrap();
+
+    let init_payload = serde_json::json!({
+      "dbName": db,
+      "schemaJson": schema_json,
+      "storage": "indexeddb",
+    });
+    let init_result = worker_call(
+      &worker,
+      1,
+      "init_index",
+      serde_wasm_bindgen::to_value(&init_payload).unwrap(),
+    )
+    .await;
+    if let Err(err) = init_result {
+      if skip_if_worker_runtime_unavailable(&err) {
+        worker.terminate();
+        return;
+      }
+      panic!("worker init failed: {err:?}");
+    }
+
+    let docs_payload = serde_json::json!({
+      "docs": [{ "_id": "doc-1", "body": "timeout path" }],
+    });
+    worker_call(
+      &worker,
+      2,
+      "add_documents",
+      serde_wasm_bindgen::to_value(&docs_payload).unwrap(),
+    )
+    .await
+    .unwrap();
+
+    let request_payload = serde_json::json!({
+      "request": { "query": "timeout", "limit": 5, "return_stored": true },
+      "delayMs": 200,
+      "timeoutMs": 20,
+    });
+    let err = match worker_call(
+      &worker,
+      3,
+      "search_request",
+      serde_wasm_bindgen::to_value(&request_payload).unwrap(),
+    )
+    .await
+    {
+      Ok(_) => panic!("expected timeout error from worker search"),
+      Err(err) if skip_if_worker_runtime_unavailable(&err) => {
+        worker.terminate();
+        let _ = Searchlite::drop_index(db).await;
+        return;
+      }
+      Err(err) => err,
+    };
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "timeout");
+
+    worker.terminate();
+    let db_name = init_payload["dbName"].as_str().unwrap().to_string();
+    Searchlite::drop_index(db_name).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn worker_client_search_request_abort_returns_typed_error() {
+    if !demo_worker_assets_available().await {
+      return;
+    }
+    let db = unique_db("searchlite-worker-client-abort");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let client = match new_worker_client_instance().await {
+      Ok(client) => client,
+      Err(err) => {
+        if skip_if_worker_runtime_unavailable(&err) {
+          return;
+        }
+        panic!("worker client init failed: {err:?}");
+      }
+    };
+
+    let init_args = js_sys::Array::new();
+    init_args.push(&JsValue::from_str(&db));
+    init_args.push(&JsValue::from_str(&schema_json));
+    init_args.push(&JsValue::from_str("indexeddb"));
+    let init_res =
+      JsFuture::from(call_worker_client_method(&client, "initIndex", &init_args).unwrap()).await;
+    if let Err(err) = init_res {
+      if skip_if_worker_runtime_unavailable(&err) {
+        return;
+      }
+      panic!("worker client initIndex failed: {err:?}");
+    }
+
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "abort path" })];
+    let add_args = js_sys::Array::new();
+    add_args.push(&serde_wasm_bindgen::to_value(&docs).unwrap());
+    JsFuture::from(call_worker_client_method(&client, "addDocuments", &add_args).unwrap())
+      .await
+      .unwrap();
+
+    let controller = web_sys::AbortController::new().unwrap();
+    let controller_for_timeout = controller.clone();
+    set_timeout_once(20, move || controller_for_timeout.abort());
+
+    let request = serde_json::json!({ "query": "abort", "limit": 5, "return_stored": true });
+    let options = js_sys::Object::new();
+    js_sys::Reflect::set(
+      &options,
+      &JsValue::from_str("delayMs"),
+      &JsValue::from_f64(200.0),
+    )
+    .unwrap();
+    js_sys::Reflect::set(
+      &options,
+      &JsValue::from_str("timeoutMs"),
+      &JsValue::from_f64(800.0),
+    )
+    .unwrap();
+    js_sys::Reflect::set(
+      &options,
+      &JsValue::from_str("signal"),
+      controller.signal().as_ref(),
+    )
+    .unwrap();
+    let search_args = js_sys::Array::new();
+    search_args.push(&serde_wasm_bindgen::to_value(&request).unwrap());
+    search_args.push(options.as_ref());
+    let err = match JsFuture::from(
+      call_worker_client_method(&client, "searchRequest", &search_args).unwrap(),
+    )
+    .await
+    {
+      Ok(_) => panic!("expected abort error from worker client search"),
+      Err(err) if skip_if_worker_runtime_unavailable(&err) => {
+        return;
+      }
+      Err(err) => err,
+    };
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "aborted");
+
+    let dispose_args = js_sys::Array::new();
+    JsFuture::from(call_worker_client_method(&client, "dispose", &dispose_args).unwrap())
+      .await
+      .unwrap();
+    Searchlite::drop_index(db).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn worker_client_search_request_rejects_invalid_timeout() {
+    if !demo_worker_assets_available().await {
+      return;
+    }
+    let db = unique_db("searchlite-worker-client-invalid-timeout");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let client = match new_worker_client_instance().await {
+      Ok(client) => client,
+      Err(err) => {
+        if skip_if_worker_runtime_unavailable(&err) {
+          return;
+        }
+        panic!("worker client init failed: {err:?}");
+      }
+    };
+
+    let init_args = js_sys::Array::new();
+    init_args.push(&JsValue::from_str(&db));
+    init_args.push(&JsValue::from_str(&schema_json));
+    init_args.push(&JsValue::from_str("indexeddb"));
+    let init_res =
+      JsFuture::from(call_worker_client_method(&client, "initIndex", &init_args).unwrap()).await;
+    if let Err(err) = init_res {
+      if skip_if_worker_runtime_unavailable(&err) {
+        return;
+      }
+      panic!("worker client initIndex failed: {err:?}");
+    }
+
+    let request = serde_json::json!({ "query": "timeout", "limit": 5, "return_stored": true });
+    let options = js_sys::Object::new();
+    js_sys::Reflect::set(
+      &options,
+      &JsValue::from_str("timeoutMs"),
+      &JsValue::from_f64(-1.0),
+    )
+    .unwrap();
+    let search_args = js_sys::Array::new();
+    search_args.push(&serde_wasm_bindgen::to_value(&request).unwrap());
+    search_args.push(options.as_ref());
+    let err = match JsFuture::from(
+      call_worker_client_method(&client, "searchRequest", &search_args).unwrap(),
+    )
+    .await
+    {
+      Ok(_) => panic!("expected invalid_timeout error from worker client search"),
+      Err(err) if skip_if_worker_runtime_unavailable(&err) => {
+        return;
+      }
+      Err(err) => err,
+    };
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "invalid_timeout");
+    assert!(payload.reason.contains("timeoutMs"));
+
+    let dispose_args = js_sys::Array::new();
+    JsFuture::from(call_worker_client_method(&client, "dispose", &dispose_args).unwrap())
+      .await
+      .unwrap();
+    Searchlite::drop_index(db).await.unwrap();
+  }
+
+  #[cfg(not(feature = "threads"))]
+  #[wasm_bindgen_test]
+  async fn init_threads_without_feature_returns_typed_error() {
+    let db = unique_db("searchlite-threads-disabled");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json, None)
+      .await
+      .unwrap();
+    let err = idx.init_threads(None).await.unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "threads_feature_disabled");
+    Searchlite::drop_index(db).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
   async fn init_reuses_existing_index() {
     let db = unique_db("searchlite-reopen");
     let schema = Schema::default_text_body();
@@ -1162,5 +3701,313 @@ mod tests {
     let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
     let hits = result_json["hits"].as_array().unwrap();
     assert_eq!(hits.len(), 1);
+  }
+
+  #[wasm_bindgen_test]
+  async fn list_indexes_includes_initialized_db() {
+    let db = unique_db("searchlite-list-indexes");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json, None)
+      .await
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let indexes_js = Searchlite::list_indexes().await.unwrap();
+    let indexes: Vec<IndexRegistryEntry> = serde_wasm_bindgen::from_value(indexes_js).unwrap();
+    assert!(indexes.iter().any(|entry| entry.db_name == db));
+  }
+
+  #[wasm_bindgen_test]
+  async fn clear_index_resets_contents() {
+    let db = unique_db("searchlite-clear-index");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json.clone(), None)
+      .await
+      .unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "clear me" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    Searchlite::clear_index(db.clone()).await.unwrap();
+
+    let reopened = Searchlite::init(db, schema_json, None).await.unwrap();
+    let result = reopened.search("clear".to_string(), 5, None).unwrap();
+    let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = result_json["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 0);
+  }
+
+  #[wasm_bindgen_test]
+  async fn drop_index_removes_registry_entry() {
+    let db = unique_db("searchlite-drop-index");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json.clone(), None)
+      .await
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    Searchlite::drop_index(db.clone()).await.unwrap();
+
+    let indexes_js = Searchlite::list_indexes().await.unwrap();
+    let indexes: Vec<IndexRegistryEntry> = serde_wasm_bindgen::from_value(indexes_js).unwrap();
+    assert!(!indexes.iter().any(|entry| entry.db_name == db));
+
+    // Can recreate after deletion.
+    let recreated = Searchlite::init(db, schema_json, None).await.unwrap();
+    recreated.commit().await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn storage_usage_returns_supported_or_note() {
+    let usage_js = Searchlite::storage_usage().await.unwrap();
+    let usage: StorageUsageResponse = serde_wasm_bindgen::from_value(usage_js).unwrap();
+    assert!(usage.supported || usage.note.is_some());
+    if usage.supported {
+      assert!(
+        usage.usage_bytes.is_some() || usage.quota_bytes.is_some() || usage.persisted.is_some()
+      );
+    }
+  }
+
+  #[wasm_bindgen_test]
+  async fn commit_surfaces_quota_exceeded_error_type() {
+    let db = unique_db("searchlite-quota-error");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json, None)
+      .await
+      .unwrap();
+    idx
+      .add_document(
+        serde_wasm_bindgen::to_value(&serde_json::json!({ "_id": "doc-1", "body": "quota" }))
+          .unwrap(),
+      )
+      .unwrap();
+    let _guard = PersistQuotaFailureGuard::enable();
+    let err = idx.commit().await.unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "quota_exceeded");
+    assert!(payload.reason.contains("compact()"));
+    assert!(payload.reason.contains("cleanup_indexes"));
+    Searchlite::drop_index(db).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn cleanup_indexes_drops_only_stale_entries() {
+    let fresh = unique_db("searchlite-cleanup-fresh");
+    let stale = unique_db("searchlite-cleanup-stale");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+
+    let fresh_idx = Searchlite::init(fresh.clone(), schema_json.clone(), None)
+      .await
+      .unwrap();
+    fresh_idx.commit().await.unwrap();
+    let stale_idx = Searchlite::init(stale.clone(), schema_json, None)
+      .await
+      .unwrap();
+    stale_idx.commit().await.unwrap();
+
+    let mut stale_entry = get_registry_entry(&stale).await.unwrap().unwrap();
+    stale_entry.updated_at_ms -= 60_000.0;
+    upsert_registry_entry(&stale_entry).await.unwrap();
+
+    let cleanup_js = Searchlite::cleanup_indexes(30_000.0, Some(false))
+      .await
+      .unwrap();
+    let cleanup: CleanupIndexesResponse = serde_wasm_bindgen::from_value(cleanup_js).unwrap();
+    assert!(cleanup.dropped.iter().any(|name| name == &stale));
+    assert!(cleanup.kept.iter().any(|name| name == &fresh));
+
+    let indexes_js = Searchlite::list_indexes().await.unwrap();
+    let indexes: Vec<IndexRegistryEntry> = serde_wasm_bindgen::from_value(indexes_js).unwrap();
+    assert!(indexes.iter().any(|entry| entry.db_name == fresh));
+    assert!(!indexes.iter().any(|entry| entry.db_name == stale));
+
+    Searchlite::drop_index(fresh).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn cleanup_orphaned_files_removes_only_unknown_paths() {
+    let db = unique_db("searchlite-cleanup-orphans");
+    let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json, None)
+      .await
+      .unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "retain me" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let orphan_path = PathBuf::from(db.clone()).join("orphan.bin");
+    persist_operations_batch(
+      &db,
+      &[(orphan_path.clone(), PersistOperation::Put(vec![1, 2, 3]))],
+    )
+    .await
+    .unwrap();
+
+    let cleanup_js = idx.cleanup_orphaned_files(Some(false)).await.unwrap();
+    let cleanup: CleanupOrphanedFilesResponse = serde_wasm_bindgen::from_value(cleanup_js).unwrap();
+    assert!(cleanup
+      .removed
+      .iter()
+      .any(|path| path == &path_key(&orphan_path)));
+
+    let result = idx.search("retain".to_string(), 5, Some(true)).unwrap();
+    let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = result_json["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 1);
+    Searchlite::drop_index(db).await.unwrap();
+  }
+
+  #[wasm_bindgen_test]
+  async fn plan_migration_reports_compatibility_and_rebuild() {
+    let db = unique_db("searchlite-plan-migration");
+    let schema_v1 = Schema::default_text_body();
+    let schema_v1_json = serde_json::to_string(&schema_v1).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_v1_json.clone(), None)
+      .await
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let compatible_js = Searchlite::plan_migration(db.clone(), schema_v1_json)
+      .await
+      .unwrap();
+    let compatible: MigrationPlan = serde_wasm_bindgen::from_value(compatible_js).unwrap();
+    assert_eq!(compatible.status, "compatible");
+    assert!(!compatible.rebuild_required);
+
+    let mut schema_v2 = Schema::default_text_body();
+    schema_v2
+      .keyword_fields
+      .push(searchlite_core::api::types::KeywordField {
+        name: "category".to_string(),
+        stored: true,
+        indexed: true,
+        fast: true,
+        nullable: false,
+      });
+    let schema_v2_json = serde_json::to_string(&schema_v2).unwrap();
+    let rebuild_js = Searchlite::plan_migration(db, schema_v2_json)
+      .await
+      .unwrap();
+    let rebuild: MigrationPlan = serde_wasm_bindgen::from_value(rebuild_js).unwrap();
+    assert_eq!(rebuild.status, "rebuild_required");
+    assert!(rebuild.rebuild_required);
+  }
+
+  #[wasm_bindgen_test]
+  async fn migrate_index_creates_missing_index() {
+    let db = unique_db("searchlite-migrate-create");
+    let schema = Schema::default_text_body();
+    let schema_json = serde_json::to_string(&schema).unwrap();
+
+    let created_js = Searchlite::migrate_index(db.clone(), schema_json.clone())
+      .await
+      .unwrap();
+    let created: MigrationExecutionResult = serde_wasm_bindgen::from_value(created_js).unwrap();
+    assert_eq!(created.status, "created");
+    assert!(!created.rebuild_performed);
+
+    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let result = idx.search("anything".to_string(), 5, None).unwrap();
+    let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = result_json["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 0);
+  }
+
+  #[wasm_bindgen_test]
+  async fn migrate_index_rebuilds_on_schema_change() {
+    let db = unique_db("searchlite-migrate-rebuild");
+    let schema_v1 = Schema::default_text_body();
+    let schema_v1_json = serde_json::to_string(&schema_v1).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_v1_json, None)
+      .await
+      .unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "keep me if rollback" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let mut schema_v2 = Schema::default_text_body();
+    schema_v2
+      .keyword_fields
+      .push(searchlite_core::api::types::KeywordField {
+        name: "category".to_string(),
+        stored: true,
+        indexed: true,
+        fast: true,
+        nullable: false,
+      });
+    let schema_v2_json = serde_json::to_string(&schema_v2).unwrap();
+
+    let rebuild_js = Searchlite::migrate_index(db.clone(), schema_v2_json.clone())
+      .await
+      .unwrap();
+    let rebuild: MigrationExecutionResult = serde_wasm_bindgen::from_value(rebuild_js).unwrap();
+    assert_eq!(rebuild.status, "rebuilt");
+    assert!(rebuild.rebuild_performed);
+
+    let reopened = Searchlite::init(db, schema_v2_json, None).await.unwrap();
+    let result = reopened
+      .search("rollback".to_string(), 5, Some(true))
+      .unwrap();
+    let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = result_json["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 0);
+  }
+
+  #[wasm_bindgen_test]
+  async fn migrate_index_rolls_back_on_rebuild_failure() {
+    let db = unique_db("searchlite-migrate-rollback");
+    let schema_v1 = Schema::default_text_body();
+    let schema_v1_json = serde_json::to_string(&schema_v1).unwrap();
+    let idx = Searchlite::init(db.clone(), schema_v1_json.clone(), None)
+      .await
+      .unwrap();
+    let docs = vec![serde_json::json!({ "_id": "doc-1", "body": "rollback sentinel" })];
+    idx
+      .add_documents(serde_wasm_bindgen::to_value(&docs).unwrap())
+      .unwrap();
+    idx.commit().await.unwrap();
+
+    let mut schema_v2 = Schema::default_text_body();
+    schema_v2
+      .keyword_fields
+      .push(searchlite_core::api::types::KeywordField {
+        name: "category".to_string(),
+        stored: true,
+        indexed: true,
+        fast: true,
+        nullable: false,
+      });
+    let schema_v2_json = serde_json::to_string(&schema_v2).unwrap();
+
+    let _guard = MigrationFailureGuard::enable();
+    let err = Searchlite::migrate_index(db.clone(), schema_v2_json.clone())
+      .await
+      .unwrap_err();
+    let payload: WasmErrorPayload = serde_wasm_bindgen::from_value(err).unwrap();
+    assert_eq!(payload.error_type, "migration_rebuild_failed");
+
+    let reopened = Searchlite::init(db.clone(), schema_v1_json, None)
+      .await
+      .unwrap();
+    let result = reopened
+      .search("sentinel".to_string(), 5, Some(true))
+      .unwrap();
+    let result_json: serde_json::Value = serde_wasm_bindgen::from_value(result).unwrap();
+    let hits = result_json["hits"].as_array().unwrap();
+    assert_eq!(hits.len(), 1);
+
+    let mismatch = match Searchlite::init(db, schema_v2_json, None).await {
+      Ok(_) => panic!("expected schema mismatch after rollback"),
+      Err(err) => err,
+    };
+    let mismatch_payload: WasmErrorPayload = serde_wasm_bindgen::from_value(mismatch).unwrap();
+    assert_eq!(mismatch_payload.error_type, "schema_mismatch");
   }
 }

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -1052,13 +1052,24 @@ async fn persist_queue_worker(db_name: String, state: Arc<Mutex<PendingQueueStat
       web_sys::console::error_1(&JsValue::from_str(&format!("persist batch error: {msg}")));
       // Re-insert failed operations so a subsequent flush can retry.
       // Do not overwrite entries added concurrently during this batch.
-      let mut guard = state.lock();
-      for (path, op) in operations {
-        guard.queue.entry(path).or_insert_with(|| PendingEntry {
-          operation: op,
-          waiters: Vec::new(),
-        });
+      // Stop the worker after re-queuing to avoid an infinite retry loop;
+      // the next explicit flush() will spawn a new worker.
+      {
+        let mut guard = state.lock();
+        for (path, op) in operations {
+          guard.queue.entry(path).or_insert_with(|| PendingEntry {
+            operation: op,
+            waiters: Vec::new(),
+          });
+        }
+        guard.worker_running = false;
       }
+      for waiters in waiter_sets {
+        for tx in waiters {
+          let _ = tx.send(Err(anyhow!(msg.clone())));
+        }
+      }
+      return;
     }
     for waiters in waiter_sets {
       for tx in waiters {

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -1009,6 +1009,46 @@ impl PendingWrites {
         }
       }
     }
+    // If previous batches failed and re-queued operations, ensure a worker
+    // is running so those entries are retried before we return.
+    {
+      let mut guard = self.state.lock();
+      if !guard.queue.is_empty() && !guard.worker_running {
+        let (tx, rx) = oneshot::channel();
+        // Attach a waiter to the first queued entry so we can await it.
+        if let Some(entry) = guard.queue.values_mut().next() {
+          entry.waiters.push(tx);
+          self.pending.lock().push(rx);
+        } else {
+          drop(tx);
+        }
+        guard.worker_running = true;
+        let db_name = self.db_name.clone();
+        let state = self.state.clone();
+        spawn_local(async move {
+          persist_queue_worker(db_name, state).await;
+        });
+      }
+    }
+    let retry_receivers = {
+      let mut guard = self.pending.lock();
+      std::mem::take(&mut *guard)
+    };
+    for rx in retry_receivers {
+      match rx.await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+          if first_error.is_none() {
+            first_error = Some(err);
+          }
+        }
+        Err(_) => {
+          if first_error.is_none() {
+            first_error = Some(anyhow!("pending persist dropped"));
+          }
+        }
+      }
+    }
     if let Some(err) = first_error {
       Err(err)
     } else {
@@ -1695,6 +1735,12 @@ impl Searchlite {
 
   #[wasm_bindgen(js_name = clear_index)]
   pub async fn clear_index(db_name: String) -> Result<(), JsValue> {
+    if db_name == REGISTRY_DB_NAME {
+      return Err(js_error(
+        "reserved_name",
+        format!("'{REGISTRY_DB_NAME}' is reserved for internal use"),
+      ));
+    }
     clear_data_store(&db_name)
       .await
       .map_err(|err| typed_js_error("storage_clear_error", err))?;
@@ -1703,6 +1749,12 @@ impl Searchlite {
 
   #[wasm_bindgen(js_name = drop_index)]
   pub async fn drop_index(db_name: String) -> Result<(), JsValue> {
+    if db_name == REGISTRY_DB_NAME {
+      return Err(js_error(
+        "reserved_name",
+        format!("'{REGISTRY_DB_NAME}' is reserved for internal use"),
+      ));
+    }
     delete_database(&db_name)
       .await
       .map_err(|err| typed_js_error("storage_delete_error", err))?;
@@ -1751,10 +1803,12 @@ impl Searchlite {
       matched += 1;
       let db_name = entry.db_name.clone();
       if !dry_run {
-        let _ = remove_registry_entry(&db_name).await;
         delete_database(&db_name)
           .await
           .map_err(|err| typed_js_error("storage_delete_error", err))?;
+        remove_registry_entry(&db_name)
+          .await
+          .map_err(|err| typed_js_error("registry_delete_error", err))?;
       }
       dropped.push(db_name);
     }

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -990,55 +990,50 @@ impl PendingWrites {
 
   async fn flush(&self) -> Result<()> {
     let mut first_error = None;
-    loop {
-      // Drain all pending receivers from normal enqueue paths.
-      let receivers = {
-        let mut guard = self.pending.lock();
-        std::mem::take(&mut *guard)
-      };
-      for rx in receivers {
-        match rx.await {
-          Ok(Ok(())) => {}
-          Ok(Err(err)) => {
-            if first_error.is_none() {
-              first_error = Some(err);
-            }
-          }
-          Err(_) => {
-            if first_error.is_none() {
-              first_error = Some(anyhow!("pending persist dropped"));
-            }
-          }
-        }
-      }
-      // If previous batches failed and re-queued operations, ensure a worker
-      // is running so those entries are retried. Attach a waiter to the LAST
-      // queued entry so we block until the entire queue has been processed.
-      let has_retry = {
-        let mut guard = self.state.lock();
-        if !guard.queue.is_empty() && !guard.worker_running {
-          let (tx, rx) = oneshot::channel();
-          if let Some(entry) = guard.queue.values_mut().next_back() {
-            entry.waiters.push(tx);
-            self.pending.lock().push(rx);
-          } else {
-            drop(tx);
-          }
-          guard.worker_running = true;
-          let db_name = self.db_name.clone();
-          let state = self.state.clone();
-          spawn_local(async move {
-            persist_queue_worker(db_name, state).await;
-          });
-          true
+    // If a previous batch failed and re-queued operations, spawn a new worker
+    // to retry before draining receivers. Attach a waiter to the LAST queued
+    // entry so we block until the worker either completes the entire queue
+    // or fails (in which case all remaining waiters are drained with the
+    // error by the worker's failure path). We only make ONE retry attempt
+    // per flush() call — a persistent failure returns an error immediately
+    // instead of looping.
+    {
+      let mut guard = self.state.lock();
+      if !guard.queue.is_empty() && !guard.worker_running {
+        let (tx, rx) = oneshot::channel();
+        if let Some(entry) = guard.queue.values_mut().next_back() {
+          entry.waiters.push(tx);
+          self.pending.lock().push(rx);
         } else {
-          false
+          drop(tx);
         }
-      };
-      if !has_retry {
-        break;
+        guard.worker_running = true;
+        let db_name = self.db_name.clone();
+        let state = self.state.clone();
+        spawn_local(async move {
+          persist_queue_worker(db_name, state).await;
+        });
       }
-      // Loop back to drain the retry receivers and check again.
+    }
+    // Drain all pending receivers (from enqueues plus any retry waiter).
+    let receivers = {
+      let mut guard = self.pending.lock();
+      std::mem::take(&mut *guard)
+    };
+    for rx in receivers {
+      match rx.await {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => {
+          if first_error.is_none() {
+            first_error = Some(err);
+          }
+        }
+        Err(_) => {
+          if first_error.is_none() {
+            first_error = Some(anyhow!("pending persist dropped"));
+          }
+        }
+      }
     }
     if let Some(err) = first_error {
       Err(err)
@@ -1085,6 +1080,10 @@ async fn persist_queue_worker(db_name: String, state: Arc<Mutex<PendingQueueStat
       // Do not overwrite entries added concurrently during this batch.
       // Stop the worker after re-queuing to avoid an infinite retry loop;
       // the next explicit flush() will spawn a new worker.
+      // Also drain any waiters attached to remaining queued entries (batches
+      // that were never attempted) so flush() can return the error without
+      // hanging or looping.
+      let mut pending_waiters: Vec<oneshot::Sender<Result<()>>> = Vec::new();
       {
         let mut guard = state.lock();
         for (path, op) in operations {
@@ -1093,12 +1092,18 @@ async fn persist_queue_worker(db_name: String, state: Arc<Mutex<PendingQueueStat
             waiters: Vec::new(),
           });
         }
+        for entry in guard.queue.values_mut() {
+          pending_waiters.append(&mut entry.waiters);
+        }
         guard.worker_running = false;
       }
       for waiters in waiter_sets {
         for tx in waiters {
           let _ = tx.send(Err(anyhow!(msg.clone())));
         }
+      }
+      for tx in pending_waiters {
+        let _ = tx.send(Err(anyhow!(msg.clone())));
       }
       return;
     }


### PR DESCRIPTION
## Summary
- **PR matrix cut from 5 → 2 toolchains**: only MSRV (`1.88.0`) and `stable` run on PRs; `beta` and `nightly` move to a main-only `lint-test-extended` job
- **Benchmarks main-only**: `cargo bench` no longer runs on PR pushes
- **Concurrency cancellation**: new pushes to the same PR cancel in-progress runs

## Context
Actions Linux usage hit 11,066 minutes (~$66) this billing period. With ~63 pushes triggering a 5-toolchain matrix + benchmarks each time, most of that spend was on PR iterations. These changes should reduce per-PR minutes from ~130 to ~50, a roughly **60% reduction**.

## Test plan
- [ ] Verify PR CI runs only `lint-test` (MSRV + stable), `test-wasm-browser`, and `test-node`
- [ ] Verify `lint-test-extended` and `bench` are skipped on PR events
- [ ] Verify pushing to main triggers all jobs including extended and bench
- [ ] Verify rapid pushes to a PR cancel the previous run

🤖 Generated with [Claude Code](https://claude.com/claude-code)