### PR TITLE
fix(score): apply max_boost to function score before boost_mode combination

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -354,13 +354,14 @@ pub(crate) fn evaluate_compiled_score(
       }
       let mut combined =
         if let Some(func_score) = combine_function_scores(&function_values, *score_mode) {
-          apply_boost_mode(effective_base, func_score, *boost_mode)
+          let capped = match max_boost {
+            Some(max) => func_score.min(*max),
+            None => func_score,
+          };
+          apply_boost_mode(effective_base, capped, *boost_mode)
         } else {
           effective_base
         };
-      if let Some(max) = max_boost {
-        combined = combined.min(*max);
-      }
       if let Some(min) = min_score {
         if combined < *min {
           return None;

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -656,7 +656,13 @@ fn max_boost_caps_function_score_before_boost_mode_sum() {
 fn max_boost_caps_function_score_before_boost_mode_multiply() {
   let reader = setup_reader();
   let req = base_request(QueryNode::FunctionScore {
-    query: Box::new(QueryNode::MatchAll { boost: None }),
+    query: Box::new(QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(2.0),
+    }),
     functions: vec![FunctionSpec::Weight {
       weight: 10.0,
       filter: None,
@@ -668,13 +674,14 @@ fn max_boost_caps_function_score_before_boost_mode_multiply() {
     boost: None,
   });
   let resp = reader.search(&req).unwrap();
-  assert_eq!(resp.hits.len(), 3);
-  // base=1.0, func=10.0, max_boost=5.0 → capped_func=5.0 → 1.0 * 5.0 = 5.0
-  // Old buggy code: min(1.0 * 10.0, 5.0) = 5.0 (same result for this case)
+  assert_eq!(resp.hits.len(), 2);
+  // base=2.0 (ConstantScore), func=10.0, max_boost=5.0
+  // Correct: 2.0 * min(10.0, 5.0) = 2.0 * 5.0 = 10.0
+  // Old buggy code: min(2.0 * 10.0, 5.0) = 5.0
   for hit in &resp.hits {
     assert!(
-      (hit.score - 5.0).abs() < 1e-6,
-      "expected 1.0 * capped(5.0) = 5.0, got {}",
+      (hit.score - 10.0).abs() < 1e-6,
+      "expected 2.0 * capped(5.0) = 10.0, got {}",
       hit.score
     );
   }

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -624,3 +624,58 @@ fn rescore_explain_consistent_for_non_matching_docs() {
     doc3.score
   );
 }
+
+#[test]
+fn max_boost_caps_function_score_before_boost_mode_sum() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 10.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Sum),
+    max_boost: Some(5.0),
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  // base=1.0, func=10.0, max_boost=5.0 → capped_func=5.0 → 1.0+5.0=6.0
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 6.0).abs() < 1e-6,
+      "expected 6.0 (base + capped func), got {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn max_boost_caps_function_score_before_boost_mode_multiply() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 10.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Multiply),
+    max_boost: Some(5.0),
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  // base=1.0, func=10.0, max_boost=5.0 → capped_func=5.0 → 1.0 * 5.0 = 5.0
+  // Old buggy code: min(1.0 * 10.0, 5.0) = 5.0 (same result for this case)
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 5.0).abs() < 1e-6,
+      "expected 1.0 * capped(5.0) = 5.0, got {}",
+      hit.score
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Fixes `evaluate_compiled_score` to apply `max_boost` to the function score **before** combining it with the base query score via `apply_boost_mode`, aligning with Elasticsearch `function_score` semantics
- Previously, `max_boost` was applied after `apply_boost_mode`, which incorrectly capped the entire blended score instead of only the function contribution
- Adds two regression tests verifying correct behavior with `Sum` and `Multiply` boost modes

## Details

Per Elasticsearch documentation: *"The `max_boost` parameter can be used to limit the maximum effect of the score functions. Only the score function scores are affected by `max_boost`, not the final score."*

**Example (boost_mode: Sum):**
- Base query score: 1.0, Function score: 10.0, max_boost: 5.0
- Before fix: `min(1.0 + 10.0, 5.0)` = **5.0** (wrong — base score suppressed)
- After fix: `1.0 + min(10.0, 5.0)` = **6.0** (correct — only function score capped)

The fix reorders the operations in `scoring.rs` lines 355–363: the combined function score from `combine_function_scores` is now capped by `max_boost` before being passed to `apply_boost_mode`.

Closes #279

## Test plan

- [x] `cargo test -p searchlite-core --test function_score` — 19 tests pass including 2 new regression tests
- [x] `cargo test -p searchlite-core` — full suite (562 tests) passes with 0 failures