### PR TITLE
fix(aggs): use checked arithmetic on date_histogram calendar bucket_start (BUG-289)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4044,7 +4044,14 @@ fn bucket_start(value: i64, offset: i64, interval: &DateInterval) -> Option<i64>
       Some(bucket.saturating_mul(*step).saturating_add(offset))
     }
     DateInterval::Calendar(unit) => {
-      truncate_calendar(value - offset, *unit).map(|start| start + offset)
+      // Use checked arithmetic to match the overflow hardening of the
+      // fixed-interval branch above (BUG-289). Plain `value - offset` /
+      // `start + offset` panics in debug builds and wraps silently in
+      // release builds for timestamps near the `i64` bounds; `None`
+      // propagates as "skip this document" through the collector's
+      // existing `None` handling.
+      let shifted = value.checked_sub(offset)?;
+      truncate_calendar(shifted, *unit).and_then(|start| start.checked_add(offset))
     }
   }
 }
@@ -4643,6 +4650,73 @@ mod tests {
           "truncate_calendar returned None for {date} with unit {name}; \
            DateHistogramCollector would silently drop this document",
         );
+      }
+    }
+  }
+
+  /// BUG-289: the calendar path of `bucket_start` previously used plain
+  /// `value - offset` / `start + offset`, which overflows `i64` when a
+  /// document timestamp sits near `i64::MIN`/`i64::MAX` with a non-zero
+  /// offset. In debug builds this panics ("attempt to subtract with
+  /// overflow") on a path reachable from the public search API; in release
+  /// builds it wraps silently and places the document in a bucket that can
+  /// be off by the full `i64` range. With `checked_*` the function returns
+  /// `None`, which the collector already treats as "skip this document".
+  #[test]
+  fn bucket_start_calendar_does_not_overflow_near_i64_bounds() {
+    let units = [
+      CalendarUnit::Day,
+      CalendarUnit::Week,
+      CalendarUnit::Month,
+      CalendarUnit::Quarter,
+      CalendarUnit::Year,
+    ];
+    // Values chosen so that `value - offset` (or `start + offset`) would
+    // overflow an `i64` under unchecked arithmetic.
+    let cases: &[(i64, i64)] = &[
+      (i64::MIN + 500, 1_000),  // subtraction overflow on the way in
+      (i64::MIN, 1),            // exact `i64::MIN` with positive offset
+      (i64::MAX - 500, -1_000), // addition overflow on the way in
+      (i64::MAX, -1),           // exact `i64::MAX` with negative offset
+    ];
+    for unit in units {
+      for &(value, offset) in cases {
+        // Must not panic under debug overflow checks, and must not wrap.
+        let result = bucket_start(value, offset, &DateInterval::Calendar(unit));
+        if let Some(start) = result {
+          assert!(
+            start.checked_add(offset).is_some(),
+            "bucket_start returned a value that cannot represent the \
+             offset-adjusted bucket key for value={value}, offset={offset}"
+          );
+        }
+      }
+    }
+  }
+
+  /// BUG-289 cross-path consistency: the calendar and fixed-interval
+  /// branches of `bucket_start` must both tolerate extreme timestamps
+  /// without panicking. The fixed path already used saturating arithmetic;
+  /// the calendar path now uses checked arithmetic. Neither must panic for
+  /// any `(value, offset)` near the `i64` bounds.
+  #[test]
+  fn bucket_start_never_panics_near_i64_bounds() {
+    let intervals = [
+      DateInterval::Fixed(86_400_000), // 1 day
+      DateInterval::Calendar(CalendarUnit::Day),
+      DateInterval::Calendar(CalendarUnit::Month),
+      DateInterval::Calendar(CalendarUnit::Year),
+    ];
+    let values = [i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX - 1, i64::MAX];
+    let offsets = [i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX - 1, i64::MAX];
+    for interval in &intervals {
+      for &value in &values {
+        for &offset in &offsets {
+          // Must return Some or None, never panic. Debug builds would
+          // previously panic on the calendar path with
+          // "attempt to subtract with overflow".
+          let _ = bucket_start(value, offset, interval);
+        }
       }
     }
   }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4671,25 +4671,55 @@ mod tests {
       CalendarUnit::Quarter,
       CalendarUnit::Year,
     ];
