### PR TITLE
fix(rescore): non-matching docs receive zero contribution under Multiply/Min (BUG-263)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2038,6 +2038,11 @@ impl IndexReader {
           continue;
         }
         if !query_eval.matches(doc_id) {
+          let hit = hits.get_mut(hit_idx).unwrap();
+          let orig_score = hit.score;
+          let combined = combine_rescore_scores(rescore.score_mode, orig_score, 0.0);
+          hit.score = combined;
+          hit.key = sort_plan.build_key(seg, doc_id, combined, segment_ord);
           continue;
         }
         stats.candidates_examined += 1;

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2043,6 +2043,21 @@ impl IndexReader {
           let combined = combine_rescore_scores(rescore.score_mode, orig_score, 0.0);
           hit.score = combined;
           hit.key = sort_plan.build_key(seg, doc_id, combined, segment_ord);
+          if req.explain {
+            let mut expl = hit.explanation.take().unwrap_or(HitExplanation {
+              base_score: orig_score,
+              functions: Vec::new(),
+              rescore: None,
+              final_score: orig_score,
+            });
+            expl.rescore = Some(RescoreExplanation {
+              rescore_score: 0.0,
+              combined_score: combined,
+              functions: Vec::new(),
+            });
+            expl.final_score = combined;
+            hit.explanation = Some(expl);
+          }
           continue;
         }
         stats.candidates_examined += 1;

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -568,3 +568,59 @@ fn rescore_max_preserves_score_for_non_matching_docs() {
     doc3.score
   );
 }
+
+#[test]
+fn rescore_explain_consistent_for_non_matching_docs() {
+  let reader = setup_reader();
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 5.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::Term {
+      field: "body".into(),
+      value: "rust".into(),
+      boost: None,
+    },
+    score_mode: RescoreMode::Multiply,
+  });
+  req.explain = true;
+  let resp = reader.search(&req).unwrap();
+  // doc-3 does not match the rescore query — its explanation must reflect
+  // the zero-contribution rescore and the combined score must match hit.score.
+  let doc3 = resp.hits.iter().find(|h| h.doc_id == "doc-3").unwrap();
+  let expl = doc3
+    .explanation
+    .as_ref()
+    .expect("missing explanation for doc-3");
+  let rescore_expl = expl
+    .rescore
+    .as_ref()
+    .expect("missing rescore explanation for doc-3");
+  assert!(
+    rescore_expl.rescore_score.abs() < 1e-6,
+    "non-matching rescore_score should be 0.0, got {}",
+    rescore_expl.rescore_score
+  );
+  assert!(
+    (rescore_expl.combined_score - doc3.score).abs() < 1e-6,
+    "combined_score ({}) should match hit.score ({})",
+    rescore_expl.combined_score,
+    doc3.score
+  );
+  assert!(
+    (expl.final_score - doc3.score).abs() < 1e-6,
+    "final_score ({}) should match hit.score ({})",
+    expl.final_score,
+    doc3.score
+  );
+}

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -416,3 +416,155 @@ fn script_score_evaluates_expression_with_score_and_field() {
   let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
   assert!(scores[0] > scores[1] && scores[1] > scores[2]);
 }
+
+#[test]
+fn rescore_multiply_zeros_non_matching_docs() {
+  let reader = setup_reader();
+  // Give every doc a constant score of 5.0 via function_score + Replace.
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 5.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore with a term that only matches doc-1 ("rust fast") and doc-2 ("rust slow").
+  // doc-3 ("boring") does not match and should receive 5.0 * 0.0 = 0.0.
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::Term {
+      field: "body".into(),
+      value: "rust".into(),
+      boost: None,
+    },
+    score_mode: RescoreMode::Multiply,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  // Find doc-3's score — it must be zero because it did not match the rescore query.
+  let doc3 = resp.hits.iter().find(|h| h.doc_id == "doc-3").unwrap();
+  assert!(
+    doc3.score.abs() < 1e-6,
+    "expected doc-3 score ≈ 0.0 under Multiply, got {}",
+    doc3.score
+  );
+  // doc-1 and doc-2 matched the rescore query, so they should have positive scores.
+  for hit in resp.hits.iter().filter(|h| h.doc_id != "doc-3") {
+    assert!(
+      hit.score > 0.0,
+      "expected positive rescore score for {}, got {}",
+      hit.doc_id,
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn rescore_min_zeros_non_matching_docs() {
+  let reader = setup_reader();
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 5.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore with Min mode — non-matching docs get min(5.0, 0.0) = 0.0.
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::Term {
+      field: "body".into(),
+      value: "rust".into(),
+      boost: None,
+    },
+    score_mode: RescoreMode::Min,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  let doc3 = resp.hits.iter().find(|h| h.doc_id == "doc-3").unwrap();
+  assert!(
+    doc3.score.abs() < 1e-6,
+    "expected doc-3 score ≈ 0.0 under Min, got {}",
+    doc3.score
+  );
+}
+
+#[test]
+fn rescore_total_preserves_score_for_non_matching_docs() {
+  let reader = setup_reader();
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 5.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore with Total mode — non-matching docs get 5.0 + 0.0 = 5.0 (unchanged).
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::Term {
+      field: "body".into(),
+      value: "rust".into(),
+      boost: None,
+    },
+    score_mode: RescoreMode::Total,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  let doc3 = resp.hits.iter().find(|h| h.doc_id == "doc-3").unwrap();
+  assert!(
+    (doc3.score - 5.0).abs() < 1e-6,
+    "expected doc-3 score ≈ 5.0 under Total, got {}",
+    doc3.score
+  );
+}
+
+#[test]
+fn rescore_max_preserves_score_for_non_matching_docs() {
+  let reader = setup_reader();
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 5.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore with Max mode — non-matching docs get max(5.0, 0.0) = 5.0 (unchanged).
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::Term {
+      field: "body".into(),
+      value: "rust".into(),
+      boost: None,
+    },
+    score_mode: RescoreMode::Max,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  let doc3 = resp.hits.iter().find(|h| h.doc_id == "doc-3").unwrap();
+  assert!(
+    (doc3.score - 5.0).abs() < 1e-6,
+    "expected doc-3 score ≈ 5.0 under Max, got {}",
+    doc3.score
+  );
+}


### PR DESCRIPTION
## Summary

- When a document in the rescore window does not match the rescore query, `rescore_hits` now computes `combine_rescore_scores(mode, original, 0.0)` instead of skipping via `continue`
- Fixes `Multiply` mode (`original * 0 = 0`) and `Min` mode (`min(original, 0) = 0`) which previously left non-matching documents with their full original score
- `Total`/`Sum` and `Max` modes are unaffected since `original + 0` and `max(original, 0)` match the prior skip behavior

## Root cause

The `continue` at the `query_eval.matches(doc_id)` check in `rescore_hits` was written for the `Total` case where skipping is equivalent to adding zero. The `Multiply` and `Min` modes were not considered, causing non-matching documents to retain inflated scores.

## Changes

- **`searchlite-core/src/api/reader.rs`**: Replace the early `continue` with an explicit call to `combine_rescore_scores(mode, original_score, 0.0)` and update the hit's score and sort key
- **`searchlite-core/tests/function_score.rs`**: Add four tests covering all rescore modes with non-matching documents (`Multiply`, `Min`, `Total`, `Max`)

## Test plan

- [x] `cargo test -p searchlite-core --test function_score` — 16 tests pass (4 new)
- [x] `cargo test -p searchlite-core` — 539 tests pass, 0 failures
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #263