### PR TITLE
fix(score): Log2p modifier uses ln(value+2) instead of log₂(value+1) (BUG-261)

### DIFF
--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -209,10 +209,10 @@ fn apply_modifier(value: f64, modifier: &FieldValueModifier) -> f64 {
       }
     }
     FieldValueModifier::Log2p => {
-      if value <= -1.0 {
+      if value <= -2.0 {
         0.0
       } else {
-        (value + 1.0).log2()
+        (value + 2.0).ln()
       }
     }
     FieldValueModifier::Sqrt => {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -386,17 +386,17 @@ fn log2p_modifier_uses_natural_log_of_value_plus_two() {
   assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
   let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
   assert!(
-    (scores[0] - 12_f64.ln() as f32).abs() < 1e-4,
+    (scores[0] - 12_f32.ln()).abs() < 1e-6,
     "doc-1: {}",
     scores[0]
   );
   assert!(
-    (scores[1] - 7_f64.ln() as f32).abs() < 1e-4,
+    (scores[1] - 7_f32.ln()).abs() < 1e-6,
     "doc-3: {}",
     scores[1]
   );
   assert!(
-    (scores[2] - 3_f64.ln() as f32).abs() < 1e-4,
+    (scores[2] - 3_f32.ln()).abs() < 1e-6,
     "doc-2: {}",
     scores[2]
   );

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -363,6 +363,46 @@ fn rank_feature_uses_numeric_fast_field() {
 }
 
 #[test]
+fn log2p_modifier_uses_natural_log_of_value_plus_two() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::Log2p),
+      missing: None,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  // popularity: doc-1=10, doc-3=5, doc-2=1
+  // Log2p = ln(value + 2): ln(12) ≈ 2.485, ln(7) ≈ 1.946, ln(3) ≈ 1.099
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert!(
+    (scores[0] - 12_f64.ln() as f32).abs() < 1e-4,
+    "doc-1: {}",
+    scores[0]
+  );
+  assert!(
+    (scores[1] - 7_f64.ln() as f32).abs() < 1e-4,
+    "doc-3: {}",
+    scores[1]
+  );
+  assert!(
+    (scores[2] - 3_f64.ln() as f32).abs() < 1e-4,
+    "doc-2: {}",
+    scores[2]
+  );
+}
+
+#[test]
 fn script_score_evaluates_expression_with_score_and_field() {
   let reader = setup_reader();
   let req = base_request(QueryNode::ScriptScore {


### PR DESCRIPTION
## Summary

- Fix `Log2p` modifier in `apply_modifier` to compute `ln(value + 2)` (natural log with +2 offset) instead of `log₂(value + 1)` (base-2 log with +1 offset)
- Align domain guard from `value <= -1.0` to `value <= -2.0` to match the corrected formula
- Add integration test validating exact `Log2p` scores against expected `ln(value + 2)` values

## Root cause

The `Log2p` arm confused Rust's `f64::log2()` (base-2 logarithm) with the semantic intent of "log, plus 2" (natural log with +2 offset). The sibling variants `Log` and `Log1p` both use natural logarithm, so `Log2p` should follow the same convention with an addend of 2.

## Changes

**`searchlite-core/src/query/score_functions.rs`**
- `Log2p` arm: `(value + 1.0).log2()` → `(value + 2.0).ln()`
- Domain guard: `value <= -1.0` → `value <= -2.0`

**`searchlite-core/tests/function_score.rs`**
- New test `log2p_modifier_uses_natural_log_of_value_plus_two` that asserts scores match `ln(12)`, `ln(7)`, `ln(3)` for popularity values 10, 5, 1

## Test plan

- [x] `cargo test -p searchlite-core --test function_score` — 12 tests pass
- [x] `cargo test -p searchlite-core` — full suite passes (350+ unit tests, 16 integration test files)
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #261