### PR TITLE
fix(aggs): sort significant_terms by significance score before truncation

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -257,7 +257,20 @@ impl<'a> SignificantTermsCollector<'a> {
       .into_values()
       .filter(|b| b.doc_count >= self.min_doc_count)
       .collect();
-    buckets.sort_by(|a, b| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count));
+    // Sort by significance score (doc_count/bg_count ratio) descending before
+    // truncation. Since the foreground/background totals are constant across all
+    // buckets, the ratio `doc_count / bg_count` is monotonically related to the
+    // full significance score `(doc_count/fg_total) / (bg_count/bg_total)` and
+    // is sufficient for ranking. This avoids discarding high-significance
+    // low-frequency terms that would be lost by a doc_count-only sort.
+    buckets.sort_by(|a, b| {
+      let a_score = a.doc_count as f64 / (a.bg_count.max(1)) as f64;
+      let b_score = b.doc_count as f64 / (b.bg_count.max(1)) as f64;
+      b_score
+        .partial_cmp(&a_score)
+        .unwrap_or(Ordering::Equal)
+        .then_with(|| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count))
+    });
     let limit = self.size.unwrap_or(buckets.len()).min(MAX_BUCKETS);
     buckets.truncate(limit);
     AggregationIntermediate::SignificantTerms {
@@ -2377,7 +2390,16 @@ fn merge_intermediate_in_place(
       let limit = target_size
         .unwrap_or_else(|| target_buckets.len())
         .min(MAX_BUCKETS);
-      target_buckets.sort_by(|a, b| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count));
+      // Sort by significance score proxy (doc_count/bg_count ratio) to
+      // preserve high-significance low-frequency terms during truncation.
+      target_buckets.sort_by(|a, b| {
+        let a_score = a.doc_count as f64 / (a.bg_count.max(1)) as f64;
+        let b_score = b.doc_count as f64 / (b.bg_count.max(1)) as f64;
+        b_score
+          .partial_cmp(&a_score)
+          .unwrap_or(Ordering::Equal)
+          .then_with(|| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count))
+      });
       if target_buckets.len() > limit {
         target_buckets.truncate(limit);
       }
@@ -4296,6 +4318,132 @@ mod tests {
         );
       }
       date = date.succ_opt().unwrap();
