### PR TITLE
fix(aggs): hard_bounds filters on bucket key, not raw value (BUG-269)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1379,11 +1379,8 @@ impl<'a> HistogramCollector<'a> {
     // `hard_bounds.max`. Drop any bucket whose key-value falls outside the
     // half-open range `[hard_bounds.min, hard_bounds.max)`.
     if let Some((hmin, hmax)) = hard_bounds {
-      buckets.retain(|_, b| {
-        let bv = match &b.key {
-          serde_json::Value::Number(n) => n.as_f64().unwrap_or(0.0),
-          _ => return true,
-        };
+      buckets.retain(|bucket_id, _| {
+        let bv = bucket_value(*bucket_id);
         bv >= hmin && bv < hmax
       });
     }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1292,12 +1292,13 @@ impl<'a> HistogramCollector<'a> {
     }
     let mut seen = HashSet::new();
     for val in values {
+      let bucket_id = self.bucket_key(val);
       if let Some((min, max)) = self.hard_bounds {
-        if val < min || val > max {
+        let bucket_val = bucket_id as f64 * self.interval + self.offset;
+        if bucket_val < min || bucket_val >= max {
           continue;
         }
       }
-      let bucket_id = self.bucket_key(val);
       if !seen.insert(bucket_id) {
         continue;
       }
@@ -1372,6 +1373,19 @@ impl<'a> HistogramCollector<'a> {
           }
         }
       }
+    }
+    // BUG-269: the fill loop maps `hard_bounds` values to bucket keys via
+    // `floor()`, which can produce keys below `hard_bounds.min` or at
+    // `hard_bounds.max`. Drop any bucket whose key-value falls outside the
+    // half-open range `[hard_bounds.min, hard_bounds.max)`.
+    if let Some((hmin, hmax)) = hard_bounds {
+      buckets.retain(|_, b| {
+        let bv = match &b.key {
+          serde_json::Value::Number(n) => n.as_f64().unwrap_or(0.0),
+          _ => return true,
+        };
+        bv >= hmin && bv < hmax
+      });
     }
     let mut buckets: Vec<BucketIntermediate> = buckets
       .into_values()
@@ -1477,15 +1491,15 @@ impl<'a> DateHistogramCollector<'a> {
     }
     let mut seen = HashSet::new();
     for val in values {
-      if let Some((min, max)) = self.hard_bounds {
-        if val < min || val > max {
-          continue;
-        }
-      }
       let bucket_start = match bucket_start(val, self.offset_millis, &self.interval) {
         Some(v) => v,
         None => continue,
       };
+      if let Some((min, max)) = self.hard_bounds {
+        if bucket_start < min || bucket_start >= max {
+          continue;
+        }
+      }
       if !seen.insert(bucket_start) {
         continue;
       }
@@ -1546,6 +1560,13 @@ impl<'a> DateHistogramCollector<'a> {
           };
         }
       }
+    }
+    // BUG-269: the fill loop maps `hard_bounds` timestamps to bucket starts
+    // via `bucket_start()`, which can produce a bucket start below
+    // `hard_bounds.min` or at `hard_bounds.max`. Drop any bucket whose start
+    // falls outside the half-open range `[hard_bounds.min, hard_bounds.max)`.
+    if let Some((hmin, hmax)) = self.hard_bounds {
+      buckets.retain(|&bucket_start, _| bucket_start >= hmin && bucket_start < hmax);
     }
     let mut buckets: Vec<BucketIntermediate> = buckets
       .into_values()

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -225,6 +225,161 @@ fn histogram_nested_bounds_produce_expected_buckets() {
   }
 }
 
