### PR TITLE
ci: reduce PR workflow to MSRV + stable, move bench to main-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
       - opened
       - synchronize
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint-test:
     name: Lint / Build / Test (${{ matrix.toolchain }})
@@ -16,7 +20,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.92.0, 1.88.0, stable, beta, nightly]
+        toolchain: [1.88.0, stable]
+        include:
+          - toolchain: stable
+            check-fmt: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
@@ -27,8 +34,33 @@ jobs:
         with:
           cache-on-failure: true
       - name: Format check
-        if: ${{ matrix.toolchain == 'stable' }}
+        if: ${{ matrix.check-fmt }}
         run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --all --all-features --all-targets -- -D warnings
+      - name: Build
+        run: cargo build --all --all-features
+      - name: Test
+        run: cargo test --all --all-features
+
+  # Full toolchain coverage — only on main
+  lint-test-extended:
+    name: Extended / ${{ matrix.toolchain }}
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [beta, nightly]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
       - name: Clippy
         run: cargo clippy --all --all-features --all-targets -- -D warnings
       - name: Build
@@ -86,6 +118,7 @@ jobs:
 
   bench:
     name: Benchmarks
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: lint-test
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [1.88.0, stable]
         include:
+          - toolchain: 1.88.0
+            check_fmt: false
           - toolchain: stable
-            check-fmt: true
+            check_fmt: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@v1
@@ -34,7 +35,7 @@ jobs:
         with:
           cache-on-failure: true
       - name: Format check
-        if: ${{ matrix.check-fmt }}
+        if: ${{ matrix.check_fmt }}
         run: cargo fmt --all -- --check
       - name: Clippy
         run: cargo clippy --all --all-features --all-targets -- -D warnings


### PR DESCRIPTION
## Summary
- **PR matrix cut from 5 to 2 toolchains**: only MSRV (`1.88.0`) and `stable` run on PRs; `beta` and `nightly` move to a main-only `lint-test-extended` job
- **Benchmarks main-only**: `cargo bench` no longer runs on PR pushes
- **Concurrency cancellation**: new pushes to the same PR cancel in-progress runs

## Context
Actions Linux usage hit 11,066 minutes (~$66) this billing period. With ~63 pushes triggering a 5-toolchain matrix + benchmarks each time, most of that spend was on PR iterations. These changes should reduce per-PR minutes from ~130 to ~50, a roughly **60% reduction**.

## Test plan
- [ ] Verify PR CI runs only `lint-test` (MSRV + stable), `test-node`
- [ ] Verify `lint-test-extended` and `bench` are skipped on PR events
- [ ] Verify pushing to main triggers all jobs including extended and bench
- [ ] Verify rapid pushes to a PR cancel the previous run

🤖 Generated with [Claude Code](https://claude.com/claude-code)