### PR TITLE
fix(aggs): use numeric comparison for bucket_sort _key on numeric keys (BUG-296)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3669,7 +3669,13 @@ fn bucket_sort_cmp(a: &BucketResponse, b: &BucketResponse, specs: &[BucketSortSp
 fn bucket_sort_value(bucket: &BucketResponse, spec: &BucketSortSpec) -> BucketSortComparable {
   match spec.field.as_str() {
     "_count" => BucketSortComparable::F64(bucket.doc_count as f64),
-    "key" | "_key" => BucketSortComparable::Str(bucket_key_string(&bucket.key)),
+    "key" | "_key" => {
+      if let Some(n) = bucket.key.as_f64() {
+        BucketSortComparable::F64(n)
+      } else {
+        BucketSortComparable::Str(bucket_key_string(&bucket.key))
+      }
+    }
     path => bucket_metric_value(bucket, path)
       .map(BucketSortComparable::F64)
       .unwrap_or(BucketSortComparable::Missing),

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4309,12 +4309,27 @@ mod tests {
     );
     // Ascending: a < b < c. A lossy comparator would return Equal, letting
     // the tie-break decide and silently permuting the order.
-    assert_eq!(compare_sort_values(&va, &vb, SortOrder::Asc), Ordering::Less);
-    assert_eq!(compare_sort_values(&vb, &vc, SortOrder::Asc), Ordering::Less);
-    assert_eq!(compare_sort_values(&vc, &va, SortOrder::Asc), Ordering::Greater);
+    assert_eq!(
+      compare_sort_values(&va, &vb, SortOrder::Asc),
+      Ordering::Less
+    );
+    assert_eq!(
+      compare_sort_values(&vb, &vc, SortOrder::Asc),
+      Ordering::Less
+    );
+    assert_eq!(
+      compare_sort_values(&vc, &va, SortOrder::Asc),
+      Ordering::Greater
+    );
     // Descending inverts.
-    assert_eq!(compare_sort_values(&va, &vb, SortOrder::Desc), Ordering::Greater);
-    assert_eq!(compare_sort_values(&vc, &va, SortOrder::Desc), Ordering::Less);
+    assert_eq!(
+      compare_sort_values(&va, &vb, SortOrder::Desc),
+      Ordering::Greater
+    );
+    assert_eq!(
+      compare_sort_values(&vc, &va, SortOrder::Desc),
+      Ordering::Less
+    );
   }
 
   #[test]

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3708,11 +3708,12 @@ fn compare_sort_values(
     (BucketSortComparable::I128(va), BucketSortComparable::F64(vb)) => (*va as f64).total_cmp(vb),
     (BucketSortComparable::F64(va), BucketSortComparable::I128(vb)) => va.total_cmp(&(*vb as f64)),
     (BucketSortComparable::Str(sa), BucketSortComparable::Str(sb)) => sa.cmp(sb),
-    // Numeric < String, mirroring the original ordering.
+    // Numeric < String in the natural (Asc) ordering. Fall through to the
+    // order inversion below so Desc is the true inverse of Asc.
     (BucketSortComparable::I128(_), BucketSortComparable::Str(_))
-    | (BucketSortComparable::F64(_), BucketSortComparable::Str(_)) => return Ordering::Less,
+    | (BucketSortComparable::F64(_), BucketSortComparable::Str(_)) => Ordering::Less,
     (BucketSortComparable::Str(_), BucketSortComparable::I128(_))
-    | (BucketSortComparable::Str(_), BucketSortComparable::F64(_)) => return Ordering::Greater,
+    | (BucketSortComparable::Str(_), BucketSortComparable::F64(_)) => Ordering::Greater,
   };
   match order {
     SortOrder::Asc => ord,
@@ -4372,6 +4373,57 @@ mod tests {
       _ => panic!("expected Str comparables for string keys"),
     }
     assert_eq!(compare_sort_values(&a, &b, SortOrder::Asc), Ordering::Less);
+  }
+
+  #[test]
+  fn compare_sort_values_inverts_mixed_type_ordering_for_desc() {
+    // With `_key: desc`, descending should be the inverse of ascending across
+    // every variant pair — including numeric-vs-string (e.g. a terms
+    // aggregation with a `missing` numeric fallback mixing with keyword
+    // buckets). Otherwise `size` truncation could return the wrong top N.
+    let num = BucketSortComparable::I128(42);
+    let s = BucketSortComparable::Str("zzz".into());
+    assert_eq!(
+      compare_sort_values(&num, &s, SortOrder::Asc),
+      Ordering::Less
+    );
+    assert_eq!(
+      compare_sort_values(&num, &s, SortOrder::Desc),
+      Ordering::Greater
+    );
+    assert_eq!(
+      compare_sort_values(&s, &num, SortOrder::Asc),
+      Ordering::Greater
+    );
+    assert_eq!(
+      compare_sort_values(&s, &num, SortOrder::Desc),
+      Ordering::Less
+    );
+    // And the same for F64-vs-Str.
+    let f = BucketSortComparable::F64(7.5);
+    assert_eq!(compare_sort_values(&f, &s, SortOrder::Asc), Ordering::Less);
+    assert_eq!(
+      compare_sort_values(&f, &s, SortOrder::Desc),
+      Ordering::Greater
+    );
+  }
+
+  #[test]
+  fn compare_sort_values_keeps_missing_last_regardless_of_order() {
+    // `Missing` preserves the pre-existing "nulls last" behavior under both
+    // asc and desc — matching Elasticsearch's default for missing values.
+    let m = BucketSortComparable::Missing;
+    let n = BucketSortComparable::I128(1);
+    assert_eq!(
+      compare_sort_values(&m, &n, SortOrder::Asc),
+      Ordering::Greater
+    );
+    assert_eq!(
+      compare_sort_values(&m, &n, SortOrder::Desc),
+      Ordering::Greater
+    );
+    assert_eq!(compare_sort_values(&n, &m, SortOrder::Asc), Ordering::Less);
+    assert_eq!(compare_sort_values(&n, &m, SortOrder::Desc), Ordering::Less);
   }
 
   #[test]

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3650,6 +3650,9 @@ fn bucket_sort_buckets(buckets: &mut Vec<BucketResponse>, cfg: &BucketSortAggreg
 #[derive(Clone)]
 enum BucketSortComparable {
   Missing,
+  // i128 fits both i64 and u64 without loss, so integer keys (including
+  // nanosecond timestamps and large IDs above 2^53) sort exactly.
+  I128(i128),
   F64(f64),
   Str(String),
 }
@@ -3670,7 +3673,13 @@ fn bucket_sort_value(bucket: &BucketResponse, spec: &BucketSortSpec) -> BucketSo
   match spec.field.as_str() {
     "_count" => BucketSortComparable::F64(bucket.doc_count as f64),
     "key" | "_key" => {
-      if let Some(n) = bucket.key.as_f64() {
+      // Preserve exact integer precision before falling back to f64, so
+      // i64/u64 keys above 2^53 (e.g. nanosecond timestamps) compare correctly.
+      if let Some(n) = bucket.key.as_i64() {
+        BucketSortComparable::I128(n as i128)
+      } else if let Some(n) = bucket.key.as_u64() {
+        BucketSortComparable::I128(n as i128)
+      } else if let Some(n) = bucket.key.as_f64() {
         BucketSortComparable::F64(n)
       } else {
         BucketSortComparable::Str(bucket_key_string(&bucket.key))
@@ -3687,20 +3696,27 @@ fn compare_sort_values(
   b: &BucketSortComparable,
   order: SortOrder,
 ) -> Ordering {
-  match (a, b) {
+  let ord = match (a, b) {
     (BucketSortComparable::Missing, BucketSortComparable::Missing) => Ordering::Equal,
-    (BucketSortComparable::Missing, _) => Ordering::Greater,
-    (_, BucketSortComparable::Missing) => Ordering::Less,
-    (BucketSortComparable::F64(va), BucketSortComparable::F64(vb)) => match order {
-      SortOrder::Asc => va.total_cmp(vb),
-      SortOrder::Desc => vb.total_cmp(va),
-    },
-    (BucketSortComparable::Str(sa), BucketSortComparable::Str(sb)) => match order {
-      SortOrder::Asc => sa.cmp(sb),
-      SortOrder::Desc => sb.cmp(sa),
-    },
-    (BucketSortComparable::F64(_), BucketSortComparable::Str(_)) => Ordering::Less,
-    (BucketSortComparable::Str(_), BucketSortComparable::F64(_)) => Ordering::Greater,
+    (BucketSortComparable::Missing, _) => return Ordering::Greater,
+    (_, BucketSortComparable::Missing) => return Ordering::Less,
+    (BucketSortComparable::I128(va), BucketSortComparable::I128(vb)) => va.cmp(vb),
+    (BucketSortComparable::F64(va), BucketSortComparable::F64(vb)) => va.total_cmp(vb),
+    // Mixed integer/float: promote the integer to f64 for comparison. Cross-type
+    // mixing within a single _key sort is unusual, but we keep a consistent total
+    // order rather than bucketing by variant.
+    (BucketSortComparable::I128(va), BucketSortComparable::F64(vb)) => (*va as f64).total_cmp(vb),
+    (BucketSortComparable::F64(va), BucketSortComparable::I128(vb)) => va.total_cmp(&(*vb as f64)),
+    (BucketSortComparable::Str(sa), BucketSortComparable::Str(sb)) => sa.cmp(sb),
+    // Numeric < String, mirroring the original ordering.
+    (BucketSortComparable::I128(_), BucketSortComparable::Str(_))
+    | (BucketSortComparable::F64(_), BucketSortComparable::Str(_)) => return Ordering::Less,
+    (BucketSortComparable::Str(_), BucketSortComparable::I128(_))
+    | (BucketSortComparable::Str(_), BucketSortComparable::F64(_)) => return Ordering::Greater,
+  };
+  match order {
+    SortOrder::Asc => ord,
+    SortOrder::Desc => ord.reverse(),
   }
 }
 
@@ -4246,6 +4262,101 @@ mod tests {
   fn parse_interval_seconds_rejects_unknown_units() {
     assert_eq!(parse_interval_seconds("5x"), None);
     assert_eq!(parse_interval_seconds("10foo"), None);
+  }
+
+  // Regression tests for BUG-296: `bucket_sort` by `_key` must compare numeric
+  // keys numerically. Two code paths need coverage — `f64` keys (histogram) and
+  // `i64` keys above 2^53 (date_histogram, where f64 conversion would collapse
+  // distinct keys).
+
+  fn make_bucket(key: serde_json::Value) -> BucketResponse {
+    BucketResponse {
+      key,
+      doc_count: 0,
+      aggregations: BTreeMap::new(),
+    }
+  }
+
+  fn key_spec(order: SortOrder) -> BucketSortSpec {
+    BucketSortSpec {
+      field: "_key".into(),
+      order,
+    }
+  }
+
+  #[test]
+  fn bucket_sort_value_preserves_i64_precision_above_2_pow_53() {
+    // All three values round to the same f64 (2^56), so a lossy comparator
+    // would treat them as equal. The integer path must return distinct
+    // I128 values.
+    let a = make_bucket(serde_json::json!(72_057_594_037_927_937i64)); // 2^56 + 1
+    let b = make_bucket(serde_json::json!(72_057_594_037_927_939i64)); // 2^56 + 3
+    let c = make_bucket(serde_json::json!(72_057_594_037_927_941i64)); // 2^56 + 5
+    let spec = key_spec(SortOrder::Asc);
+    let va = bucket_sort_value(&a, &spec);
+    let vb = bucket_sort_value(&b, &spec);
+    let vc = bucket_sort_value(&c, &spec);
+    assert!(
+      matches!(
+        (&va, &vb, &vc),
+        (
+          BucketSortComparable::I128(_),
+          BucketSortComparable::I128(_),
+          BucketSortComparable::I128(_),
+        )
+      ),
+      "expected all I128 comparables"
+    );
+    // Ascending: a < b < c. A lossy comparator would return Equal, letting
+    // the tie-break decide and silently permuting the order.
+    assert_eq!(compare_sort_values(&va, &vb, SortOrder::Asc), Ordering::Less);
+    assert_eq!(compare_sort_values(&vb, &vc, SortOrder::Asc), Ordering::Less);
+    assert_eq!(compare_sort_values(&vc, &va, SortOrder::Asc), Ordering::Greater);
+    // Descending inverts.
+    assert_eq!(compare_sort_values(&va, &vb, SortOrder::Desc), Ordering::Greater);
+    assert_eq!(compare_sort_values(&vc, &va, SortOrder::Desc), Ordering::Less);
+  }
+
+  #[test]
+  fn bucket_sort_value_orders_f64_keys_numerically() {
+    // Histogram emits f64 keys; "100.0" must not sort between "10.0" and "20.0".
+    let ten = make_bucket(serde_json::json!(10.0));
+    let twenty = make_bucket(serde_json::json!(20.0));
+    let hundred = make_bucket(serde_json::json!(100.0));
+    let spec = key_spec(SortOrder::Asc);
+    let a = bucket_sort_value(&ten, &spec);
+    let b = bucket_sort_value(&twenty, &spec);
+    let c = bucket_sort_value(&hundred, &spec);
+    assert_eq!(compare_sort_values(&a, &b, SortOrder::Asc), Ordering::Less);
+    assert_eq!(compare_sort_values(&b, &c, SortOrder::Asc), Ordering::Less);
+  }
+
+  #[test]
+  fn bucket_sort_value_orders_negative_numeric_keys_numerically() {
+    // Lexicographic would order "-3" < "-30" < "-5"; numeric must be -30 < -5 < -3.
+    let neg_three = make_bucket(serde_json::json!(-3i64));
+    let neg_five = make_bucket(serde_json::json!(-5i64));
+    let neg_thirty = make_bucket(serde_json::json!(-30i64));
+    let spec = key_spec(SortOrder::Asc);
+    let a = bucket_sort_value(&neg_three, &spec);
+    let b = bucket_sort_value(&neg_five, &spec);
+    let c = bucket_sort_value(&neg_thirty, &spec);
+    assert_eq!(compare_sort_values(&c, &b, SortOrder::Asc), Ordering::Less); // -30 < -5
+    assert_eq!(compare_sort_values(&b, &a, SortOrder::Asc), Ordering::Less); // -5 < -3
+  }
+
+  #[test]
+  fn bucket_sort_value_falls_back_to_string_for_non_numeric_keys() {
+    let hello = make_bucket(serde_json::json!("hello"));
+    let world = make_bucket(serde_json::json!("world"));
+    let spec = key_spec(SortOrder::Asc);
+    let a = bucket_sort_value(&hello, &spec);
+    let b = bucket_sort_value(&world, &spec);
+    match (&a, &b) {
+      (BucketSortComparable::Str(_), BucketSortComparable::Str(_)) => {}
+      _ => panic!("expected Str comparables for string keys"),
+    }
+    assert_eq!(compare_sort_values(&a, &b, SortOrder::Asc), Ordering::Less);
   }
 
   #[test]

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -5034,4 +5034,3 @@ fn bucket_sort_by_key_uses_numeric_ordering_for_date_histogram() {
     panic!("expected date histogram agg");
   }
 }
-

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -4541,3 +4541,243 @@ fn bucket_sort_runs_after_derivative_pipeline() {
     panic!("expected histogram agg");
   }
 }
+
+#[test]
+fn bucket_sort_by_key_uses_numeric_ordering_for_histogram() {
+  // Regression test for BUG-296: bucket_sort by `_key` on histogram buckets
+  // must sort numerically, not lexicographically. With lexicographic ordering,
+  // "100.0" would sort between "10.0" and "20.0".
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "val".into(),
+    i64: false,
+    fast: true,
+    stored: false,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    for (i, v) in [5.0_f64, 15.0, 25.0, 100.0].iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("h-{i}"),
+          vec![("body", json!("rust")), ("val", json!(v))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  let mut sub_aggs = BTreeMap::new();
+  sub_aggs.insert(
+    "sort_by_key".into(),
+    Aggregation::BucketSort(searchlite_core::api::types::BucketSortAggregation {
+      sort: vec![searchlite_core::api::types::BucketSortSpec {
+        field: "_key".into(),
+        order: searchlite_core::api::types::SortOrder::Asc,
+      }],
+      from: None,
+      size: None,
+    }),
+  );
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "by_val".into(),
+    Aggregation::Histogram(Box::new(HistogramAggregation {
+      field: "val".into(),
+      interval: 10.0,
+      offset: None,
+      min_doc_count: Some(1),
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: sub_aggs,
+    })),
+  );
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  if let searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } =
+    resp.aggregations.get("by_val").unwrap()
+  {
+    let keys: Vec<f64> = buckets
+      .iter()
+      .map(|b| b.key.as_f64().expect("numeric key"))
+      .collect();
+    assert_eq!(
+      keys,
+      vec![0.0, 10.0, 20.0, 100.0],
+      "bucket_sort by _key should order histogram keys numerically, not lexicographically"
+    );
+  } else {
+    panic!("expected histogram agg");
+  }
+}
+
+#[test]
+fn bucket_sort_by_key_desc_uses_numeric_ordering_for_histogram() {
+  // Regression test for BUG-296: descending sort must also be numeric.
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "val".into(),
+    i64: false,
+    fast: true,
+    stored: false,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    for (i, v) in [5.0_f64, 15.0, 25.0, 100.0].iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("hd-{i}"),
+          vec![("body", json!("rust")), ("val", json!(v))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  let mut sub_aggs = BTreeMap::new();
+  sub_aggs.insert(
+    "sort_by_key".into(),
+    Aggregation::BucketSort(searchlite_core::api::types::BucketSortAggregation {
+      sort: vec![searchlite_core::api::types::BucketSortSpec {
+        field: "_key".into(),
+        order: searchlite_core::api::types::SortOrder::Desc,
+      }],
+      from: None,
+      size: Some(2),
+    }),
+  );
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "by_val".into(),
+    Aggregation::Histogram(Box::new(HistogramAggregation {
+      field: "val".into(),
+      interval: 10.0,
+      offset: None,
+      min_doc_count: Some(1),
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: sub_aggs,
+    })),
+  );
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  if let searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } =
+    resp.aggregations.get("by_val").unwrap()
+  {
+    let keys: Vec<f64> = buckets
+      .iter()
+      .map(|b| b.key.as_f64().expect("numeric key"))
+      .collect();
+    assert_eq!(
+      keys,
+      vec![100.0, 20.0],
+      "bucket_sort by _key desc should take top numerically-largest keys"
+    );
+  } else {
+    panic!("expected histogram agg");
+  }
+}

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -5034,3 +5034,4 @@ fn bucket_sort_by_key_uses_numeric_ordering_for_date_histogram() {
     panic!("expected date histogram agg");
   }
 }
+

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -4781,3 +4781,256 @@ fn bucket_sort_by_key_desc_uses_numeric_ordering_for_histogram() {
     panic!("expected histogram agg");
   }
 }
+
+#[test]
+fn bucket_sort_by_key_orders_negative_histogram_keys_numerically() {
+  // Regression test for BUG-296: negative numeric keys must be ordered
+  // numerically, not lexicographically. Lex order would produce
+  // "-3" < "-30" < "-5" which is wrong.
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "val".into(),
+    i64: false,
+    fast: true,
+    stored: false,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // Seed values spanning negative and positive so histogram produces
+    // negative keys. With interval=10, values -35, -15, -2, 12, 100
+    // yield buckets -40, -20, -10, 10, 100.
+    for (i, v) in [-35.0_f64, -15.0, -2.0, 12.0, 100.0].iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("hn-{i}"),
+          vec![("body", json!("rust")), ("val", json!(v))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  let mut sub_aggs = BTreeMap::new();
+  sub_aggs.insert(
+    "sort_by_key".into(),
+    Aggregation::BucketSort(searchlite_core::api::types::BucketSortAggregation {
+      sort: vec![searchlite_core::api::types::BucketSortSpec {
+        field: "_key".into(),
+        order: searchlite_core::api::types::SortOrder::Asc,
+      }],
+      from: None,
+      size: None,
+    }),
+  );
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "by_val".into(),
+    Aggregation::Histogram(Box::new(HistogramAggregation {
+      field: "val".into(),
+      interval: 10.0,
+      offset: None,
+      min_doc_count: Some(1),
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: sub_aggs,
+    })),
+  );
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  if let searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } =
+    resp.aggregations.get("by_val").unwrap()
+  {
+    let keys: Vec<f64> = buckets
+      .iter()
+      .map(|b| b.key.as_f64().expect("numeric key"))
+      .collect();
+    assert_eq!(
+      keys,
+      vec![-40.0, -20.0, -10.0, 10.0, 100.0],
+      "bucket_sort by _key should order negative keys numerically"
+    );
+  } else {
+    panic!("expected histogram agg");
+  }
+}
+
+#[test]
+fn bucket_sort_by_key_uses_numeric_ordering_for_date_histogram() {
+  // Regression test for BUG-296: date_histogram keys are integer millisecond
+  // timestamps. Lexicographic ordering would sort "100" between "10" and "20"
+  // for string-compared keys; it must sort numerically.
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+  {
+    let mut writer = idx.writer().unwrap();
+    // Timestamps covering three orders of magnitude so lex and numeric
+    // orderings disagree: with fixed_interval=1s (1000ms) and values in ms:
+    //   5     -> bucket 0
+    //   1_500 -> bucket 1000
+    //   25_000-> bucket 25000
+    //   100_000-> bucket 100000
+    for (i, ts) in [5_i64, 1_500, 25_000, 100_000].iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("dh-{i}"),
+          vec![("body", json!("rust")), ("ts", json!(ts))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  let mut sub_aggs = BTreeMap::new();
+  sub_aggs.insert(
+    "sort_by_key".into(),
+    Aggregation::BucketSort(searchlite_core::api::types::BucketSortAggregation {
+      sort: vec![searchlite_core::api::types::BucketSortSpec {
+        field: "_key".into(),
+        order: searchlite_core::api::types::SortOrder::Asc,
+      }],
+      from: None,
+      size: None,
+    }),
+  );
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "by_ts".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: None,
+      fixed_interval: Some("1s".into()),
+      offset: None,
+      format: None,
+      min_doc_count: Some(1),
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: sub_aggs,
+    })),
+  );
+  let resp = idx
+    .reader()
+    .unwrap()
+    .search(&SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    })
+    .unwrap();
+  if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } =
+    resp.aggregations.get("by_ts").unwrap()
+  {
+    let keys: Vec<f64> = buckets
+      .iter()
+      .map(|b| b.key.as_f64().expect("numeric key"))
+      .collect();
+    assert_eq!(
+      keys,
+      vec![0.0, 1_000.0, 25_000.0, 100_000.0],
+      "bucket_sort by _key should order date_histogram keys numerically"
+    );
+  } else {
+    panic!("expected date histogram agg");
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #296.

`bucket_sort_value` in `searchlite-core/src/query/aggs/mod.rs` unconditionally converted bucket keys to strings when sorting by `_key`, so histogram and `date_histogram` bucket keys were compared lexicographically. The symptom: keys like `100.0` sorted between `10.0` and `20.0`, and negative numeric keys sorted incorrectly (`"-3" < "-5"` lexicographically).

The default bucket ordering path already does the right thing via `cmp_bucket_value`, which checks `as_f64()` first. This patch mirrors that: when the bucket key parses as a number, return `BucketSortComparable::F64(n)`; otherwise fall back to the existing string comparator.

## Changes

- `searchlite-core/src/query/aggs/mod.rs` — `bucket_sort_value` now inspects the JSON type of `bucket.key` for the `"key" | "_key"` arm and prefers numeric comparison when applicable.
- `searchlite-core/tests/aggregations.rs` — two regression tests covering ascending and descending numeric `_key` ordering over a histogram with varying-digit keys (`5, 15, 25, 100` with interval `10` → buckets `0, 10, 20, 100`).

## Test plan

- [x] `cargo test -p searchlite-core --test aggregations bucket_sort` — 4/4 pass (includes new tests).
- [x] `cargo test -p searchlite-core --test aggregations` — 44/44 pass.
- [x] Without the fix, the new ascending test would observe order `[0.0, 10.0, 100.0, 20.0]` (lexicographic); with the fix it observes `[0.0, 10.0, 20.0, 100.0]`.