### PR TITLE
perf(http): share IndexReader pool across parallel multi_search

### DIFF
--- a/searchlite-core/src/api/writer.rs
+++ b/searchlite-core/src/api/writer.rs
@@ -1215,6 +1215,7 @@ mod tests {
       manifest: RwLock::new(manifest),
       writer_lock: Mutex::new(()),
       storage: storage.clone(),
+      reader_opens: std::sync::atomic::AtomicUsize::new(0),
     });
 
     storage.fail_next_pending_manifest_store();
@@ -1284,6 +1285,7 @@ mod tests {
       manifest: RwLock::new(manifest),
       writer_lock: Mutex::new(()),
       storage: storage.clone(),
+      reader_opens: std::sync::atomic::AtomicUsize::new(0),
     });
 
     storage.fail_next_manifest_store();

--- a/searchlite-core/src/index/mod.rs
+++ b/searchlite-core/src/index/mod.rs
@@ -1,4 +1,5 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Context, Result};
@@ -40,6 +41,10 @@ pub(crate) struct InnerIndex {
   pub manifest: RwLock<Manifest>,
   pub writer_lock: Mutex<()>,
   pub storage: Arc<dyn Storage>,
+  /// Monotonic count of successful `Index::reader()` calls. Exposed via
+  /// `Index::reader_open_count` so pooling/caching layers can be regression-
+  /// tested without relying on wall-clock heuristics.
+  pub(crate) reader_opens: AtomicUsize,
 }
 
 impl Index {
@@ -97,6 +102,7 @@ impl Index {
       options: opts,
       manifest: RwLock::new(manifest),
       writer_lock: Mutex::new(()),
+      reader_opens: AtomicUsize::new(0),
     });
     Ok(Self { inner })
   }
@@ -129,6 +135,7 @@ impl Index {
       options: opts,
       manifest: RwLock::new(manifest),
       writer_lock: Mutex::new(()),
+      reader_opens: AtomicUsize::new(0),
     });
     Ok(Self { inner })
   }
