### PR TITLE
fix(query): align normalize_pattern case-folding with default tokenizer (BUG-255)

### DIFF
--- a/searchlite-core/src/analysis/analyzer.rs
+++ b/searchlite-core/src/analysis/analyzer.rs
@@ -30,16 +30,21 @@ impl Analyzer {
 
   /// Applies inexpensive, structure-preserving normalization suitable for patterns
   /// (e.g., wildcard/regex) without re-tokenizing or stripping delimiters.
+  ///
+  /// The folding strategy must match the tokenizer so that pattern terms align
+  /// with indexed terms. The `Unicode` tokenizer and the `Lowercase` filter
+  /// both apply full Unicode case-folding (`str::to_lowercase`), while the
+  /// `Default` tokenizer applies ASCII-only folding (`char::to_ascii_lowercase`).
   pub fn normalize_pattern(&self, pattern: &str) -> String {
-    let lowercases = matches!(
-      self.tokenizer,
-      TokenizerKind::Default | TokenizerKind::Unicode
-    ) || self
-      .filters
-      .iter()
-      .any(|f| matches!(f, TokenFilter::Lowercase));
-    if lowercases {
+    let has_unicode_lower = matches!(self.tokenizer, TokenizerKind::Unicode)
+      || self
+        .filters
+        .iter()
+        .any(|f| matches!(f, TokenFilter::Lowercase));
+    if has_unicode_lower {
       pattern.to_lowercase()
+    } else if matches!(self.tokenizer, TokenizerKind::Default) {
+      pattern.chars().map(|c| c.to_ascii_lowercase()).collect()
     } else {
       pattern.to_string()
     }
@@ -566,5 +571,50 @@ mod tests {
       texts,
       vec!["r".to_string(), "ru".to_string(), "rus".to_string()]
     );
+  }
+
+  #[test]
+  fn normalize_pattern_default_uses_ascii_only_folding() {
+    let analyzer = Analyzer::default_analyzer();
+    // ASCII uppercase is lowered.
+    assert_eq!(analyzer.normalize_pattern("RÉS*"), "rÉs*");
+    // Non-ASCII uppercase is preserved (É stays É), matching default_tokenize.
+    assert_eq!(analyzer.normalize_pattern("RÉSUMÉ"), "rÉsumÉ");
+    // Pure ASCII still works as expected.
+    assert_eq!(analyzer.normalize_pattern("HELLO*"), "hello*");
+  }
+
+  #[test]
+  fn normalize_pattern_unicode_uses_full_unicode_folding() {
+    let analyzer = Analyzer {
+      tokenizer: TokenizerKind::Unicode,
+      filters: vec![],
+    };
+    // Full Unicode: É → é.
+    assert_eq!(analyzer.normalize_pattern("RÉS*"), "rés*");
+    assert_eq!(analyzer.normalize_pattern("RÉSUMÉ"), "résumé");
+  }
+
+  #[test]
+  fn normalize_pattern_default_with_lowercase_filter_uses_unicode_folding() {
+    let analyzer = Analyzer {
+      tokenizer: TokenizerKind::Default,
+      filters: vec![TokenFilter::Lowercase],
+    };
+    // The Lowercase filter applies full Unicode folding, so normalize_pattern
+    // should match that behavior even though the tokenizer is Default.
+    assert_eq!(analyzer.normalize_pattern("RÉS*"), "rés*");
+    assert_eq!(analyzer.normalize_pattern("RÉSUMÉ"), "résumé");
+  }
+
+  #[test]
+  fn normalize_pattern_whitespace_no_filters_preserves_case() {
+    let analyzer = Analyzer {
+      tokenizer: TokenizerKind::Whitespace,
+      filters: vec![],
+    };
+    // Whitespace tokenizer does not lowercase at all.
+    assert_eq!(analyzer.normalize_pattern("RÉS*"), "RÉS*");
+    assert_eq!(analyzer.normalize_pattern("HELLO"), "HELLO");
   }
 }

--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -1346,4 +1346,31 @@ mod tests {
     let tokens = analyze_pattern_tokens(analyzer, "HELLO", &wildcard);
     assert_eq!(tokens, vec!["hello"]);
   }
+
+  #[test]
+  fn analyze_pattern_tokens_wildcard_non_ascii_uppercase_matches_default_tokenizer() {
+    // BUG-255 repro: wildcard pattern "RÉS*" with the default analyzer.
+    // default_tokenize uses ASCII-only lowering, so indexed term for "RÉSUMÉ"
+    // is "rÉsumÉ". normalize_pattern must produce "rÉs*" (not "rés*") so
+    // that the prefix matches the indexed form.
+    let registry = AnalyzerRegistry::with_default();
+    let analyzer = registry.get("default").unwrap();
+    let wildcard = TermExpansion::Wildcard {
+      max_expansions: 100,
+    };
+    let tokens = analyze_pattern_tokens(analyzer, "RÉS*", &wildcard);
+    assert_eq!(tokens, vec!["rÉs*"]);
+  }
+
+  #[test]
+  fn analyze_pattern_tokens_regex_non_ascii_uppercase_matches_default_tokenizer() {
+    // Same BUG-255 scenario but for regex expansion.
+    let registry = AnalyzerRegistry::with_default();
+    let analyzer = registry.get("default").unwrap();
+    let regex = TermExpansion::Regex {
+      max_expansions: 100,
+    };
+    let tokens = analyze_pattern_tokens(analyzer, "RÉS.+", &regex);
+    assert_eq!(tokens, vec!["rÉs.+"]);
+  }
 }

