### PR TITLE
fix(highlight): ensure fragment window fully contains match (BUG-285)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"ff7b0b3e-bebc-4395-8d07-9f45ddff4f9d","pid":47451,"acquiredAt":1776445365687}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"ff7b0b3e-bebc-4395-8d07-9f45ddff4f9d","pid":47451,"acquiredAt":1776445365687}

--- a/searchlite-core/src/index/highlight.rs
+++ b/searchlite-core/src/index/highlight.rs
@@ -51,7 +51,9 @@ pub fn highlight_fragments(
       // `replace_all` on the truncated fragment silently fails to highlight.
       let match_len = m.end() - m.start();
       let effective_size = opts.fragment_size.max(match_len);
-      let raw_start = m.start().saturating_sub(effective_size.saturating_sub(match_len) / 2);
+      let raw_start = m
+        .start()
+        .saturating_sub(effective_size.saturating_sub(match_len) / 2);
       let raw_end = usize::min(
         text.len(),
         raw_start.saturating_add(effective_size).max(m.end()),
@@ -152,8 +154,7 @@ mod tests {
     let text = "aaaaaaaaa bbbbbbbb cccccccc dddddddd eeeeeeee \
                 the quick brown fox jumps over the lazy dog near the river yyyy";
     let phrase: Vec<String> = [
-      "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog", "near", "the",
-      "river",
+      "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog", "near", "the", "river",
     ]
     .iter()
     .map(|s| s.to_string())

--- a/searchlite-core/src/index/highlight.rs
+++ b/searchlite-core/src/index/highlight.rs
@@ -47,8 +47,15 @@ pub fn highlight_fragments(
   let mut offset = 0usize;
   for _ in 0..opts.number_of_fragments {
     if let Some(m) = re.find_at(text, offset) {
-      let raw_start = m.start().saturating_sub(opts.fragment_size / 2);
-      let raw_end = usize::min(text.len(), raw_start.saturating_add(opts.fragment_size));
+      // Ensure the window is wide enough to fully contain the match; otherwise
+      // `replace_all` on the truncated fragment silently fails to highlight.
+      let match_len = m.end() - m.start();
+      let effective_size = opts.fragment_size.max(match_len);
+      let raw_start = m.start().saturating_sub(effective_size.saturating_sub(match_len) / 2);
+      let raw_end = usize::min(
+        text.len(),
+        raw_start.saturating_add(effective_size).max(m.end()),
+      );
       // Snap to character boundaries to avoid slicing mid-character.
       let start = snap_char_boundary_left(text, raw_start);
       let end = snap_char_boundary_right(text, raw_end);
@@ -133,6 +140,44 @@ mod tests {
     assert!(
       frags[0].contains("<em>système</em>"),
       "fragment should contain highlighted term, got: {}",
+      frags[0]
+    );
+  }
+
+  #[test]
+  fn long_phrase_match_is_fully_contained_in_fragment() {
+    // Regression for issue #285: when a phrase match is longer than
+    // fragment_size / 2, the fragment window must still fully contain it so
+    // that `replace_all` can apply highlight tags.
+    let text = "aaaaaaaaa bbbbbbbb cccccccc dddddddd eeeeeeee \
+                the quick brown fox jumps over the lazy dog near the river yyyy";
+    let phrase: Vec<String> = [
+      "the", "quick", "brown", "fox", "jumps", "over", "the", "lazy", "dog", "near", "the",
+      "river",
+    ]
+    .iter()
+    .map(|s| s.to_string())
+    .collect();
+    let frags = highlight_fragments(
+      text,
+      &[],
+      &[phrase],
+      HighlightOptions {
+        pre_tag: "<em>",
+        post_tag: "</em>",
+        fragment_size: 100,
+        number_of_fragments: 1,
+      },
+    );
+    assert!(!frags.is_empty(), "should produce a fragment");
+    assert!(
+      frags[0].contains("<em>") && frags[0].contains("</em>"),
+      "fragment should contain highlight tags, got: {}",
+      frags[0]
+    );
+    assert!(
+      frags[0].contains("river</em>"),
+      "fragment should fully contain the phrase match including 'river', got: {}",
       frags[0]
     );
   }


### PR DESCRIPTION
## Summary

Fixes #285.

`highlight_fragments` centered its fragment on `m.start()` with a fixed width of `fragment_size`, giving the match only `fragment_size / 2` bytes of forward coverage. When a phrase match was longer than that (common for multi-term phrase queries, or phrase matches in multi-byte UTF-8), the tail of the match fell outside the fragment. The subsequent `regex.replace_all` on the truncated fragment then failed to find the full match, so the fragment was returned **without any highlight tags** — a silent correctness failure.

## Fix

Expand the window to at least the match length, and extend the end to cover `m.end()`, so `replace_all` can always apply highlight tags.

```rust
let match_len = m.end() - m.start();
let effective_size = opts.fragment_size.max(match_len);
let raw_start = m.start().saturating_sub(effective_size.saturating_sub(match_len) / 2);
let raw_end = usize::min(
  text.len(),
  raw_start.saturating_add(effective_size).max(m.end()),
);
```

The `effective_size - match_len` recentering keeps the match visually near the middle of the fragment when `fragment_size > match_len`, and degrades gracefully when the match is larger than the requested fragment (rather than pushing the fragment entirely to the left of the match).

## Test plan
- [x] Added regression test `long_phrase_match_is_fully_contained_in_fragment` reproducing the scenario from the issue (100-byte fragment, ~57-byte phrase match starting at byte ~46).
- [x] `cargo test -p searchlite-core --lib` — 373 passed.
- [x] Existing highlight tests still pass (first-term, multibyte, char-boundary snapping).