### PR TITLE
fix(aggs): preserve sub-day time in add_calendar for offset-aligned bucket keys

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3942,7 +3942,11 @@ fn add_calendar(value: i64, unit: CalendarUnit) -> Option<i64> {
       .with_month(1)?
       .with_day(1)?,
   };
-  let next_dt = next_date.and_hms_opt(0, 0, 0)?;
+  // Preserve the original time-of-day so that bucket keys remain aligned
+  // with any sub-day offset applied by `bucket_start`. Previously this
+  // hardcoded midnight via `and_hms_opt(0, 0, 0)`, which discarded the
+  // offset and produced misaligned fill-loop keys (issue #251).
+  let next_dt = next_date.and_time(dt.naive_utc().time());
   Some(chrono::DateTime::<Utc>::from_naive_utc_and_offset(next_dt, Utc).timestamp_millis())
 }
 
@@ -4332,6 +4336,105 @@ mod tests {
         );
       }
       date = date.succ_opt().unwrap();
+    }
+  }
+
+  /// Regression for #251: add_calendar must preserve the sub-day time
+  /// component so that bucket keys stay aligned with the offset applied by
+  /// bucket_start. Previously `and_hms_opt(0, 0, 0)` discarded the time,
+  /// snapping every bucket after the first to midnight.
+  #[test]
+  fn add_calendar_preserves_sub_day_time_component() {
+    use chrono::{NaiveDate, Utc};
+    // Input: 2024-04-01T01:00:00Z (midnight + 1h offset)
+    let dt = NaiveDate::from_ymd_opt(2024, 4, 1)
+      .unwrap()
+      .and_hms_opt(1, 0, 0)
+      .unwrap();
+    let ts = chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).timestamp_millis();
+
+    // Month: expect 2024-05-01T01:00:00Z, NOT 2024-05-01T00:00:00Z
+    let next = add_calendar(ts, CalendarUnit::Month).unwrap();
+    let expected = NaiveDate::from_ymd_opt(2024, 5, 1)
+      .unwrap()
+      .and_hms_opt(1, 0, 0)
+      .unwrap();
+    let expected_ts =
+      chrono::DateTime::<Utc>::from_naive_utc_and_offset(expected, Utc).timestamp_millis();
+    assert_eq!(
+      next, expected_ts,
+      "add_calendar(Month) must preserve 01:00:00 offset"
+    );
+
+    // Quarter: expect 2024-07-01T01:00:00Z
+    let next_q = add_calendar(ts, CalendarUnit::Quarter).unwrap();
+    let expected_q = NaiveDate::from_ymd_opt(2024, 7, 1)
+      .unwrap()
+      .and_hms_opt(1, 0, 0)
+      .unwrap();
+    let expected_q_ts =
+      chrono::DateTime::<Utc>::from_naive_utc_and_offset(expected_q, Utc).timestamp_millis();
+    assert_eq!(
+      next_q, expected_q_ts,
+      "add_calendar(Quarter) must preserve 01:00:00 offset"
+    );
+
+    // Year: expect 2025-01-01T01:00:00Z
+    let next_y = add_calendar(ts, CalendarUnit::Year).unwrap();
+    let expected_y = NaiveDate::from_ymd_opt(2025, 1, 1)
+      .unwrap()
+      .and_hms_opt(1, 0, 0)
+      .unwrap();
+    let expected_y_ts =
+      chrono::DateTime::<Utc>::from_naive_utc_and_offset(expected_y, Utc).timestamp_millis();
+    assert_eq!(
+      next_y, expected_y_ts,
+      "add_calendar(Year) must preserve 01:00:00 offset"
+    );
+  }
+
+  /// Regression for #251: chained add_calendar calls (as the fill loop does)
+  /// must produce a monotonically increasing sequence where every bucket key
+  /// keeps the original sub-day offset.
+  #[test]
+  fn add_calendar_fill_loop_stays_aligned_with_offset() {
+    use chrono::{NaiveDate, Utc};
+    let offset_ms: i64 = 3_600_000; // 1 hour
+    let start_dt = NaiveDate::from_ymd_opt(2024, 4, 1)
+      .unwrap()
+      .and_hms_opt(1, 0, 0)
+      .unwrap();
+    let start =
+      chrono::DateTime::<Utc>::from_naive_utc_and_offset(start_dt, Utc).timestamp_millis();
+
+    let expected_keys: Vec<i64> = [(2024, 4, 1), (2024, 5, 1), (2024, 6, 1), (2024, 7, 1)]
+      .iter()
+      .map(|(y, m, d)| {
+        let dt = NaiveDate::from_ymd_opt(*y, *m, *d)
+          .unwrap()
+          .and_hms_opt(1, 0, 0)
+          .unwrap();
+        chrono::DateTime::<Utc>::from_naive_utc_and_offset(dt, Utc).timestamp_millis()
+      })
+      .collect();
+
+    let mut current = start;
+    let mut keys = vec![current];
+    for _ in 0..3 {
+      current = add_calendar(current, CalendarUnit::Month).unwrap();
+      keys.push(current);
+    }
+    assert_eq!(
+      keys, expected_keys,
+      "fill loop must produce keys at T01:00:00Z, not T00:00:00Z"
+    );
+
+    // Also verify bucket_start + add_interval round-trip consistency
+    let interval = DateInterval::Calendar(CalendarUnit::Month);
+    let mut cur = bucket_start(start, offset_ms, &interval).unwrap();
+    for expected in &expected_keys {
+      assert_eq!(cur, *expected);
+      cur = add_interval(cur, &interval).unwrap();
     }
   }
 

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -2594,3 +2594,160 @@ mod bug_233 {
     );
   }
 }