+    }
+  }
+
+  /// Regression test for #249: finalize_response must rank significant_terms
+  /// buckets by significance score, not by doc_count. A low-frequency term
+  /// with a very low bg_count must outrank a high-frequency term with a high
+  /// bg_count when its significance score is higher.
+  #[test]
+  fn significant_terms_finalize_ranks_by_significance_score() {
+    use serde_json::json;
+
+    let intermediate = AggregationIntermediate::SignificantTerms {
+      buckets: vec![
+        // "common": high doc_count, high bg_count → low significance
+        SignificantBucketIntermediate {
+          key: json!("common"),
+          doc_count: 80,
+          bg_count: 5000,
+          aggs: BTreeMap::new(),
+        },
+        // "frequent": medium doc_count, high bg_count → low significance
+        SignificantBucketIntermediate {
+          key: json!("frequent"),
+          doc_count: 50,
+          bg_count: 4000,
+          aggs: BTreeMap::new(),
+        },
+        // "rare_sig": low doc_count, very low bg_count → very high significance
+        SignificantBucketIntermediate {
+          key: json!("rare_sig"),
+          doc_count: 3,
+          bg_count: 5,
+          aggs: BTreeMap::new(),
+        },
+      ],
+      size: Some(2),
+      min_doc_count: 1,
+      pipeline: BTreeMap::new(),
+      doc_count: 100,
+      bg_count: 10_000,
+      sampled: false,
+    };
+
+    let response = finalize_response(intermediate);
+    if let AggregationResponse::SignificantTerms { buckets, .. } = response {
+      assert_eq!(buckets.len(), 2, "size=2 should yield 2 buckets");
+      assert_eq!(
+        buckets[0].key.as_str().unwrap(),
+        "rare_sig",
+        "rare_sig (score=60.0) must be ranked #1"
+      );
+      assert!(
+        buckets[0].score > buckets[1].score,
+        "first bucket should have higher score"
+      );
+      // Verify that "rare_sig" was not discarded by intermediate truncation
+      let keys: Vec<&str> = buckets.iter().map(|b| b.key.as_str().unwrap()).collect();
+      assert!(
+        keys.contains(&"rare_sig"),
+        "rare_sig must survive truncation"
+      );
+    } else {
+      panic!("expected SignificantTerms response");
+    }
+  }
+
+  /// Regression test for #249: cross-segment merge must also sort by
+  /// significance score proxy before truncation.
+  #[test]
+  fn significant_terms_merge_preserves_high_significance_terms() {
+    use serde_json::json;
+
+    // Segment 1: contains "common" (high doc_count)
+    let mut seg1 = AggregationIntermediate::SignificantTerms {
+      buckets: vec![SignificantBucketIntermediate {
+        key: json!("common"),
+        doc_count: 40,
+        bg_count: 2500,
+        aggs: BTreeMap::new(),
+      }],
+      size: Some(1),
+      min_doc_count: 1,
+      pipeline: BTreeMap::new(),
+      doc_count: 50,
+      bg_count: 5000,
+      sampled: false,
+    };
+
+    // Segment 2: contains "common" (more) and "rare_sig" (low doc_count, very low bg_count)
+    let seg2 = AggregationIntermediate::SignificantTerms {
+      buckets: vec![
+        SignificantBucketIntermediate {
+          key: json!("common"),
+          doc_count: 40,
+          bg_count: 2500,
+          aggs: BTreeMap::new(),
+        },
+        SignificantBucketIntermediate {
+          key: json!("rare_sig"),
+          doc_count: 3,
+          bg_count: 5,
+          aggs: BTreeMap::new(),
+        },
+      ],
+      size: Some(1),
+      min_doc_count: 1,
+      pipeline: BTreeMap::new(),
+      doc_count: 50,
+      bg_count: 5000,
+      sampled: false,
+    };
+
+    merge_intermediate_in_place(&mut seg1, seg2);
+
+    // After merge with size=1, "rare_sig" should survive because its
+    // doc_count/bg_count ratio (3/5 = 0.6) is much higher than
+    // "common"'s (80/5000 = 0.016).
+    if let AggregationIntermediate::SignificantTerms { buckets, .. } = &seg1 {
+      assert_eq!(buckets.len(), 1, "size=1 should yield 1 bucket after merge");
+      assert_eq!(
+        buckets[0].key.as_str().unwrap(),
+        "rare_sig",
+        "rare_sig must survive merge truncation due to higher significance"
+      );
+    } else {
+      panic!("expected SignificantTerms intermediate");
     }
   }
 }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -257,19 +257,26 @@ impl<'a> SignificantTermsCollector<'a> {
       .into_values()
       .filter(|b| b.doc_count >= self.min_doc_count)
       .collect();
-    // Sort by significance score (doc_count/bg_count ratio) descending before
-    // truncation. Since the foreground/background totals are constant across all
-    // buckets, the ratio `doc_count / bg_count` is monotonically related to the
-    // full significance score `(doc_count/fg_total) / (bg_count/bg_total)` and
-    // is sufficient for ranking. This avoids discarding high-significance
-    // low-frequency terms that would be lost by a doc_count-only sort.
+    // Sort by significance score proxy (doc_count / bg_count) descending
+    // before truncation. Since the foreground/background totals are constant
+    // across all buckets, this proxy is monotonically related to the full
+    // significance score `(doc_count/fg_total) / (bg_count/bg_total)`.
+    //
+    // Buckets with bg_count == 0 are treated as score 0 to match the final
+    // scoring guard in finalize_response. Compare ratios via integer
+    // cross-multiplication to avoid float rounding.
     buckets.sort_by(|a, b| {
-      let a_score = a.doc_count as f64 / (a.bg_count.max(1)) as f64;
-      let b_score = b.doc_count as f64 / (b.bg_count.max(1)) as f64;
-      b_score
-        .partial_cmp(&a_score)
-        .unwrap_or(Ordering::Equal)
-        .then_with(|| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count))
+      let score_cmp = match (a.bg_count == 0, b.bg_count == 0) {
+        (true, true) => Ordering::Equal,
+        (true, false) => Ordering::Greater, // a has score 0, b > 0 → b first
+        (false, true) => Ordering::Less,    // b has score 0, a > 0 → a first
+        (false, false) => {
+          let left = (a.doc_count as u128) * (b.bg_count as u128);
+          let right = (b.doc_count as u128) * (a.bg_count as u128);
+          right.cmp(&left)
+        }
+      };
+      score_cmp.then_with(|| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count))
     });
     let limit = self.size.unwrap_or(buckets.len()).min(MAX_BUCKETS);
     buckets.truncate(limit);
