### PR TITLE
fix(aggs): handle unary negation of variables in bucket_script (BUG-275)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3403,6 +3403,7 @@ enum ScriptToken {
   Number(f64),
   Var(String),
   Op(char),
+  Neg,
   LParen,
   RParen,
 }
@@ -3411,6 +3412,7 @@ fn op_precedence(op: char) -> u8 {
   match op {
     '+' | '-' => 1,
     '*' | '/' => 2,
+    '~' => 3,
     _ => 0,
   }
 }
@@ -3477,6 +3479,11 @@ fn tokenize_script(script: &str) -> Option<Vec<ScriptToken>> {
     }
     match ch {
       '+' | '-' | '*' | '/' => {
+        if ch == '-' && expect_unary {
+          tokens.push(ScriptToken::Neg);
+          chars.next();
+          continue;
+        }
         tokens.push(ScriptToken::Op(ch));
         chars.next();
         expect_unary = true;
@@ -3497,20 +3504,30 @@ fn tokenize_script(script: &str) -> Option<Vec<ScriptToken>> {
   Some(tokens)
 }
 
+fn pop_op(op: char) -> ScriptToken {
+  if op == '~' {
+    ScriptToken::Neg
+  } else {
+    ScriptToken::Op(op)
+  }
+}
+
 fn to_rpn(tokens: Vec<ScriptToken>) -> Option<Vec<ScriptToken>> {
   let mut output = Vec::new();
   let mut ops: Vec<char> = Vec::new();
   for token in tokens.into_iter() {
     match token {
       ScriptToken::Number(_) | ScriptToken::Var(_) => output.push(token),
+      ScriptToken::Neg => {
+        ops.push('~');
+      }
       ScriptToken::Op(op) => {
         while let Some(&top) = ops.last() {
           if top == '(' {
             break;
           }
           if op_precedence(top) >= op_precedence(op) {
-            output.push(ScriptToken::Op(top));
-            ops.pop();
+            output.push(pop_op(ops.pop().unwrap()));
           } else {
             break;
           }
@@ -3525,7 +3542,7 @@ fn to_rpn(tokens: Vec<ScriptToken>) -> Option<Vec<ScriptToken>> {
             found_lparen = true;
             break;
           }
-          output.push(ScriptToken::Op(op));
+          output.push(pop_op(op));
         }
         if !found_lparen {
           return None;
@@ -3537,7 +3554,7 @@ fn to_rpn(tokens: Vec<ScriptToken>) -> Option<Vec<ScriptToken>> {
     if op == '(' {
       return None;
     }
-    output.push(ScriptToken::Op(op));
+    output.push(pop_op(op));
   }
   Some(output)
 }
@@ -3548,6 +3565,10 @@ fn eval_rpn(tokens: Vec<ScriptToken>, vars: &BTreeMap<String, f64>) -> Option<f6
     match token {
       ScriptToken::Number(v) => stack.push(v),
       ScriptToken::Var(name) => stack.push(*vars.get(&name)?),
+      ScriptToken::Neg => {
+        let a = stack.pop()?;
+        stack.push(-a);
+      }
       ScriptToken::Op(op) => {
         let b = stack.pop()?;
         let a = stack.pop()?;
@@ -4206,6 +4227,49 @@ mod tests {
     vars.insert("c".to_string(), 4.0);
     let value = eval_bucket_script("(a + b) * c", &vars).unwrap();
     assert!((value - 20.0).abs() < 1e-6);
+  }
+
+  #[test]
+  fn bucket_script_unary_negation_of_variable() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 2.0);
+    vars.insert("b".to_string(), 3.0);
+    let value = eval_bucket_script("a * -b", &vars).unwrap();
+    assert!((value - (-6.0)).abs() < 1e-6);
+  }
+
+  #[test]
+  fn bucket_script_leading_unary_negation_variable() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 5.0);
+    let value = eval_bucket_script("-a", &vars).unwrap();
+    assert!((value - (-5.0)).abs() < 1e-6);
+  }
+
+  #[test]
+  fn bucket_script_double_negation_variable() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 3.0);
+    vars.insert("b".to_string(), 2.0);
+    let value = eval_bucket_script("a - -b", &vars).unwrap();
+    assert!((value - 5.0).abs() < 1e-6);
+  }
+
+  #[test]
+  fn bucket_script_negation_in_parens() {
+    let mut vars = BTreeMap::new();
+    vars.insert("b".to_string(), 4.0);
+    let value = eval_bucket_script("(-b)", &vars).unwrap();
+    assert!((value - (-4.0)).abs() < 1e-6);
+  }
+
+  #[test]
+  fn bucket_script_division_by_negated_variable() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 10.0);
+    vars.insert("b".to_string(), 2.0);
+    let value = eval_bucket_script("a / -b", &vars).unwrap();
+    assert!((value - (-5.0)).abs() < 1e-6);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

- Fixes `tokenize_script` in the bucket_script evaluator to correctly handle unary negation of variables (e.g., `-a`, `a * -b`, `a - -b`, `(-b)`, `a / -b`)
- Adds a dedicated `Neg` unary operator token with higher precedence than `*`/`/`, processed through the tokenizer, shunting-yard RPN converter, and RPN evaluator
- Previously, unary minus before a variable was misclassified as a binary operator, producing a malformed token stream that caused `eval_bucket_script` to silently return `None` for every bucket

## Root cause

The `looks_numeric` guard in `tokenize_script` only recognized unary minus when followed by a digit or `.`. When `-` preceded a variable name, it fell through to the binary operator branch, producing two consecutive binary operators in the token stream. The RPN evaluator's stack underflowed and silently returned `None`.

## Approach

Rather than the synthetic-zero rewrite (`-x` → `0 - x`) which breaks operator precedence for expressions like `a * -b`, this uses a proper unary negation operator (`Neg`) that:
1. Has higher precedence than all binary operators (precedence 3 vs 2 for `*`/`/`)
2. Is emitted by the tokenizer when `expect_unary` is true and `-` is not followed by a digit
3. Pops a single operand in `eval_rpn` and pushes its negation

## Test plan

- [x] `cargo test -p searchlite-core bucket_script` — 11 tests (6 existing + 5 new)
- [x] `cargo test -p searchlite-core` — full suite passes (367 tests)
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p searchlite-core -- --check` — clean

New test cases cover: `a * -b`, `-a`, `a - -b`, `(-b)`, `a / -b`

Closes #275

https://claude.ai/code/session_01S13nj6nAPPTkfa1GufYLQ4