### PR TITLE
fix(rescore): shrink sort_window by removed hits to exclude non-rescored (BUG-291)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2129,14 +2129,22 @@ impl IndexReader {
         }
       }
     }
-    if !to_remove.is_empty() {
+    let removed = if !to_remove.is_empty() {
       to_remove.sort_unstable();
       to_remove.dedup();
+      let n = to_remove.len();
       for idx in to_remove.into_iter().rev() {
         hits.remove(idx);
       }
-    }
-    let sort_window = rescore.window_size.min(hits.len());
+      n
+    } else {
+      0
+    };
+    // Only hits that were actually rescored (the first `window - removed`
+    // survivors) are on the combined-score scale. Any hits that shifted left
+    // due to removals still carry raw scores and must not be re-sorted against
+    // rescored survivors.
+    let sort_window = window.saturating_sub(removed).min(hits.len());
     if sort_window > 0 {
       hits[..sort_window].sort_by(|a, b| a.key.cmp(&b.key));
     }

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -686,3 +686,73 @@ fn max_boost_caps_function_score_before_boost_mode_multiply() {
     );
   }
 }
+
+#[test]
+fn rescore_sort_window_excludes_non_rescored_after_removal() {
+  // Regression test for BUG-291: when rescore drops hits from within the
+  // window (via function_score + min_score causing evaluate_compiled_score
+  // to return None), the sort window must shrink by the number of removed
+  // hits. Otherwise non-rescored hits that shifted left into the original
+  // window bounds get re-sorted against rescored hits whose scores are on
+  // a different scale, producing incorrect ranking.
+  let reader = setup_reader();
+  // Base query: MatchAll scored by popularity (field_value_factor, Replace).
+  // Raw scores → doc-1: 10, doc-3: 5, doc-2: 1. Initial order: [doc-1, doc-3, doc-2].
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::None),
+      missing: None,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore window covers only the first two hits (doc-1 and doc-3). The
+  // rescore query yields 0.01 for doc-1 and 0.005 for doc-3; min_score=0.008
+  // drops doc-3 (returns None) but keeps doc-1. With RescoreMode::Multiply:
+  // doc-1 combined = 10 * 0.01 = 0.1. doc-2 sits outside the window and
+  // keeps its raw score of 1.0. If the sort window is not shrunk, the
+  // post-removal sort would re-order doc-2 (1.0) above doc-1 (0.1), even
+  // though doc-2 was never rescored.
+  req.rescore = Some(RescoreRequest {
+    window_size: 2,
+    query: QueryNode::FunctionScore {
+      query: Box::new(QueryNode::MatchAll { boost: None }),
+      functions: vec![FunctionSpec::FieldValueFactor {
+        field: "popularity".into(),
+        factor: 0.001,
+        modifier: Some(FieldValueModifier::None),
+        missing: None,
+        filter: None,
+      }],
+      score_mode: Some(FunctionScoreMode::Sum),
+      boost_mode: Some(FunctionBoostMode::Replace),
+      max_boost: None,
+      min_score: Some(0.008),
+      boost: None,
+    },
+    score_mode: RescoreMode::Multiply,
+  });
+  let resp = reader.search(&req).unwrap();
+  // doc-3 was dropped by rescore; doc-1 stays first (rescored), doc-2 stays
+  // second (non-rescored raw score preserved at its original rank).
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-2"]);
+  let doc1 = resp.hits.iter().find(|h| h.doc_id == "doc-1").unwrap();
+  let doc2 = resp.hits.iter().find(|h| h.doc_id == "doc-2").unwrap();
+  assert!(
+    (doc1.score - 0.1).abs() < 1e-6,
+    "doc-1 combined score should be 10 * 0.01 = 0.1, got {}",
+    doc1.score
+  );
+  assert!(
+    (doc2.score - 1.0).abs() < 1e-6,
+    "doc-2 raw score should be preserved at 1.0, got {}",
+    doc2.score
+  );
+}


### PR DESCRIPTION
## Summary

Fixes #291. When `rescore_hits` drops hits from inside the rescore window because `evaluate_compiled_score` returns `None` (e.g. `function_score` + `min_score` in the rescore query), the subsequent sort window was recomputed from `rescore.window_size.min(hits.len())` on the post-removal list. Hits that originally sat outside the window shifted left into the sort range and were re-sorted against rescored hits whose scores are on a different scale (combined BM25+rescore vs. raw BM25), producing incorrect ranking.

## What changed

- **`searchlite-core/src/api/reader.rs`** (`rescore_hits`): capture `to_remove.len()` after dedup, then derive `sort_window = window.saturating_sub(removed).min(hits.len())`. Only the rescored survivors (positions `0..(window - removed)`) are re-sorted; shifted non-rescored hits keep their original relative rank.

- **`searchlite-core/tests/function_score.rs`** — new regression test `rescore_sort_window_excludes_non_rescored_after_removal`. The test:
  - Scores three docs by `popularity` (doc-1=10, doc-3=5, doc-2=1).
  - Uses `window_size=2`, so doc-1 and doc-3 are rescored and doc-2 is not.
  - Rescore is a `function_score` with `field_value_factor(factor=0.001)` and `min_score=0.008`, which yields `0.01` for doc-1 (passes) and `0.005` for doc-3 (returns `None`, so doc-3 is dropped).
  - Under `RescoreMode::Multiply`, doc-1's combined score becomes `10 * 0.01 = 0.1`, while doc-2's raw score (`1.0`) is untouched.
  - Without the fix the post-removal sort re-orders doc-2 above doc-1 (`1.0 > 0.1`), even though doc-2 was never rescored. With the fix the sort range shrinks to a single element and the final order is `[doc-1, doc-2]`.

Verified the test fails on `main` and passes on this branch.

## Test plan

- [x] `cargo test -p searchlite-core --test function_score` — 20/20 pass (19 existing + 1 new regression).
- [x] `cargo test -p searchlite-core --lib` — 384/384 pass.
- [x] `cargo test -p searchlite-core` — full core test matrix green (lib + all integration suites).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p searchlite-core --tests --no-deps -- -D warnings` clean.

Closes #291