@@ -2390,15 +2397,22 @@ fn merge_intermediate_in_place(
       let limit = target_size
         .unwrap_or_else(|| target_buckets.len())
         .min(MAX_BUCKETS);
-      // Sort by significance score proxy (doc_count/bg_count ratio) to
-      // preserve high-significance low-frequency terms during truncation.
+      // Sort by significance score proxy (doc_count/bg_count) to preserve
+      // high-significance low-frequency terms during truncation. Buckets with
+      // bg_count == 0 are treated as score 0 to match finalize_response.
+      // Compare ratios via integer cross-multiplication to avoid float rounding.
       target_buckets.sort_by(|a, b| {
-        let a_score = a.doc_count as f64 / (a.bg_count.max(1)) as f64;
-        let b_score = b.doc_count as f64 / (b.bg_count.max(1)) as f64;
-        b_score
-          .partial_cmp(&a_score)
-          .unwrap_or(Ordering::Equal)
-          .then_with(|| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count))
+        let score_cmp = match (a.bg_count == 0, b.bg_count == 0) {
+          (true, true) => Ordering::Equal,
+          (true, false) => Ordering::Greater,
+          (false, true) => Ordering::Less,
+          (false, false) => {
+            let left = (a.doc_count as u128) * (b.bg_count as u128);
+            let right = (b.doc_count as u128) * (a.bg_count as u128);
+            right.cmp(&left)
+          }
+        };
+        score_cmp.then_with(|| terms_bucket_cmp(&a.key, a.doc_count, &b.key, b.doc_count))
       });
       if target_buckets.len() > limit {
         target_buckets.truncate(limit);
@@ -4378,6 +4392,55 @@ mod tests {
       assert!(
         keys.contains(&"rare_sig"),
         "rare_sig must survive truncation"
+      );
+    } else {
+      panic!("expected SignificantTerms response");
+    }
+  }
+
+  /// Zero bg_count buckets must not displace genuinely significant terms.
+  /// finalize_response assigns score 0.0 when bg_count == 0, so the
+  /// intermediate proxy sort must also treat them as score 0.0.
+  #[test]
+  fn significant_terms_zero_bg_count_does_not_displace_real_terms() {
+    use serde_json::json;
+
+    let intermediate = AggregationIntermediate::SignificantTerms {
+      buckets: vec![
+        // "real_sig": genuinely significant (bg_count > 0)
+        SignificantBucketIntermediate {
+          key: json!("real_sig"),
+          doc_count: 5,
+          bg_count: 10,
+          aggs: BTreeMap::new(),
+        },
+        // "zero_bg": high doc_count but bg_count == 0 → final score 0.0
+        SignificantBucketIntermediate {
+          key: json!("zero_bg"),
+          doc_count: 90,
+          bg_count: 0,
+          aggs: BTreeMap::new(),
+        },
+      ],
+      size: Some(1),
+      min_doc_count: 1,
+      pipeline: BTreeMap::new(),
+      doc_count: 100,
+      bg_count: 10_000,
+      sampled: false,
+    };
+
+    let response = finalize_response(intermediate);
+    if let AggregationResponse::SignificantTerms { buckets, .. } = response {
+      assert_eq!(buckets.len(), 1, "size=1 should yield 1 bucket");
+      assert_eq!(
+        buckets[0].key.as_str().unwrap(),
+        "real_sig",
+        "zero bg_count bucket must not displace genuinely significant term"
+      );
+      assert!(
+        buckets[0].score > 0.0,
+        "real_sig should have a positive score"
       );
     } else {
       panic!("expected SignificantTerms response");

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -4167,17 +4167,20 @@ fn significant_terms_preserves_high_significance_low_frequency_terms() {
   };
   let idx = IndexBuilder::create(&path, schema, opts).expect("create index");
 
-  // Build a corpus:
-  // - "common" tag appears in 80 foreground docs and 5000 background docs
-  //   → score ≈ (80/100) / (5000/10000) = 1.6
-  // - "frequent" tag appears in 50 foreground docs and 4000 background docs
-  //   → score ≈ (50/100) / (4000/10000) = 1.25
-  // - "rare_sig" tag appears in 3 foreground docs and 5 background docs
-  //   → score ≈ (3/100) / (5/10000) = 60.0
+  // Build a corpus of 9005 total docs. The foreground set (matching "target")
+  // contains 133 docs (80 + 50 + 3). Background counts are total occurrences
+  // across the full corpus (foreground + background-only docs).
+  //
+  // - "common" tag: 80 foreground, 5000 total bg
+  //   → score ≈ (80/133) / (5000/9005) ≈ 1.08
+  // - "frequent" tag: 50 foreground, 4000 total bg
+  //   → score ≈ (50/133) / (4000/9005) ≈ 0.85
+  // - "rare_sig" tag: 3 foreground, 5 total bg
+  //   → score ≈ (3/133) / (5/9005) ≈ 40.6
   //
   // With size=2, a doc_count sort would keep "common"(80) and "frequent"(50),
-  // discarding "rare_sig"(3). The correct result keeps "rare_sig" (score=60)
-  // and "common" (score=1.6).
+  // discarding "rare_sig"(3). The correct result keeps "rare_sig" (score≈40.6)
+  // and "common" (score≈1.08).
   {
     let mut writer = idx.writer().expect("writer");
     let mut id = 0u64;

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -4135,3 +4135,204 @@ fn date_range_to_is_exclusive_at_boundary() {
     panic!("expected date range agg response");
   }
 }
+
+/// Regression test for #249: significant_terms intermediate truncation must
+/// sort by significance score (doc_count/bg_count ratio), not by raw doc_count.
+/// A low-frequency term with a very low background count can have a much higher
+/// significance score than a high-frequency term with a high background count.
+/// With size=2, the two most *significant* terms must survive truncation.
+#[test]
+fn significant_terms_preserves_high_significance_low_frequency_terms() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema
+    .keyword_fields
+    .push(searchlite_core::api::types::KeywordField {
+      name: "tag".into(),
+      stored: true,
+      indexed: true,
+      fast: true,
+      nullable: false,
+    });
+  let opts = IndexOptions {
+    path: path.clone(),
+    create_if_missing: true,
+    enable_positions: true,
+    bm25_k1: 0.9,
+    bm25_b: 0.4,
+    storage: StorageType::Filesystem,
+    #[cfg(feature = "vectors")]
+    vector_defaults: None,
+  };
+  let idx = IndexBuilder::create(&path, schema, opts).expect("create index");
+
+  // Build a corpus:
+  // - "common" tag appears in 80 foreground docs and 5000 background docs
+  //   → score ≈ (80/100) / (5000/10000) = 1.6
+  // - "frequent" tag appears in 50 foreground docs and 4000 background docs
+  //   → score ≈ (50/100) / (4000/10000) = 1.25
+  // - "rare_sig" tag appears in 3 foreground docs and 5 background docs
+  //   → score ≈ (3/100) / (5/10000) = 60.0
+  //
+  // With size=2, a doc_count sort would keep "common"(80) and "frequent"(50),
+  // discarding "rare_sig"(3). The correct result keeps "rare_sig" (score=60)
+  // and "common" (score=1.6).
+  {
+    let mut writer = idx.writer().expect("writer");
+    let mut id = 0u64;
+
+    // Background-only docs: "common" tag in 4920 docs (total bg will be 5000)
+    for _ in 0..4920 {
+      writer
+        .add_document(&doc(
+          &id.to_string(),
+          vec![
+            ("body", json!("background noise")),
+            ("tag", json!("common")),
+          ],
+        ))
+        .unwrap();
+      id += 1;
+    }
+
+    // Background-only docs: "frequent" tag in 3950 docs (total bg will be 4000)
+    for _ in 0..3950 {
+      writer
+        .add_document(&doc(
+          &id.to_string(),
+          vec![
+            ("body", json!("background noise")),
+            ("tag", json!("frequent")),
+          ],
+        ))
+        .unwrap();
+      id += 1;
+    }
+
+    // Background-only docs: "rare_sig" tag in 2 docs (total bg will be 5)
+    for _ in 0..2 {
+      writer
+        .add_document(&doc(
+          &id.to_string(),
+          vec![
+            ("body", json!("background noise")),
+            ("tag", json!("rare_sig")),
+          ],
+        ))
+        .unwrap();
+      id += 1;
+    }
+
+    // Foreground docs matching "target": 80 with "common"
+    for _ in 0..80 {
+      writer
+        .add_document(&doc(
+          &id.to_string(),
+          vec![("body", json!("target query")), ("tag", json!("common"))],
+        ))
+        .unwrap();
+      id += 1;
+    }
+
+    // Foreground docs matching "target": 50 with "frequent"
+    for _ in 0..50 {
+      writer
+        .add_document(&doc(
+          &id.to_string(),
+          vec![("body", json!("target query")), ("tag", json!("frequent"))],
+        ))
+        .unwrap();
+      id += 1;
+    }
+
+    // Foreground docs matching "target": 3 with "rare_sig"
+    for _ in 0..3 {
+      writer
+        .add_document(&doc(
+          &id.to_string(),
+          vec![("body", json!("target query")), ("tag", json!("rare_sig"))],
+        ))
+        .unwrap();
+      id += 1;
+    }
+
+    writer.commit().unwrap();
+  }
+
+  let reader = idx.reader().unwrap();
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "sig".to_string(),
+    Aggregation::SignificantTerms(Box::new(SignificantTermsAggregation {
+      field: "tag".into(),
+      size: Some(2),
+      min_doc_count: None,
+      background_filter: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+
+  let resp = reader
+    .search(&SearchRequest {
+      query: "target".into(),
+      fields: None,
+      filter: None,
+      limit: 0,
+      from: 0,
+      return_hits: false,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+
+  let sig = resp.aggregations.get("sig").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::SignificantTerms { buckets, .. } = sig {
+    assert_eq!(buckets.len(), 2, "expected 2 significant_terms buckets");
+    // "rare_sig" must be in the results despite having doc_count=3,
+    // because its significance score is far higher than "frequent"
+    let keys: Vec<String> = buckets
+      .iter()
+      .map(|b| b.key.as_str().unwrap().to_string())
+      .collect();
+    assert!(
+      keys.contains(&"rare_sig".to_string()),
+      "rare_sig (high significance, low doc_count) must survive truncation, got: {:?}",
+      keys
+    );
+    // "rare_sig" should be ranked first (highest score)
+    assert_eq!(
+      buckets[0].key.as_str().unwrap(),
+      "rare_sig",
+      "rare_sig should be ranked #1 by significance score"
+    );
+    assert!(
+      buckets[0].score > buckets[1].score,
+      "first bucket should have higher score than second"
+    );
+  } else {
+    panic!("expected significant_terms response");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #249. `SignificantTermsCollector::finish` and the cross-segment merge step both sorted intermediate buckets by `doc_count` descending (via `terms_bucket_cmp`) and truncated to `size` — but the final ranking in `finalize_response` sorts by significance **score** (`foreground_pct / background_pct`). These orderings are fundamentally different: a term with low `doc_count` but very low `bg_count` can have a far higher significance score than a common term with high `doc_count`. The intermediate truncation systematically discarded exactly the kind of terms `significant_terms` is designed to surface.

## What changed

- **`searchlite-core/src/query/aggs/mod.rs`** — in `SignificantTermsCollector::finish()`, replace the `terms_bucket_cmp` (doc_count descending) sort with a significance score proxy sort (`doc_count / bg_count.max(1)` ratio descending). Since the foreground/background totals are constant across all terms in a given segment, this ratio is monotonically related to the full significance score and sufficient for correct ranking before truncation.
- **`searchlite-core/src/query/aggs/mod.rs`** — apply the same significance-score-proxy sort in the cross-segment merge step, replacing the `terms_bucket_cmp` sort that was also discarding high-significance low-frequency terms during merge truncation.
- **`searchlite-core/src/query/aggs/mod.rs`** (unit tests) — add two regression tests:
  - `significant_terms_finalize_ranks_by_significance_score` — constructs `SignificantBucketIntermediate` values directly and verifies that `finalize_response` ranks a low-frequency high-significance term ("rare_sig", score=60) above a high-frequency low-significance term ("common", score=1.6) with `size=2`.
  - `significant_terms_merge_preserves_high_significance_terms` — tests the cross-segment merge path: two segments are merged with `size=1`, and the high-significance low-frequency term survives truncation instead of the high-frequency one.
- **`searchlite-core/tests/aggregations.rs`** — add end-to-end integration test `significant_terms_preserves_high_significance_low_frequency_terms`: indexes a realistic corpus (≈9000 docs) with three tags of varying foreground frequency and background frequency, runs a `significant_terms` aggregation with `size=2`, and asserts that "rare_sig" (doc_count=3, bg_count=5, score≈60) survives truncation and is ranked #1 despite "common" (doc_count=80) and "frequent" (doc_count=50) having much higher raw doc counts.

## Test plan

- [x] `cargo test -p searchlite-core --lib query::aggs::tests::significant_terms` — 2/2 pass (new).
- [x] `cargo test -p searchlite-core --test aggregations significant_terms` — 2/2 pass (1 existing + 1 new).
- [x] `cargo test -p searchlite-core` — full core test matrix green (480 tests, 0 failures).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.

Closes #249