+
+/// Regression tests for #251: add_calendar must preserve the sub-day time
+/// component so that the fill loop produces bucket keys aligned with the
+/// offset applied by bucket_start.
+mod bug_251 {
+  use super::*;
+
+  /// Calendar month interval with offset=1h and extended_bounds spanning
+  /// April–June. The fill loop must produce keys at T01:00:00Z (not midnight)
+  /// for every bucket, and there must be no phantom duplicate buckets.
+  #[test]
+  fn date_histogram_calendar_month_with_offset_produces_aligned_keys() {
+    let tmp = tempfile::tempdir().unwrap();
+    let path = tmp.path().to_path_buf();
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "ts".into(),
+      i64: true,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    let idx = Index::create(&path, schema, build_base_options(&path)).unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      // April 15 doc
+      let apr = DateTime::parse_from_rfc3339("2024-04-15T10:00:00Z")
+        .unwrap()
+        .timestamp_millis();
+      writer
+        .add_document(&doc(
+          "d1",
+          vec![("body", json!("test")), ("ts", json!(apr))],
+        ))
+        .unwrap();
+      // May 20 doc
+      let may = DateTime::parse_from_rfc3339("2024-05-20T10:00:00Z")
+        .unwrap()
+        .timestamp_millis();
+      writer
+        .add_document(&doc(
+          "d2",
+          vec![("body", json!("test")), ("ts", json!(may))],
+        ))
+        .unwrap();
+      writer.commit().unwrap();
+    }
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: Some("month".into()),
+        fixed_interval: None,
+        offset: Some("1h".into()),
+        format: None,
+        min_doc_count: Some(0),
+        extended_bounds: Some(DateHistogramBounds {
+          min: "2024-04-01T02:00:00Z".into(),
+          max: "2024-06-01T02:00:00Z".into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let resp = idx
+      .reader()
+      .unwrap()
+      .search(&SearchRequest {
+        query: "test".into(),
+        fields: None,
+        filter: None,
+        limit: 0,
+        from: 0,
+        return_hits: false,
+        candidate_size: None,
+        #[cfg(feature = "vectors")]
+        max_global_vector_candidates: None,
+        sort: Vec::new(),
+        cursor: None,
+        search_after: None,
+        execution: ExecutionStrategy::Wand,
+        bmw_block_size: None,
+        fuzzy: None,
+        track_total_hits: None,
+        #[cfg(feature = "vectors")]
+        vector_query: None,
+        #[cfg(feature = "vectors")]
+        vector_filter: None,
+        return_stored: false,
+        highlight_field: None,
+        highlight: None,
+        collapse: None,
+        aggs,
+        suggest: BTreeMap::new(),
+        rescore: None,
+        explain: false,
+        profile: false,
+      })
+      .unwrap();
+
+    let hist = resp.aggregations.get("hist").unwrap();
+    let buckets = match hist {
+      searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } => buckets,
+      other => panic!("expected DateHistogram, got: {other:?}"),
+    };
+
+    // Collect (key_ms, doc_count) pairs
+    let entries: Vec<(i64, u64)> = buckets
+      .iter()
+      .map(|b| {
+        let key = b.key.as_i64().unwrap();
+        (key, b.doc_count)
+      })
+      .collect();
+
+    // Expected bucket keys: all at T01:00:00Z due to 1h offset
+    let apr_key = DateTime::parse_from_rfc3339("2024-04-01T01:00:00Z")
+      .unwrap()
+      .timestamp_millis();
+    let may_key = DateTime::parse_from_rfc3339("2024-05-01T01:00:00Z")
+      .unwrap()
+      .timestamp_millis();
+    let jun_key = DateTime::parse_from_rfc3339("2024-06-01T01:00:00Z")
+      .unwrap()
+      .timestamp_millis();
+
+    // Must have exactly 3 buckets (Apr, May, Jun) — no phantom midnight buckets
+    assert_eq!(
+      entries.len(),
+      3,
+      "expected 3 buckets (Apr/May/Jun), got {}: {entries:?}",
+      entries.len()
+    );
+
+    // Verify all keys are at T01:00:00Z
+    let keys: Vec<i64> = entries.iter().map(|(k, _)| *k).collect();
+    assert_eq!(
+      keys,
+      vec![apr_key, may_key, jun_key],
+      "bucket keys must be at T01:00:00Z, not midnight; got: {entries:?}"
+    );
+
+    // April: 1 doc, May: 1 doc, June: 0 docs
+    assert_eq!(entries[0].1, 1, "April bucket should have 1 doc");
+    assert_eq!(entries[1].1, 1, "May bucket should have 1 doc");
+    assert_eq!(entries[2].1, 0, "June bucket should have 0 docs");
+
+    // Total doc_count must equal indexed docs (no double-counting)
+    let total: u64 = entries.iter().map(|(_, c)| c).sum();
+    assert_eq!(total, 2, "total doc_count must equal indexed docs");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #251. `add_calendar` (used by the date_histogram empty-bucket fill loop and the span-cap estimator) hardcoded midnight (`and_hms_opt(0, 0, 0)`) when reconstructing the next bucket boundary. When the input timestamp carried a sub-day time component — which happens whenever `bucket_start` adds a non-zero `offset` — every bucket after the first was placed at midnight instead of at midnight + offset. This produced phantom empty buckets at wrong timestamps, misaligned with the buckets created by the collection path.

## What changed

- **`searchlite-core/src/query/aggs/mod.rs`** — replace `next_date.and_hms_opt(0, 0, 0)` with `next_date.and_time(dt.naive_utc().time())` so the original hour:minute:second is preserved in the returned timestamp. This affects all five `CalendarUnit` variants (Day, Week, Month, Quarter, Year) since they all share the same timestamp reconstruction line.
- **`searchlite-core/src/query/aggs/mod.rs`** (unit tests) — add:
  - `add_calendar_preserves_sub_day_time_component` — verifies Month, Quarter, and Year variants all preserve a 1h offset.
  - `add_calendar_fill_loop_stays_aligned_with_offset` — simulates the fill loop's chained `add_calendar` calls and verifies all resulting keys stay at `T01:00:00Z`. Also validates round-trip consistency with `bucket_start` + `add_interval`.
- **`searchlite-core/tests/aggregation_bounds.rs`** — add `bug_251::date_histogram_calendar_month_with_offset_produces_aligned_keys`: end-to-end test that indexes docs in April and May, runs a `calendar_interval: "month"` aggregation with `offset: "1h"` and `extended_bounds`, and asserts exactly 3 buckets at `T01:00:00Z` with correct doc counts and no phantom midnight duplicates.

## Test plan

- [x] `cargo test -p searchlite-core --lib query::aggs::tests::add_calendar` — 2/2 pass (new).
- [x] `cargo test -p searchlite-core --test aggregation_bounds bug_251` — 1/1 pass (new).
- [x] `cargo test -p searchlite-core` — full core test matrix green (lib + all integration suites).
- [x] `cargo fmt --all --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.

Closes #251