### PR TITLE
fix(analysis): skip edge_ngram emission for tokens shorter than min (BUG-259)

### DIFF
--- a/searchlite-core/src/analysis/analyzer.rs
+++ b/searchlite-core/src/analysis/analyzer.rs
@@ -585,7 +585,10 @@ mod tests {
       })],
       "ab",
     );
-    assert!(tokens.is_empty(), "tokens shorter than min should produce no ngrams");
+    assert!(
+      tokens.is_empty(),
+      "tokens shorter than min should produce no ngrams"
+    );
   }
 
   #[test]

--- a/searchlite-core/src/analysis/analyzer.rs
+++ b/searchlite-core/src/analysis/analyzer.rs
@@ -427,8 +427,11 @@ fn edge_ngrams(tokens: Vec<Token>, cfg: &EdgeNgramConfig) -> Vec<Token> {
   let mut out = Vec::new();
   for token in tokens.into_iter() {
     let len = token.text.chars().count();
+    if len < cfg.min {
+      continue;
+    }
     let max = usize::min(cfg.max, len);
-    let min = usize::min(cfg.min, max);
+    let min = cfg.min;
     if min == 0 || max == 0 {
       continue;
     }
@@ -571,6 +574,31 @@ mod tests {
       texts,
       vec!["r".to_string(), "ru".to_string(), "rus".to_string()]
     );
+  }
+
+  #[test]
+  fn edge_ngram_skips_tokens_shorter_than_min() {
+    let tokens = analyze_with(
+      vec![TokenFilterDef::EdgeNgram(EdgeNgramConfig {
+        min: 3,
+        max: 5,
+      })],
+      "ab",
+    );
+    assert!(tokens.is_empty(), "tokens shorter than min should produce no ngrams");
+  }
+
+  #[test]
+  fn edge_ngram_includes_token_equal_to_min() {
+    let tokens = analyze_with(
+      vec![TokenFilterDef::EdgeNgram(EdgeNgramConfig {
+        min: 3,
+        max: 5,
+      })],
+      "abc",
+    );
+    let texts: Vec<String> = tokens.into_iter().map(|t| t.text).collect();
+    assert_eq!(texts, vec!["abc".to_string()]);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Fix `edge_ngrams()` to skip tokens shorter than the configured `min` length, matching Elasticsearch's `EdgeNGramTokenFilter` semantics
- Previously, `min` was silently clamped to the token length, causing short tokens (e.g. `"ab"` with `min=3`) to emit ngrams below the configured minimum
- Add tests for both the skip case (token < min) and the boundary case (token == min)

## Root cause

In `analyzer.rs:431`, the line `let min = usize::min(cfg.min, max)` reduces `min` to the token length when `len < cfg.min`. The zero-check guard only catches empty tokens, not tokens shorter than the configured minimum.

## Fix

Add an early-exit `if len < cfg.min { continue; }` before the clamping logic, so tokens shorter than the configured minimum produce no ngrams at all.

## Test plan

- [x] `cargo test -p searchlite-core -- edge_ngram` — 4 tests pass (2 new + 2 existing)
- [x] `cargo test -p searchlite-core` — full suite passes (349 tests)
- [x] `cargo clippy -p searchlite-core -- -D warnings` — clean

Closes #259