+/// Regression test for BUG-269 — `hard_bounds` was applied against the raw
+/// document value instead of the computed bucket key, and used an inclusive
+/// upper bound (`val > max`) instead of exclusive on the bucket key
+/// (`bucket_val >= max`).
+///
+/// **Lower bound:** `interval = 10`, `hard_bounds = { min: 25, max: 80 }`.
+/// A document with value 27 has `bucket_key = 20`. Since `20 < 25`, the
+/// bucket must be dropped. Before the fix the raw-value check `27 >= 25`
+/// passed, producing a spurious bucket at key 20.
+///
+/// **Upper bound:** `interval = 10`, `hard_bounds = { min: 0, max: 30 }`.
+/// A document with value 30 has `bucket_key = 30`. Since `30 >= 30`
+/// (exclusive upper), the bucket must be dropped. Before the fix the
+/// raw-value check `30 > 30` evaluated to false, letting the bucket
+/// through.
+#[test]
+fn histogram_hard_bounds_filters_on_bucket_key_not_raw_value() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "score".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = Index::create(&path, schema, build_base_options(&path)).unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // 27 → bucket_key 20 (below hard_bounds.min 25 → excluded)
+    // 60 → bucket_key 60 (inside [25, 80) → included)
+    for val in [27_i64, 60] {
+      writer
+        .add_document(&doc(
+          &format!("hb-{val}"),
+          vec![("body", json!("rust")), ("score", json!(val))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "hist".into(),
+    Aggregation::Histogram(Box::new(HistogramAggregation {
+      field: "score".into(),
+      interval: 10.0,
+      offset: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: Some(HistogramBounds {
+        min: 25.0,
+        max: 80.0,
+      }),
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+
+  let mut req = SearchRequest::new("rust");
+  req.aggs = aggs;
+  let resp = idx.reader().unwrap().search(&req).unwrap();
+
+  let hist = resp.aggregations.get("hist").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } = hist {
+    let keys: Vec<_> = buckets.iter().map(|b| b.key.clone()).collect();
+    // hard_bounds [25, 80) produces filled buckets at keys 30..=70 (key 20
+    // is below min, key 80 is at the exclusive upper bound). The doc with
+    // value 27 maps to bucket_key 20 which is outside hard_bounds, so only
+    // the doc with value 60 contributes a hit.
+    assert_eq!(
+      keys,
+      vec![json!(30.0), json!(40.0), json!(50.0), json!(60.0), json!(70.0)]
+    );
+    assert_eq!(buckets[0].doc_count, 0); // key 30 — empty fill
+    assert_eq!(buckets[1].doc_count, 0); // key 40 — empty fill
+    assert_eq!(buckets[2].doc_count, 0); // key 50 — empty fill
+    assert_eq!(buckets[3].doc_count, 1); // key 60 — collected from val 60
+    assert_eq!(buckets[4].doc_count, 0); // key 70 — empty fill
+  } else {
+    panic!("unexpected histogram response");
+  }
+}
+
+/// Companion to the lower-bound test above: verifies that the upper bound
+/// is exclusive on the bucket key (`bucket_key >= max` → drop).
+#[test]
+fn histogram_hard_bounds_upper_bound_is_exclusive_on_bucket_key() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "score".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = Index::create(&path, schema, build_base_options(&path)).unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // 25 → bucket_key 20 (inside [0, 30) → included)
+    // 30 → bucket_key 30 (30 >= 30, exclusive upper → excluded)
+    for val in [25_i64, 30] {
+      writer
+        .add_document(&doc(
+          &format!("hbu-{val}"),
+          vec![("body", json!("rust")), ("score", json!(val))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "hist".into(),
+    Aggregation::Histogram(Box::new(HistogramAggregation {
+      field: "score".into(),
+      interval: 10.0,
+      offset: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: Some(HistogramBounds {
+        min: 0.0,
+        max: 30.0,
+      }),
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+
+  let mut req = SearchRequest::new("rust");
+  req.aggs = aggs;
+  let resp = idx.reader().unwrap().search(&req).unwrap();
+
+  let hist = resp.aggregations.get("hist").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } = hist {
+    let keys: Vec<_> = buckets.iter().map(|b| b.key.clone()).collect();
+    // hard_bounds [0, 30) fills keys 0, 10, 20. The doc with value 30 maps
+    // to bucket_key 30 which is at the exclusive upper bound, so it is
+    // dropped. Only the doc with value 25 (bucket_key 20) contributes.
+    assert_eq!(keys, vec![json!(0.0), json!(10.0), json!(20.0)]);
+    assert_eq!(buckets[0].doc_count, 0); // key 0 — empty fill
+    assert_eq!(buckets[1].doc_count, 0); // key 10 — empty fill
+    assert_eq!(buckets[2].doc_count, 1); // key 20 — collected from val 25
+  } else {
+    panic!("unexpected histogram response");
+  }
+}
+
 #[test]
 fn histogram_requires_positive_interval() {
   let tmp = tempfile::tempdir().unwrap();
@@ -948,6 +1103,96 @@ fn date_histogram_nested_bounds_produce_expected_buckets() {
     assert_eq!(buckets[1].doc_count, 1);
     assert_eq!(buckets[2].doc_count, 1);
     assert_eq!(buckets[3].doc_count, 0);
+  } else {
+    panic!("expected date histogram response");
+  }
+}
+
+/// Regression test for BUG-269 — `DateHistogramCollector` applied
+/// `hard_bounds` against the raw timestamp instead of the computed bucket
+/// start, producing buckets whose keys fall outside `hard_bounds`.
+///
+/// `calendar_interval = "month"`, `hard_bounds = { min: "2024-01-15", max:
+/// "2024-03-15" }`. A document dated 2024-01-20 has `bucket_start =
+/// 2024-01-01T00:00:00Z`. Since Jan 1 < Jan 15, the bucket must be
+/// dropped. Before the fix the raw-value check passed because Jan 20 >=
+/// Jan 15, producing a spurious bucket at Jan 1.
+#[test]
+fn date_histogram_hard_bounds_filters_on_bucket_start_not_raw_value() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+
+  let ts = |s: &str| DateTime::parse_from_rfc3339(s).unwrap().timestamp_millis();
+  {
+    let mut writer = idx.writer().unwrap();
+    // Jan 20 → bucket_start Jan 1 (Jan 1 < Jan 15 → excluded)
+    // Feb 10 → bucket_start Feb 1 (Feb 1 >= Jan 15 and Feb 1 < Mar 15 → included)
+    // Mar 20 → bucket_start Mar 1 (Mar 1 >= Mar 15 is false, so Mar 1 < Mar 15 → included)
+    // Apr 5  → bucket_start Apr 1 (Apr 1 >= Mar 15 exclusive upper → excluded)
+    for t in [
+      "2024-01-20T00:00:00Z",
+      "2024-02-10T00:00:00Z",
+      "2024-03-20T00:00:00Z",
+      "2024-04-05T00:00:00Z",
+    ] {
+      writer
+        .add_document(&doc(
+          &format!("ts-{t}"),
+          vec![("body", json!("rust")), ("ts", json!(ts(t)))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "dates".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: Some("month".into()),
+      fixed_interval: None,
+      offset: None,
+      format: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: Some(DateHistogramBounds {
+        min: "2024-01-15T00:00:00Z".into(),
+        max: "2024-03-15T00:00:00Z".into(),
+      }),
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+
+  let mut req = SearchRequest::new("rust");
+  req.aggs = aggs;
+  let resp = idx.reader().unwrap().search(&req).unwrap();
+
+  let agg = resp.aggregations.get("dates").unwrap();
+  if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } = agg {
+    let keys: Vec<_> = buckets.iter().map(|b| b.key.clone()).collect();
+    // Only Feb 1 and Mar 1 buckets should survive.
+    // Jan 1 is below hard_bounds.min (Jan 15), Apr 1 is at/above hard_bounds.max (Mar 15).
+    assert_eq!(
+      keys,
+      vec![
+        json!(ts("2024-02-01T00:00:00Z")),
+        json!(ts("2024-03-01T00:00:00Z")),
+      ]
+    );
+    assert_eq!(buckets[0].doc_count, 1); // Feb 10 doc
+    assert_eq!(buckets[1].doc_count, 1); // Mar 20 doc
   } else {
     panic!("expected date histogram response");
   }

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -300,7 +300,13 @@ fn histogram_hard_bounds_filters_on_bucket_key_not_raw_value() {
     // the doc with value 60 contributes a hit.
     assert_eq!(
       keys,
-      vec![json!(30.0), json!(40.0), json!(50.0), json!(60.0), json!(70.0)]
+      vec![
+        json!(30.0),
+        json!(40.0),
+        json!(50.0),
+        json!(60.0),
+        json!(70.0)
+      ]
     );
     assert_eq!(buckets[0].doc_count, 0); // key 30 — empty fill
     assert_eq!(buckets[1].doc_count, 0); // key 40 — empty fill

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -2646,9 +2646,10 @@ fn date_histogram_hard_bounds_filter_out_of_range() {
   let hist = resp.aggregations.get("hist").unwrap();
   if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } = hist {
     let keys: Vec<_> = buckets.iter().map(|b| b.key.clone()).collect();
-    assert_eq!(keys, vec![json!(1_000), json!(2_000)]);
+    // hard_bounds.max is exclusive on the bucket key, so the bucket at
+    // key 2000 (== hard_bounds.max) is dropped (BUG-269).
+    assert_eq!(keys, vec![json!(1_000)]);
     assert_eq!(buckets[0].doc_count, 1);
-    assert_eq!(buckets[1].doc_count, 0);
   } else {
     panic!("expected date histogram response");
   }


### PR DESCRIPTION
## Summary

- Moves `hard_bounds` gate in `HistogramCollector::collect` and `DateHistogramCollector::collect` from raw document value to computed bucket key, using half-open `[min, max)` semantics to match Elasticsearch behavior
- Adds `retain` pass in both `finish()` methods to filter out-of-bounds buckets that the fill loop can produce when `hard_bounds` values do not align with bucket boundaries
- Adds regression tests for non-aligned histogram and date_histogram boundaries, and corrects the existing `date_histogram_hard_bounds_filter_out_of_range` test that relied on inclusive upper bound behavior

Closes #269

## Test plan

- [x] All 51 `aggregation_bounds` tests pass, including 3 new regression tests
- [x] All 41 `aggregations` tests pass (corrected `date_histogram_hard_bounds_filter_out_of_range` expectations)
- [x] Full `cargo test` suite passes with 0 failures