--- a/searchlite-core/tests/regressions.rs
+++ b/searchlite-core/tests/regressions.rs
@@ -490,3 +490,74 @@ fn keyword_match_and_filter_agree_on_non_ascii_case() {
     .collect();
   assert_eq!(cyrillic_query_ids, cyrillic_filter_ids);
 }
+
+/// Regression test for davidkelley/searchlite#255.
+///
+/// The default tokenizer applies ASCII-only case-folding
+/// (`char::to_ascii_lowercase`), so "RÉSUMÉ" is indexed as the token
+/// "rÉsumÉ" (É is not ASCII and stays uppercase). Before the fix,
+/// `normalize_pattern` applied full Unicode lowering (`str::to_lowercase`),
+/// producing "rés*" for the wildcard pattern "RÉS*". The byte sequences
+/// diverge (É = 0xC3 0x89 vs é = 0xC3 0xA9), so the prefix match failed
+/// and the document was silently omitted from results.
+///
+/// After the fix, `normalize_pattern` uses ASCII-only lowering when the
+/// tokenizer is `Default`, producing "rÉs*" which correctly matches the
+/// indexed prefix "rÉs".
+#[test]
+fn wildcard_query_matches_non_ascii_uppercase_with_default_tokenizer() {
+  let dir = tempdir().unwrap();
+  let path = dir.path().to_path_buf();
+  let idx = Index::create(&path, Schema::default_text_body(), opts(&path)).unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    writer
+      .add_document(&doc(
+        "resume_doc",
+        vec![("body", json!("RÉSUMÉ WRITING GUIDE"))],
+      ))
+      .unwrap();
+    writer
+      .add_document(&doc(
+        "plain_doc",
+        vec![("body", json!("REGULAR WRITING GUIDE"))],
+      ))
+      .unwrap();
+    writer.commit().unwrap();
+  }
+  let reader = idx.reader().unwrap();
+
+  // Wildcard query "RÉS*" must match the document with "RÉSUMÉ".
+  let wildcard_req = SearchRequest {
+    query: Query::Node(QueryNode::Wildcard {
+      field: "body".into(),
+      value: "RÉS*".into(),
+      max_expansions: None,
+      boost: None,
+    }),
+    ..base_request("", None)
+  };
+  let wildcard_ids: Vec<String> = reader
+    .search(&wildcard_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_eq!(wildcard_ids, vec!["resume_doc".to_string()]);
+
+  // A query-string search for the same term should also find the document,
+  // confirming both paths agree on case folding.
+  let match_req = SearchRequest {
+    query: Query::String("RÉSUMÉ".into()),
+    ..base_request("", None)
+  };
+  let match_ids: Vec<String> = reader
+    .search(&match_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_eq!(match_ids, vec!["resume_doc".to_string()]);
+}


### PR DESCRIPTION
## Summary

- `normalize_pattern()` applied full Unicode lowering (`str::to_lowercase`) regardless of tokenizer, while the default tokenizer uses ASCII-only folding (`char::to_ascii_lowercase`). This caused wildcard/regex queries containing non-ASCII uppercase characters (É, Ñ, Ü, Cyrillic, Greek, …) to silently return zero results for documents that should match.
- Makes `normalize_pattern` match the tokenizer's actual folding strategy: ASCII-only for `Default`, full Unicode for `Unicode`/`Lowercase` filter, no folding for `Whitespace`.
- Adds unit tests covering all three tokenizer paths and an integration test reproducing the exact scenario from the bug report (wildcard `RÉS*` against indexed `RÉSUMÉ`).

## What changed

- **`searchlite-core/src/analysis/analyzer.rs`** — `normalize_pattern()` now branches on tokenizer kind: `Default` → `char::to_ascii_lowercase` per character; `Unicode` or `Lowercase` filter → `str::to_lowercase`; `Whitespace` (no filter) → identity.
- **`searchlite-core/src/api/term_expansion.rs`** — Two new unit tests pinning the wildcard and regex paths for non-ASCII uppercase with the default analyzer.
- **`searchlite-core/tests/regressions.rs`** — Integration test: indexes "RÉSUMÉ WRITING GUIDE", runs wildcard query `RÉS*`, asserts match. Also confirms query-string search agrees.

## Test plan

- [x] `cargo test -p searchlite-core --lib analysis::analyzer::tests::normalize_pattern` — 4/4 pass (new)
- [x] `cargo test -p searchlite-core --lib api::term_expansion::tests` — 39/39 pass (2 new + 37 existing)
- [x] `cargo test -p searchlite-core --test regressions wildcard_query_matches_non_ascii_uppercase` — 1/1 pass (new)
- [x] `cargo test -p searchlite-core` — full test suite green (347 unit + all integration)
- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean

Closes #255