### PR TITLE
fix(aggs): bucket_script to_rpn silently accepts mismatched parentheses, producing wrong evaluation results (BUG-265)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3413,19 +3413,25 @@ fn to_rpn(tokens: Vec<ScriptToken>) -> Option<Vec<ScriptToken>> {
       }
       ScriptToken::LParen => ops.push('('),
       ScriptToken::RParen => {
+        let mut found_lparen = false;
         while let Some(op) = ops.pop() {
           if op == '(' {
+            found_lparen = true;
             break;
           }
           output.push(ScriptToken::Op(op));
+        }
+        if !found_lparen {
+          return None;
         }
       }
     }
   }
   while let Some(op) = ops.pop() {
-    if op != '(' {
-      output.push(ScriptToken::Op(op));
+    if op == '(' {
+      return None;
     }
+    output.push(ScriptToken::Op(op));
   }
   Some(output)
 }
@@ -4067,6 +4073,34 @@ mod tests {
     vars.insert("a".to_string(), 1.0);
     vars.insert("b".to_string(), 1e-14);
     assert!(eval_bucket_script("a / b", &vars).is_none());
+  }
+
+  #[test]
+  fn bucket_script_rejects_unmatched_rparen() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 2.0);
+    vars.insert("b".to_string(), 3.0);
+    vars.insert("c".to_string(), 4.0);
+    assert!(eval_bucket_script("a + b) * c", &vars).is_none());
+  }
+
+  #[test]
+  fn bucket_script_rejects_unmatched_lparen() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 2.0);
+    vars.insert("b".to_string(), 3.0);
+    vars.insert("c".to_string(), 4.0);
+    assert!(eval_bucket_script("(a + b * c", &vars).is_none());
+  }
+
+  #[test]
+  fn bucket_script_accepts_matched_parentheses() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 2.0);
+    vars.insert("b".to_string(), 3.0);
+    vars.insert("c".to_string(), 4.0);
+    let value = eval_bucket_script("(a + b) * c", &vars).unwrap();
+    assert!((value - 20.0).abs() < 1e-6);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- `to_rpn` shunting-yard implementation now returns `None` when parentheses are mismatched, instead of silently producing wrong results
- Unmatched `)` previously drained the operator stack and flattened precedence; now detected and rejected
- Unmatched `(` previously silently discarded during cleanup; now detected and rejected
- Mirrors the validated parenthesis-balance checks from `shunting_yard` in `script.rs`

## Changes

**`searchlite-core/src/query/aggs/mod.rs`**

- `RParen` handler: track whether a matching `(` was found; return `None` if not
- Cleanup loop: return `None` if a `(` remains on the operator stack (unmatched open paren)
- Added three tests: unmatched `)`, unmatched `(`, and matched parentheses (positive case)

## Test plan

- [x] `cargo test -p searchlite-core -- bucket_script` — 6 tests pass (3 existing + 3 new)
- [x] `cargo test -p searchlite-core` — full suite passes, no regressions
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #265