### PR TITLE
perf(reader): share doc_id allocations via Arc<str> in doc_lookup

### DIFF
--- a/searchlite-core/src/api/pagination.rs
+++ b/searchlite-core/src/api/pagination.rs
@@ -1,8 +1,7 @@
-use hashbrown::HashMap;
-
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::api::reader::DocLookupMap;
 use crate::api::scoring::score_sort_key;
 use crate::api::types::SortOrder;
 use crate::index::segment::SegmentReader;
@@ -218,7 +217,7 @@ pub(crate) fn decode_search_after_token(
   token: &[serde_json::Value],
   sort_plan: &SortPlan,
   segments: &[SegmentReader],
-  doc_lookup: &HashMap<String, Vec<(usize, DocId)>>,
+  doc_lookup: &DocLookupMap,
 ) -> Result<SortKey> {
   if token.len() < sort_plan.len().saturating_add(2) {
     bail!(
@@ -252,7 +251,7 @@ pub(crate) fn decode_search_after_token(
     .and_then(|entries| {
       entries
         .iter()
-        .find(|(seg_idx, _)| *seg_idx == segment_ord as usize)
+        .find(|(seg_idx, _)| *seg_idx == segment_ord)
         .map(|(_, doc_idx)| *doc_idx)
     })
     .or_else(|| seg.find_doc_id(&doc_id_str))

--- a/searchlite-core/src/api/pagination.rs
+++ b/searchlite-core/src/api/pagination.rs
@@ -1,12 +1,24 @@
-use anyhow::{bail, Context, Result};
-use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 
-use crate::api::reader::DocLookupMap;
+use anyhow::{bail, Context, Result};
+use hashbrown::HashMap;
+use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
+
 use crate::api::scoring::score_sort_key;
 use crate::api::types::SortOrder;
 use crate::index::segment::SegmentReader;
 use crate::query::sort::{SortKey, SortPlan, SortValue};
 use crate::DocId;
+
+/// Compact entry list for `DocLookupMap`. A given `doc_id` usually lives in a
+/// single segment, so the inline capacity of `1` keeps the common case off the
+/// heap while still supporting multi-segment tombstones for updated documents.
+pub(crate) type DocLookupEntries = SmallVec<[(u32, DocId); 1]>;
+
+/// Map from `doc_id` to the `(segment_ord, doc_idx)` pairs that currently host
+/// it. Keys are cheaply shared `Arc<str>` clones of the segment-owned doc_ids.
+pub(crate) type DocLookupMap = HashMap<Arc<str>, DocLookupEntries>;
 
 const CURSOR_VERSION: u8 = 1;
 const CURSOR_BYTES: usize = 21;

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1,4 +1,5 @@
 use hashbrown::{HashMap, HashSet};
+use smallvec::SmallVec;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BinaryHeap};
 use std::sync::Arc;
@@ -314,10 +315,13 @@ fn passes_root_filter(reader: &FastFieldsReader, doc_id: DocId, root: RootFilter
   }
 }
 
+pub(crate) type DocLookupEntries = SmallVec<[(u32, DocId); 1]>;
+pub(crate) type DocLookupMap = HashMap<Arc<str>, DocLookupEntries>;
+
 pub struct IndexReader {
   pub manifest: Manifest,
   pub segments: Vec<SegmentReader>,
-  doc_lookup: OnceLock<HashMap<String, Vec<(usize, DocId)>>>,
+  doc_lookup: OnceLock<DocLookupMap>,
   pub(crate) analysis: SchemaAnalyzers,
   options: IndexOptions,
 }
@@ -1556,14 +1560,15 @@ impl IndexReader {
       };
       let mut chosen: Option<(usize, DocId)> = None;
       for (seg_idx, doc_idx) in entries.iter().rev() {
+        let seg_usize = *seg_idx as usize;
         let seg = self
           .segments
-          .get(*seg_idx)
+          .get(seg_usize)
           .ok_or_else(|| anyhow::anyhow!("segment {seg_idx} missing for mget"))?;
         if seg.is_deleted(*doc_idx) {
           continue;
         }
-        chosen = Some((*seg_idx, *doc_idx));
+        chosen = Some((seg_usize, *doc_idx));
         break;
       }
       let Some((seg_idx, doc_idx)) = chosen else {
@@ -1586,18 +1591,20 @@ impl IndexReader {
     Ok(results)
   }
 
-  fn doc_lookup(&self) -> &HashMap<String, Vec<(usize, DocId)>> {
+  fn doc_lookup(&self) -> &DocLookupMap {
     self.doc_lookup.get_or_init(|| {
-      let mut map = HashMap::new();
+      let mut map: DocLookupMap = HashMap::new();
       for (seg_idx, seg) in self.segments.iter().enumerate() {
+        let seg_ord = seg_idx as u32;
         for (doc_idx, doc_id) in seg.doc_ids().iter().enumerate() {
-          if seg.is_deleted(doc_idx as DocId) {
+          let doc_ord = doc_idx as DocId;
+          if seg.is_deleted(doc_ord) {
             continue;
           }
           map
-            .entry(doc_id.clone())
-            .or_insert_with(Vec::new)
-            .push((seg_idx, doc_idx as DocId));
+            .entry(Arc::clone(doc_id))
+            .or_insert_with(SmallVec::new)
+            .push((seg_ord, doc_ord));
         }
       }
       map
@@ -4754,6 +4761,117 @@ mod tests {
       "plan candidate_size {} exceeds cap {}",
       plan.candidate_size,
       DEFAULT_MAX_VECTOR_GLOBAL_CANDIDATES
+    );
+  }
+
+  #[test]
+  fn doc_lookup_shares_doc_id_allocations_with_segments() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("idx");
+    let schema = Schema::default_text_body();
+    let idx = Index::create(
+      &path,
+      schema,
+      IndexOptions {
+        path: path.clone(),
+        create_if_missing: true,
+        enable_positions: true,
+        bm25_k1: 0.9,
+        bm25_b: 0.4,
+        storage: StorageType::Filesystem,
+        #[cfg(feature = "vectors")]
+        vector_defaults: None,
+      },
+    )
+    .unwrap();
+    let mut writer = idx.writer().unwrap();
+    for i in 0..8 {
+      writer
+        .add_document(&Document {
+          fields: BTreeMap::from([
+            ("_id".into(), json!(format!("doc-{i}"))),
+            ("body".into(), json!("rust search")),
+          ]),
+        })
+        .unwrap();
+    }
+    writer.commit().unwrap();
+
+    let reader = idx.reader().unwrap();
+    let lookup = reader.doc_lookup();
+    assert!(!lookup.is_empty(), "doc_lookup should be populated");
+
+    let seg = reader.segments.first().expect("segment present");
+    for arc in seg.doc_ids().iter() {
+      let key: &str = arc.as_ref();
+      assert!(
+        lookup.contains_key(key),
+        "lookup missing key {key}; expected Arc<str> sharing"
+      );
+      assert!(
+        Arc::strong_count(arc) >= 2,
+        "doc_id Arc<str> should be shared with doc_lookup; got strong_count={}",
+        Arc::strong_count(arc)
+      );
+    }
+  }
+
+  #[test]
+  fn doc_lookup_resolves_updates_to_latest_segment() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("idx");
+    let schema = Schema::default_text_body();
+    let idx = Index::create(
+      &path,
+      schema,
+      IndexOptions {
+        path: path.clone(),
+        create_if_missing: true,
+        enable_positions: true,
+        bm25_k1: 0.9,
+        bm25_b: 0.4,
+        storage: StorageType::Filesystem,
+        #[cfg(feature = "vectors")]
+        vector_defaults: None,
+      },
+    )
+    .unwrap();
+    {
+      let mut writer = idx.writer().unwrap();
+      writer
+        .add_document(&Document {
+          fields: BTreeMap::from([
+            ("_id".into(), json!("shared-1")),
+            ("body".into(), json!("first version")),
+          ]),
+        })
+        .unwrap();
+      writer.commit().unwrap();
+    }
+    {
+      let mut writer = idx.writer().unwrap();
+      writer
+        .add_document(&Document {
+          fields: BTreeMap::from([
+            ("_id".into(), json!("shared-1")),
+            ("body".into(), json!("second version")),
+          ]),
+        })
+        .unwrap();
+      writer.commit().unwrap();
+    }
+
+    let reader = idx.reader().unwrap();
+    let docs = reader
+      .mget(&["shared-1".to_string()], true)
+      .expect("mget ok");
+    assert_eq!(docs.len(), 1);
+    assert!(docs[0].found, "updated doc should be reachable via mget");
+    let source = docs[0]._source.as_ref().expect("source payload");
+    assert_eq!(
+      source.get("body").and_then(|v| v.as_str()),
+      Some("second version"),
+      "mget should return the most recent version"
     );
   }
 }

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -45,6 +45,7 @@ use crate::DocId;
 
 use super::pagination::{
   decode_cursor, decode_search_after_token, encode_cursor, encode_search_after_token, CursorState,
+  DocLookupMap,
 };
 use super::phrase::{
   build_phrase_runtimes, build_phrase_term_map, build_term_doc_lists, expand_phrase_fields,
@@ -314,9 +315,6 @@ fn passes_root_filter(reader: &FastFieldsReader, doc_id: DocId, root: RootFilter
     RootFilter::Node(filter) => passes_filter(reader, doc_id, filter),
   }
 }
-
-pub(crate) type DocLookupEntries = SmallVec<[(u32, DocId); 1]>;
-pub(crate) type DocLookupMap = HashMap<Arc<str>, DocLookupEntries>;
 
 pub struct IndexReader {
   pub manifest: Manifest,

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -1290,7 +1290,7 @@ pub struct SegmentReader {
 impl SegmentReader {
   pub fn open(storage: Arc<dyn Storage>, meta: SegmentMeta, keep_positions: bool) -> Result<Self> {
     let seg_meta_bytes = storage.read_to_end(Path::new(&meta.paths.meta))?;
-    let seg_meta: SegmentFileMeta = serde_json::from_slice(&seg_meta_bytes)?;
+    let mut seg_meta: SegmentFileMeta = serde_json::from_slice(&seg_meta_bytes)?;
     #[cfg(not(feature = "zstd"))]
     if seg_meta.use_zstd {
       bail!(
@@ -1362,10 +1362,9 @@ impl SegmentReader {
         );
       }
     }
-    let doc_ids: Vec<Arc<str>> = seg_meta
-      .doc_ids
-      .iter()
-      .map(|s| Arc::<str>::from(s.as_str()))
+    let doc_ids: Vec<Arc<str>> = std::mem::take(&mut seg_meta.doc_ids)
+      .into_iter()
+      .map(Arc::<str>::from)
       .collect();
     Ok(Self {
       meta,

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -1278,7 +1278,7 @@ pub struct SegmentReader {
   terms: TinyTerms,
   postings: RefCell<Box<dyn StorageFile>>,
   docstore: RefCell<DocStoreReader<Box<dyn StorageFile>>>,
-  doc_ids: Vec<String>,
+  doc_ids: Vec<Arc<str>>,
   deleted: FastHashSet<DocId>,
   fast_fields: FastFieldsReader,
   keep_positions: bool,
@@ -1362,12 +1362,17 @@ impl SegmentReader {
         );
       }
     }
+    let doc_ids: Vec<Arc<str>> = seg_meta
+      .doc_ids
+      .iter()
+      .map(|s| Arc::<str>::from(s.as_str()))
+      .collect();
     Ok(Self {
       meta,
       terms: TinyTerms(terms),
       postings: RefCell::new(postings),
       docstore: RefCell::new(docstore),
-      doc_ids: seg_meta.doc_ids.clone(),
+      doc_ids,
       deleted,
       fast_fields,
       keep_positions,
@@ -1407,18 +1412,18 @@ impl SegmentReader {
   }
 
   pub fn doc_id(&self, doc_id: DocId) -> Option<&str> {
-    self.doc_ids.get(doc_id as usize).map(|s| s.as_str())
+    self.doc_ids.get(doc_id as usize).map(|s| s.as_ref())
   }
 
   pub fn find_doc_id(&self, id: &str) -> Option<DocId> {
     self
       .doc_ids
       .iter()
-      .position(|d| d == id)
+      .position(|d| d.as_ref() == id)
       .map(|i| i as DocId)
   }
 
-  pub fn doc_ids(&self) -> &[String] {
+  pub fn doc_ids(&self) -> &[Arc<str>] {
     &self.doc_ids
   }
 


### PR DESCRIPTION
Closes #97

## Summary

`IndexReader::doc_lookup` previously cloned every live `doc_id` `String` across every segment, duplicating heap allocations in proportion to index size. Under HTTP `multi_search` parallel mode each sub-search opens a fresh `IndexReader`, so this cost was paid repeatedly per request.

This PR shares the `doc_id` string storage between segments and the lookup map and compacts the entry list:

- `SegmentReader.doc_ids` is now `Vec<Arc<str>>`. Strings are wrapped once when the segment is opened (the on-disk `SegmentFileMeta` remains `Vec<String>`, so the persisted format is unchanged).
- `doc_lookup` is now `HashMap<Arc<str>, SmallVec<[(u32, DocId); 1]>>`. Keys are cheap `Arc::clone`s of the segment strings (no new heap allocation for the string bytes), and the per-entry `Vec` is replaced with an inline `SmallVec` that stays on the stack for the common single-segment case.
- Entry tuples switched from `(usize, DocId)` to `(u32, DocId)` to further trim the inline footprint.

## Memory impact (per live doc)

- Before: 1 cloned `String` (24 B header + allocated bytes) + 1 `Vec` header (24 B) + 1 heap vec of `(usize, DocId)` entries (12 B each + alloc).
- After: 1 `Arc::clone` (16 B header + refcount bump, no new bytes) + inline `SmallVec` (16 B, no heap alloc for single-segment case).

For an index with N live docs in a single segment, this roughly halves per-entry overhead and eliminates 2 heap allocations per entry.

## Test plan

- [x] `cargo test -p searchlite-core --lib` (370 tests incl. 2 new regressions)
- [x] `cargo test -p searchlite-core --all-features`
- [x] `cargo test -p integration --test contracts_core`
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

New tests:
- `doc_lookup_shares_doc_id_allocations_with_segments` asserts the `Arc<str>` sharing invariant via `Arc::strong_count`, preventing future regressions that silently reintroduce cloning.
- `doc_lookup_resolves_updates_to_latest_segment` exercises the multi-segment `mget` path to confirm the `SmallVec` entry list still resolves updated documents to the most recent live segment.