@@ -145,7 +152,19 @@ impl Index {
   }
 
   pub fn reader(&self) -> Result<crate::api::reader::IndexReader> {
-    crate::api::reader::IndexReader::open(self.inner.clone())
+    let reader = crate::api::reader::IndexReader::open(self.inner.clone())?;
+    self.inner.reader_opens.fetch_add(1, Ordering::Relaxed);
+    Ok(reader)
+  }
+
+  /// Number of successful `reader()` calls issued against this `Index`.
+  ///
+  /// Exposed as an observability hook so reader-reuse behavior (e.g. the
+  /// bounded pool in HTTP `multi_search`) can be exercised in regression
+  /// tests without relying on timing or log parsing.
+  #[doc(hidden)]
+  pub fn reader_open_count(&self) -> usize {
+    self.inner.reader_opens.load(Ordering::Relaxed)
   }
 
   pub fn compact(&self) -> Result<()> {

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -24,7 +24,7 @@ use searchlite_core::api::types::{
   Document, IndexOptions, MgetRequest, MgetResponse, MultiSearchRequest, SearchRequest, StorageType,
 };
 use searchlite_core::api::PatchError;
-use searchlite_core::api::{MultiSearchResponse, SearchResult};
+use searchlite_core::api::{IndexReader, MultiSearchResponse, SearchResult};
 use searchlite_core::util::doc_id::validate_doc_id;
 use searchlite_core::{Index, Manifest, Schema};
 use thiserror::Error;
@@ -2222,8 +2222,33 @@ async fn multi_search(
     return Ok(Json(resp));
   }
 
+  // Share a bounded pool of IndexReaders across sub-searches rather than
+  // re-opening one per task. Pool size matches the effective concurrency so
+  // each permit is always backed by an available reader, and reuse eliminates
+  // the repeated segment-open cost for large multi_search payloads.
+  let pool_size = max_concurrency.min(searches.len()).max(1);
   let idx = index.clone();
-  let semaphore = Arc::new(Semaphore::new(max_concurrency));
+  let readers = {
+    let idx_for_pool = idx.clone();
+    tokio::task::spawn_blocking(move || -> anyhow::Result<Vec<IndexReader>> {
+      let mut readers = Vec::with_capacity(pool_size);
+      for _ in 0..pool_size {
+        readers.push(idx_for_pool.reader()?);
+      }
+      Ok(readers)
+    })
+    .await
+    .map_err(|err| {
+      HttpError::from_anyhow(
+        "multi_search_join",
+        StatusCode::INTERNAL_SERVER_ERROR,
+        anyhow::anyhow!(err.to_string()),
+      )
+    })?
+    .map_err(|err| HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err))?
+  };
+  let pool = Arc::new(tokio::sync::Mutex::new(readers));
+  let semaphore = Arc::new(Semaphore::new(pool_size));
   let mut tasks: FuturesUnordered<_> = FuturesUnordered::new();
   for (search_idx, mut req) in searches.into_iter().enumerate() {
     if req.cursor.is_some() {
@@ -2231,6 +2256,7 @@ async fn multi_search(
       req.from = 0;
     }
     let semaphore_clone = semaphore.clone();
+    let pool_clone = pool.clone();
     let index_clone = idx.clone();
     tasks.push(async move {
       let permit = semaphore_clone.acquire_owned().await.map_err(|err| {
@@ -2240,19 +2266,29 @@ async fn multi_search(
           anyhow::anyhow!(err.to_string()),
         )
       })?;
-      let handle = tokio::task::spawn_blocking(move || -> anyhow::Result<SearchResult> {
+      // Holding a permit guarantees a reader is available in steady state.
+      // The pool can briefly be empty if a prior blocking task panicked and
+      // dropped its reader; open a fresh one so the request still completes.
+      let reader = match pool_clone.lock().await.pop() {
+        Some(reader) => reader,
+        None => index_clone.reader().map_err(|err| {
+          HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err)
+        })?,
+      };
+      let handle = tokio::task::spawn_blocking(move || {
         let _permit = permit;
-        let reader = index_clone.reader()?;
-        reader.search(&req)
+        let result = reader.search(&req);
+        (reader, result)
       });
-      let joined = handle.await.map_err(|err: tokio::task::JoinError| {
+      let (reader, result) = handle.await.map_err(|err: tokio::task::JoinError| {
         HttpError::from_anyhow(
           "multi_search_join",
           StatusCode::INTERNAL_SERVER_ERROR,
           anyhow::anyhow!(err.to_string()),
         )
       })?;
-      let search_res = joined.map_err(|err| {
+      pool_clone.lock().await.push(reader);
+      let search_res = result.map_err(|err| {
         HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err)
       })?;
       Ok::<(usize, SearchResult), HttpError>((search_idx, search_res))
@@ -3931,6 +3967,83 @@ mod tests {
     assert_eq!(body.results.len(), 2);
     assert!(body.results[0].hits.is_empty());
     assert_eq!(body.results[1].hits.first().unwrap().doc_id, "2");
+
+    handle.abort();
+    let _ = handle.await;
+  }
+
+  #[tokio::test]
+  async fn multi_search_parallel_reuses_reader_pool() {
+    init_tracing();
+    let dir = tempdir().unwrap();
+    let index_path = dir.path().join("idx-multi-pool");
+    let (client, _base, index_base, handle, _state, _args) = setup_server(index_path).await;
+
+    client
+      .post(format!("{index_base}/init"))
+      .json(&Schema::default_text_body())
+      .send()
+      .await
+      .unwrap();
+    let ndjson =
+      "{\"_id\":\"1\",\"body\":\"rust\"}\n{\"_id\":\"2\",\"body\":\"go\"}\n{\"_id\":\"3\",\"body\":\"rust go\"}\n";
+    client
+      .post(format!("{index_base}/add"))
+      .body(ndjson.to_string())
+      .send()
+      .await
+      .unwrap();
+    client
+      .post(format!("{index_base}/commit"))
+      .send()
+      .await
+      .unwrap();
+
+    // Eight sub-searches with a pool capped at two exercises reader reuse:
+    // the pool is strictly smaller than the search count, so correctness here
+    // depends on readers being handed back and picked up again by later tasks.
+    let searches: Vec<serde_json::Value> = (0..8)
+      .map(|i| {
+        let term = if i % 2 == 0 { "rust" } else { "go" };
+        json!({ "query": term, "limit": 5, "return_stored": false })
+      })
+      .collect();
+    let req = json!({
+      "searches": searches,
+      "parallel": true,
+      "max_concurrency": 2
+    });
+    let res = client
+      .post(format!("{index_base}/multi_search"))
+      .json(&req)
+      .send()
+      .await
+      .unwrap();
+    assert!(res.status().is_success());
+    let body: MultiSearchResponse = res.json().await.unwrap();
+    assert_eq!(body.results.len(), 8);
+    for (i, result) in body.results.iter().enumerate() {
+      let ids: Vec<&str> = result.hits.iter().map(|h| h.doc_id.as_str()).collect();
+      if i % 2 == 0 {
+        assert!(
+          ids.contains(&"1"),
+          "expected doc 1 for rust query #{i}: {ids:?}"
+        );
+        assert!(
+          ids.contains(&"3"),
+          "expected doc 3 for rust query #{i}: {ids:?}"
+        );
+      } else {
+        assert!(
+          ids.contains(&"2"),
+          "expected doc 2 for go query #{i}: {ids:?}"
+        );
+        assert!(
+          ids.contains(&"3"),
+          "expected doc 3 for go query #{i}: {ids:?}"
+        );
+      }
+    }
 
     handle.abort();
     let _ = handle.await;

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -2268,21 +2268,24 @@ async fn multi_search(
       })?;
       // Holding a permit guarantees a reader is available in steady state.
       // The pool can briefly be empty if a prior blocking task panicked and
-      // dropped its reader; open a fresh one so the request still completes.
-      let reader = match pool_clone.lock().await.pop() {
-        Some(reader) => reader,
-        None => index_clone.reader().map_err(|err| {
-          HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err)
-        })?,
-      };
+      // dropped its reader; defer the fallback open into the blocking task
+      // below so file I/O never runs on a Tokio worker thread.
+      let pooled = pool_clone.lock().await.pop();
       // Keep `permit` in the outer async scope so it is not released until
       // after the reader is returned to the pool. Dropping it inside the
       // blocking closure (i.e. as soon as `reader.search` returns) would let
       // a waiting task acquire the freed permit, find the pool momentarily
       // empty, and open a new reader — growing the pool past its bound.
       let handle = tokio::task::spawn_blocking(move || {
+        let reader = match pooled {
+          Some(reader) => reader,
+          None => match index_clone.reader() {
+            Ok(reader) => reader,
+            Err(err) => return (None, Err(err)),
+          },
+        };
         let result = reader.search(&req);
-        (reader, result)
+        (Some(reader), result)
       });
       let (reader, result) = handle.await.map_err(|err: tokio::task::JoinError| {
         HttpError::from_anyhow(
@@ -2291,7 +2294,9 @@ async fn multi_search(
           anyhow::anyhow!(err.to_string()),
         )
       })?;
-      pool_clone.lock().await.push(reader);
+      if let Some(reader) = reader {
+        pool_clone.lock().await.push(reader);
+      }
       drop(permit);
       let search_res = result.map_err(|err| {
         HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err)
@@ -3982,7 +3987,7 @@ mod tests {
     init_tracing();
     let dir = tempdir().unwrap();
     let index_path = dir.path().join("idx-multi-pool");
-    let (client, _base, index_base, handle, _state, _args) = setup_server(index_path).await;
+    let (client, _base, index_base, handle, state, _args) = setup_server(index_path).await;
 
     client
       .post(format!("{index_base}/init"))
@@ -4004,9 +4009,16 @@ mod tests {
       .await
       .unwrap();
 
+    // Capture the baseline reader-open count *after* init/add/commit so the
+    // assertion below only measures opens caused by this multi_search call.
+    let managed = state.registry().resolve(INDEX_NAME).unwrap();
+    let index = managed.require_index().await.unwrap();
+    let opens_before = index.reader_open_count();
+
     // Eight sub-searches with a pool capped at two exercises reader reuse:
     // the pool is strictly smaller than the search count, so correctness here
     // depends on readers being handed back and picked up again by later tasks.
+    const POOL_SIZE: usize = 2;
     let searches: Vec<serde_json::Value> = (0..8)
       .map(|i| {
         let term = if i % 2 == 0 { "rust" } else { "go" };
@@ -4016,7 +4028,7 @@ mod tests {
     let req = json!({
       "searches": searches,
       "parallel": true,
-      "max_concurrency": 2
+      "max_concurrency": POOL_SIZE
     });
     let res = client
       .post(format!("{index_base}/multi_search"))
@@ -4049,6 +4061,16 @@ mod tests {
         );
       }
     }
+
+    // The pool caps concurrent readers at `POOL_SIZE`, so a multi_search with
+    // 8 sub-requests must open no more than that many fresh readers. Opening
+    // one per sub-search (the pre-fix behavior) would produce 8 here.
+    let opens_after = index.reader_open_count();
+    let opens_for_multi_search = opens_after - opens_before;
+    assert!(
+      opens_for_multi_search <= POOL_SIZE,
+      "expected at most {POOL_SIZE} reader opens from multi_search, observed {opens_for_multi_search}"
+    );
 
     handle.abort();
     let _ = handle.await;

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -2275,8 +2275,12 @@ async fn multi_search(
           HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err)
         })?,
       };
+      // Keep `permit` in the outer async scope so it is not released until
+      // after the reader is returned to the pool. Dropping it inside the
+      // blocking closure (i.e. as soon as `reader.search` returns) would let
+      // a waiting task acquire the freed permit, find the pool momentarily
+      // empty, and open a new reader — growing the pool past its bound.
       let handle = tokio::task::spawn_blocking(move || {
-        let _permit = permit;
         let result = reader.search(&req);
         (reader, result)
       });
@@ -2288,6 +2292,7 @@ async fn multi_search(
         )
       })?;
       pool_clone.lock().await.push(reader);
+      drop(permit);
       let search_res = result.map_err(|err| {
         HttpError::from_anyhow("multi_search_failed", StatusCode::BAD_REQUEST, err)
       })?;


### PR DESCRIPTION
Closes #98

## Summary

In HTTP `multi_search` parallel mode, each sub-search was wrapped in its own `spawn_blocking` that called `index.reader()?` — re-reading manifest metadata and reopening every segment file for the request's lifetime. Under large `searches` payloads this dominated request latency and made parallel mode heavier than the serial path (which already reused a single reader).

This PR introduces a bounded `IndexReader` pool scoped to the request:

- Open `min(max_concurrency, searches.len())` readers once (inside a single `spawn_blocking`), before dispatching any sub-searches.
- Hand readers out through `Arc<tokio::sync::Mutex<Vec<IndexReader>>>`, gated by the existing `Semaphore`. Each permit is backed by an available reader in the pool.
- Each sub-search task pops a reader, moves it into `spawn_blocking`, runs `reader.search(&req)`, and returns the reader back to the pool once the blocking task joins — whether the search itself succeeded or errored.
- Panic recovery: if a prior blocking task panicked and dropped its reader, the next task opens a fresh reader instead of deadlocking on an empty pool.

`IndexReader` itself is `Send` (each `SegmentReader` is `Send` but `!Sync`, which is why we hand out one reader per concurrent worker rather than sharing a single reader across threads).

## Why not change the serial path

The `!parallel` branch already opens a single reader and iterates over sub-searches; no change needed there.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-http --all-features` (51 passed, including the new regression)

New test:
- `multi_search_parallel_reuses_reader_pool` dispatches 8 sub-searches with `max_concurrency: 2`, which forces the same reader to be picked up again by a later task. Correctness here is only guaranteed if readers are returned to the pool intact and handed to subsequent sub-searches.