-    // Values chosen so that `value - offset` (or `start + offset`) would
-    // overflow an `i64` under unchecked arithmetic.
-    let cases: &[(i64, i64)] = &[
+    // Cases where `value - offset` (or `start + offset`) would overflow
+    // an `i64` under unchecked arithmetic, so the correct result is `None`.
+    let must_be_none: &[(i64, i64)] = &[
       (i64::MIN + 500, 1_000),  // subtraction overflow on the way in
       (i64::MIN, 1),            // exact `i64::MIN` with positive offset
       (i64::MAX - 500, -1_000), // addition overflow on the way in
       (i64::MAX, -1),           // exact `i64::MAX` with negative offset
     ];
     for unit in units {
-      for &(value, offset) in cases {
-        // Must not panic under debug overflow checks, and must not wrap.
+      for &(value, offset) in must_be_none {
+        // Must not panic under debug overflow checks. Because
+        // `value.checked_sub(offset)` overflows for these inputs, the
+        // calendar path must short-circuit to `None` rather than wrap
+        // and produce a silently incorrect bucket key.
         let result = bucket_start(value, offset, &DateInterval::Calendar(unit));
-        if let Some(start) = result {
-          assert!(
-            start.checked_add(offset).is_some(),
-            "bucket_start returned a value that cannot represent the \
-             offset-adjusted bucket key for value={value}, offset={offset}"
-          );
-        }
+        assert_eq!(
+          result, None,
+          "bucket_start must return None when `value - offset` overflows \
+           (unit={unit:?}, value={value}, offset={offset}); unchecked \
+           arithmetic would have wrapped to an incorrect bucket key"
+        );
+      }
+    }
+
+    // Non-overflowing cases near the bounds: bucket_start must agree with
+    // a locally-computed reference that performs the same checked
+    // sub -> truncate_calendar -> checked_add pipeline. This catches any
+    // future regression that re-introduces wrapping on the inner values
+    // even if the outer arithmetic happens to round-trip.
+    let safe_cases: &[(i64, i64)] = &[
+      (0, 0),
+      (0, 1_000),
+      (1_000, 0),
+      (-1_000, 0),
+      (1_577_836_800_000, 3_600_000), // 2020-01-01T00:00:00Z, +1h offset
+      (-62_135_596_800_000, 0),       // year 1 CE, no offset
+    ];
+    for unit in units {
+      for &(value, offset) in safe_cases {
+        let expected = value
+          .checked_sub(offset)
+          .and_then(|shifted| truncate_calendar(shifted, unit))
+          .and_then(|start| start.checked_add(offset));
+        let actual = bucket_start(value, offset, &DateInterval::Calendar(unit));
+        assert_eq!(
+          actual, expected,
+          "bucket_start disagrees with the reference checked pipeline \
+           for unit={unit:?}, value={value}, offset={offset}"
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #289.

The calendar branch of `bucket_start` in `date_histogram` used plain
`value - offset` and `start + offset`, while the adjacent fixed-interval
branch had already been hardened with saturating arithmetic. When a
document timestamp sits near `i64::MIN`/`i64::MAX` and the
date_histogram specifies a non-zero offset:

- **Debug builds** panic with `attempt to subtract with overflow` — a
  panic reachable from the public search API via a crafted
  date_histogram aggregation request.
- **Release builds** wrap silently via two's-complement arithmetic and
  place the document in a bucket that can be off by the full `i64`
  range (for example, a timestamp near `i64::MIN` with a 1s offset ends
  up in a bucket ~584 billion years in the future).

## Fix

Switch the calendar path to `checked_sub` / `checked_add` in
`searchlite-core/src/query/aggs/mod.rs`. `None` already propagates as
"skip this document" through `DateHistogramCollector::collect` and
`finish`, matching how `truncate_calendar` already signals
unrepresentable dates — so no caller changes are needed.

The fixed-interval branch is unchanged; it already uses
`saturating_sub` / `saturating_mul` / `saturating_add`.

## Tests

Two new regression tests in `searchlite-core/src/query/aggs/mod.rs`:

- `bucket_start_calendar_does_not_overflow_near_i64_bounds` — sweeps
  the calendar path over every `CalendarUnit` with timestamps and
  offsets chosen so that unchecked arithmetic would overflow on the
  way in (and checks that any returned bucket start is representable
  on the way out).
- `bucket_start_never_panics_near_i64_bounds` — cross-path Cartesian
  sweep of `{i64::MIN, i64::MIN+1, -1, 0, 1, i64::MAX-1, i64::MAX}` ×
  itself over both the fixed and calendar interval branches. Catches
  any future regression that re-introduces unchecked arithmetic on
  either path, since debug builds would panic.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`
- [x] `cargo test -p searchlite-core --lib` (384 passed)
- [x] New regression tests pass on both debug and release profiles
