### PR TITLE
fix(aggs): return null for empty percentiles/percentile_ranks (BUG-303)

### DIFF
--- a/searchlite-core/src/api/types.rs
+++ b/searchlite-core/src/api/types.rs
@@ -1455,12 +1455,19 @@ pub struct CardinalityResponse {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PercentilesResponse {
-  pub values: BTreeMap<String, f64>,
+  /// Percentile values keyed by their percent (e.g. `"50"`, `"99.9"`). The
+  /// value is `None` when the aggregation observed no documents with the
+  /// requested field — matching Elasticsearch, which serializes those entries
+  /// as JSON `null`. Pipeline aggregations treat `None` as a missing value.
+  pub values: BTreeMap<String, Option<f64>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct PercentileRanksResponse {
-  pub values: BTreeMap<String, f64>,
+  /// Rank values keyed by their target value. `None` signals that the
+  /// aggregation observed no documents with the requested field (rather than
+  /// a genuine `0.0` rank) so pipeline aggregations can skip the bucket.
+  pub values: BTreeMap<String, Option<f64>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -587,9 +587,13 @@ impl QuantileState {
     self.values.clear();
   }
 
-  fn percentile(&mut self, pct: f64) -> f64 {
+  /// Returns `None` when no values have been observed (`count == 0`). Matches
+  /// Elasticsearch, which serializes empty percentile buckets as `null` so
+  /// pipeline aggregations skip them instead of folding a spurious `0.0`
+  /// into their running totals (BUG-303).
+  fn percentile(&mut self, pct: f64) -> Option<f64> {
     if self.count == 0 {
-      return 0.0;
+      return None;
     }
     if self.count <= PERCENTILE_EXACT_LIMIT && self.digest.is_none() {
       let mut vals = self.values.clone();
@@ -599,31 +603,29 @@ impl QuantileState {
       let low = rank.floor() as usize;
       let high = rank.ceil() as usize;
       if low == high {
-        return vals[low];
+        return Some(vals[low]);
       }
       let weight = rank - low as f64;
-      return vals[low] * (1.0 - weight) + vals[high] * weight;
+      return Some(vals[low] * (1.0 - weight) + vals[high] * weight);
     }
     self.ensure_digest();
-    let Some(digest) = self.digest.as_ref() else {
-      return 0.0;
-    };
+    let digest = self.digest.as_ref()?;
     let q = pct.clamp(0.0, 100.0) / 100.0;
-    digest.estimate_quantile(q)
+    Some(digest.estimate_quantile(q))
   }
 
-  fn percentile_rank(&mut self, target: f64) -> f64 {
+  /// Returns `None` when no values have been observed (`count == 0`). See
+  /// [`QuantileState::percentile`] for the rationale.
+  fn percentile_rank(&mut self, target: f64) -> Option<f64> {
     if self.count == 0 {
-      return 0.0;
+      return None;
     }
     if self.count <= PERCENTILE_EXACT_LIMIT && self.digest.is_none() {
       let count = self.values.iter().filter(|v| **v <= target).count();
-      return (count as f64 / self.values.len().max(1) as f64) * 100.0;
+      return Some((count as f64 / self.values.len().max(1) as f64) * 100.0);
     }
     self.ensure_digest();
-    let Some(digest) = self.digest.as_ref() else {
-      return 0.0;
-    };
+    let digest = self.digest.as_ref()?;
     let min_val = digest.estimate_quantile(0.0);
     // Use a strict `<` here so that `target == min_val` falls through to the
     // binary search, which matches the exact path's inclusive semantics
@@ -631,11 +633,11 @@ impl QuantileState {
     // to 0.0 whenever the caller targeted the observed minimum, even though one
     // or more values in the population are equal to it.
     if target < min_val {
-      return 0.0;
+      return Some(0.0);
     }
     let max_val = digest.estimate_quantile(1.0);
     if target >= max_val {
-      return 100.0;
+      return Some(100.0);
     }
     let mut lo = 0.0_f64;
     let mut hi = 1.0_f64;
@@ -651,7 +653,7 @@ impl QuantileState {
         break;
       }
     }
-    lo * 100.0
+    Some(lo * 100.0)
   }
 }
 
@@ -3766,11 +3768,14 @@ fn extract_metric_from_response(resp: &AggregationResponse, path: Option<&str>) 
     AggregationResponse::Cardinality(val) => Some(val.value as f64),
     AggregationResponse::Percentiles(vals) => {
       let key = path?;
-      vals.values.get(key).copied()
+      // Flatten `Option<Option<f64>>`: a missing key yields `None`, and so does a
+      // present-but-null entry. The latter is how empty buckets surface (BUG-303) —
+      // pipeline aggs must skip them rather than fold the prior `0.0` default.
+      vals.values.get(key).copied().flatten()
     }
     AggregationResponse::PercentileRanks(vals) => {
       let key = path?;
-      vals.values.get(key).copied()
+      vals.values.get(key).copied().flatten()
     }
     AggregationResponse::AvgBucket(val) | AggregationResponse::SumBucket(val) => val.value,
     AggregationResponse::Derivative(val) => val.value,
@@ -3787,7 +3792,7 @@ fn cmp_bucket_value(a: &serde_json::Value, b: &serde_json::Value) -> Ordering {
   a.to_string().cmp(&b.to_string())
 }
 
-fn compute_percentiles_from_state(mut state: PercentileState) -> BTreeMap<String, f64> {
+fn compute_percentiles_from_state(mut state: PercentileState) -> BTreeMap<String, Option<f64>> {
   let mut out = BTreeMap::new();
   for p in state.percents.iter() {
     out.insert(format!("{p}"), state.quantiles.percentile(*p));
@@ -3795,7 +3800,9 @@ fn compute_percentiles_from_state(mut state: PercentileState) -> BTreeMap<String
   out
 }
 
-fn compute_percentile_ranks_from_state(mut state: PercentileRankState) -> BTreeMap<String, f64> {
+fn compute_percentile_ranks_from_state(
+  mut state: PercentileRankState,
+) -> BTreeMap<String, Option<f64>> {
   let mut out = BTreeMap::new();
   for target in state.targets.iter() {
     out.insert(
@@ -4456,8 +4463,18 @@ mod tests {
     for v in [1.0, 2.0, 3.0, 4.0] {
       q.push(v);
     }
-    assert!((q.percentile(50.0) - 2.5).abs() < 1e-6);
-    assert!((q.percentile_rank(2.0) - 50.0).abs() < 1e-6);
+    assert!((q.percentile(50.0).unwrap() - 2.5).abs() < 1e-6);
+    assert!((q.percentile_rank(2.0).unwrap() - 50.0).abs() < 1e-6);
+  }
+
+  #[test]
+  fn quantile_state_empty_percentile_returns_none() {
+    // BUG-303: with no observed values, percentile() and percentile_rank()
+    // must return None rather than a spurious 0.0, so downstream consumers
+    // (pipeline aggs, serialized responses) can represent the bucket as null.
+    let mut q = QuantileState::default();
+    assert_eq!(q.percentile(50.0), None);
+    assert_eq!(q.percentile_rank(42.0), None);
   }
 
   #[test]
@@ -5676,9 +5693,9 @@ mod tests {
   fn bucket_metric_value_resolves_decimal_percentile_key() {
     let mut aggs = BTreeMap::new();
     let mut pct_values = BTreeMap::new();
-    pct_values.insert("50".to_string(), 10.0);
-    pct_values.insert("99.9".to_string(), 42.5);
-    pct_values.insert("99.99".to_string(), 100.0);
+    pct_values.insert("50".to_string(), Some(10.0));
+    pct_values.insert("99.9".to_string(), Some(42.5));
+    pct_values.insert("99.99".to_string(), Some(100.0));
     aggs.insert(
       "latency_pct".to_string(),
       AggregationResponse::Percentiles(PercentilesResponse { values: pct_values }),
@@ -5702,8 +5719,8 @@ mod tests {
   fn bucket_metric_value_resolves_decimal_percentile_rank_key() {
     let mut aggs = BTreeMap::new();
     let mut rank_values = BTreeMap::new();
-    rank_values.insert("50.5".to_string(), 72.0);
-    rank_values.insert("100".to_string(), 99.0);
+    rank_values.insert("50.5".to_string(), Some(72.0));
+    rank_values.insert("100".to_string(), Some(99.0));
     aggs.insert(
       "rank_agg".to_string(),
       AggregationResponse::PercentileRanks(PercentileRanksResponse {
@@ -5718,6 +5735,152 @@ mod tests {
 
     assert_eq!(bucket_metric_value(&bucket, "rank_agg.50.5"), Some(72.0));
     assert_eq!(bucket_metric_value(&bucket, "rank_agg.100"), Some(99.0));
+  }
+
+  #[test]
+  fn bucket_metric_value_percentiles_null_entry_returns_none() {
+    // BUG-303: when a percentiles sub-agg has no observed values, each level
+    // is serialized as null (`Option::None`). Pipeline aggregations resolving
+    // a path like "latency_pct.50" must treat that as missing — *not* as a
+    // spurious 0.0 folded into the running total.
+    let mut aggs = BTreeMap::new();
+    let mut pct_values = BTreeMap::new();
+    pct_values.insert("50".to_string(), None);
+    pct_values.insert("99".to_string(), None);
+    aggs.insert(
+      "latency_pct".to_string(),
+      AggregationResponse::Percentiles(PercentilesResponse { values: pct_values }),
+    );
+    let bucket = BucketResponse {
+      key: serde_json::json!(0),
+      doc_count: 3,
+      aggregations: aggs,
+    };
+
+    assert_eq!(bucket_metric_value(&bucket, "latency_pct.50"), None);
+    assert_eq!(bucket_metric_value(&bucket, "latency_pct.99"), None);
+    // Missing key still resolves to None (no accidental regression to 0.0).
+    assert_eq!(bucket_metric_value(&bucket, "latency_pct.75"), None);
+  }
+
+  #[test]
+  fn bucket_metric_value_percentile_ranks_null_entry_returns_none() {
+    // BUG-303: same rule for percentile_ranks — a null rank must surface as
+    // None so pipeline aggs skip the bucket rather than average in a zero.
+    let mut aggs = BTreeMap::new();
+    let mut rank_values = BTreeMap::new();
+    rank_values.insert("42".to_string(), None);
+    aggs.insert(
+      "rank_agg".to_string(),
+      AggregationResponse::PercentileRanks(PercentileRanksResponse {
+        values: rank_values,
+      }),
+    );
+    let bucket = BucketResponse {
+      key: serde_json::json!(0),
+      doc_count: 3,
+      aggregations: aggs,
+    };
+
+    assert_eq!(bucket_metric_value(&bucket, "rank_agg.42"), None);
+  }
+
+  #[test]
+  fn avg_bucket_pipeline_skips_empty_percentile_buckets() {
+    // BUG-303 end-to-end: verify that a bucket whose percentiles sub-agg had
+    // no data (values: {"50": null}) is excluded from avg_bucket's divisor,
+    // producing `(75 + 12) / 2 = 43.5` instead of `(75 + 0 + 12) / 3 = 29`.
+    use crate::api::types::BucketMetricAggregation;
+
+    let make_bucket = |key: i64, p50: Option<f64>| -> BucketResponse {
+      let mut values = BTreeMap::new();
+      values.insert("50".to_string(), p50);
+      BucketResponse {
+        key: serde_json::json!(key),
+        doc_count: 1,
+        aggregations: BTreeMap::from([(
+          "price_pctiles".to_string(),
+          AggregationResponse::Percentiles(PercentilesResponse { values }),
+        )]),
+      }
+    };
+    let mut buckets = vec![
+      make_bucket(0, Some(75.0)),
+      make_bucket(1, None), // clothing: no docs with price — null, not 0.0
+      make_bucket(2, Some(12.0)),
+    ];
+
+    let mut pipeline = BTreeMap::new();
+    pipeline.insert(
+      "avg_median_price".to_string(),
+      Aggregation::AvgBucket(BucketMetricAggregation {
+        buckets_path: "price_pctiles.50".to_string(),
+      }),
+    );
+
+    let responses = apply_pipeline_aggs(&pipeline, &mut buckets);
+    match responses.get("avg_median_price") {
+      Some(AggregationResponse::AvgBucket(val)) => {
+        let got = val.value.expect("avg_bucket produced a value");
+        assert!(
+          (got - 43.5).abs() < 1e-9,
+          "avg_bucket must skip null percentile entries — got {got}, expected 43.5"
+        );
+      }
+      other => panic!("expected AvgBucket response, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn sum_bucket_pipeline_skips_empty_percentile_buckets() {
+    // BUG-303: sum_bucket must also treat null percentile entries as missing
+    // rather than folding a spurious 0.0 into the running total.
+    use crate::api::types::BucketMetricAggregation;
+
+    let make_bucket = |key: i64, p50: Option<f64>| -> BucketResponse {
+      let mut values = BTreeMap::new();
+      values.insert("50".to_string(), p50);
+      BucketResponse {
+        key: serde_json::json!(key),
+        doc_count: 1,
+        aggregations: BTreeMap::from([(
+          "price_pctiles".to_string(),
+          AggregationResponse::Percentiles(PercentilesResponse { values }),
+        )]),
+      }
+    };
+    let mut buckets = vec![make_bucket(0, Some(75.0)), make_bucket(1, None)];
+
+    let mut pipeline = BTreeMap::new();
+    pipeline.insert(
+      "total_median_price".to_string(),
+      Aggregation::SumBucket(BucketMetricAggregation {
+        buckets_path: "price_pctiles.50".to_string(),
+      }),
+    );
+
+    let responses = apply_pipeline_aggs(&pipeline, &mut buckets);
+    match responses.get("total_median_price") {
+      Some(AggregationResponse::SumBucket(val)) => {
+        assert_eq!(val.value, Some(75.0));
+      }
+      other => panic!("expected SumBucket response, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn percentiles_response_serializes_null_for_empty_buckets() {
+    // BUG-303: the JSON shape must match Elasticsearch — missing values are
+    // serialized as `null`, not as `0.0`. Pipeline aggs and external clients
+    // can then distinguish "no data" from "data that happens to be zero".
+    let mut values = BTreeMap::new();
+    values.insert("50".to_string(), None);
+    values.insert("99".to_string(), Some(12.5));
+    let resp = AggregationResponse::Percentiles(PercentilesResponse { values });
+    let json = serde_json::to_value(&resp).unwrap();
+    let map = json.get("values").and_then(|v| v.as_object()).unwrap();
+    assert!(map.get("50").unwrap().is_null());
+    assert_eq!(map.get("99").unwrap().as_f64().unwrap(), 12.5);
   }
 
   #[test]
@@ -5771,11 +5934,11 @@ mod tests {
   #[test]
   fn moving_avg_pipeline_with_decimal_percentile_path() {
     let mut pct_values = BTreeMap::new();
-    pct_values.insert("99.9".to_string(), 10.0);
+    pct_values.insert("99.9".to_string(), Some(10.0));
     let mut pct_values2 = BTreeMap::new();
-    pct_values2.insert("99.9".to_string(), 20.0);
+    pct_values2.insert("99.9".to_string(), Some(20.0));
     let mut pct_values3 = BTreeMap::new();
-    pct_values3.insert("99.9".to_string(), 30.0);
+    pct_values3.insert("99.9".to_string(), Some(30.0));
 
     let mut buckets = vec![
       BucketResponse {

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -5884,6 +5884,20 @@ mod tests {
   }
 
   #[test]
+  fn percentile_ranks_response_serializes_null_for_empty_buckets() {
+    // BUG-303: sibling coverage for PercentileRanks — the widened
+    // `Option<f64>` map must also serialize `None` entries as JSON `null`.
+    let mut values = BTreeMap::new();
+    values.insert("42".to_string(), None);
+    values.insert("100".to_string(), Some(87.5));
+    let resp = AggregationResponse::PercentileRanks(PercentileRanksResponse { values });
+    let json = serde_json::to_value(&resp).unwrap();
+    let map = json.get("values").and_then(|v| v.as_object()).unwrap();
+    assert!(map.get("42").unwrap().is_null());
+    assert_eq!(map.get("100").unwrap().as_f64().unwrap(), 87.5);
+  }
+
+  #[test]
   fn bucket_metric_value_stats_subfield_still_works() {
     let mut aggs = BTreeMap::new();
     aggs.insert(

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -3106,17 +3106,18 @@ fn cardinality_and_percentiles_metrics() {
   if let searchlite_core::api::types::AggregationResponse::Percentiles(p) =
     resp.aggregations.get("pct").unwrap()
   {
-    assert_eq!(p.values.get("50").copied().unwrap() as i64, 25);
+    let p50 = p.values.get("50").copied().flatten().unwrap();
+    assert_eq!(p50 as i64, 25);
   } else {
     panic!("expected percentiles agg");
   }
   if let searchlite_core::api::types::AggregationResponse::PercentileRanks(p) =
     resp.aggregations.get("pct_ranks").unwrap()
   {
-    let v20 = p.values.get("20").unwrap();
-    let v35 = p.values.get("35").unwrap();
-    assert!(*v20 > 0.0);
-    assert!(*v35 > *v20);
+    let v20 = p.values.get("20").copied().flatten().unwrap();
+    let v35 = p.values.get("35").copied().flatten().unwrap();
+    assert!(v20 > 0.0);
+    assert!(v35 > v20);
   } else {
     panic!("expected percentile ranks agg");
   }
@@ -3222,7 +3223,7 @@ fn percentile_ranks_tdigest_path_includes_observed_minimum() {
   if let searchlite_core::api::types::AggregationResponse::PercentileRanks(p) =
     resp.aggregations.get("pct_ranks").unwrap()
   {
-    let rank = *p.values.get("0").unwrap();
+    let rank = p.values.get("0").copied().flatten().unwrap();
     // The regression being guarded against is that the TDigest path
     // short-circuits to 0.0 when the target equals the observed minimum. A
     // strict `> 0.0` check is enough to catch that without being brittle to
@@ -3329,7 +3330,7 @@ fn percentile_ranks_tdigest_path_all_values_equal_target() {
   if let searchlite_core::api::types::AggregationResponse::PercentileRanks(p) =
     resp.aggregations.get("pct_ranks").unwrap()
   {
-    let rank = *p.values.get("42").unwrap();
+    let rank = p.values.get("42").copied().flatten().unwrap();
     assert!(
       (rank - 100.0).abs() < f64::EPSILON,
       "percentile_rank(target) where every value equals target must be 100.0, got {rank}"


### PR DESCRIPTION
## Summary

Fixes #303. `percentiles` / `percentile_ranks` sub-aggregations that observed no values (`count == 0`) previously returned a concrete `0.0` for every level. That value flowed into `PercentilesResponse.values` / `PercentileRanksResponse.values` as an `f64`, making empty buckets indistinguishable from genuine zeros — and pipeline aggregations (`avg_bucket`, `sum_bucket`, `derivative`, `moving_avg`, `bucket_script`) folded the spurious `0.0` into their running totals, producing incorrect results (e.g. `(75 + 0 + 12) / 3 = 29` instead of `(75 + 12) / 2 = 43.5`).

### Changes
- `QuantileState::percentile` / `percentile_rank` now return `Option<f64>`, yielding `None` when `count == 0`.
- `PercentilesResponse.values` / `PercentileRanksResponse.values` widened to `BTreeMap<String, Option<f64>>`. `None` serializes as JSON `null`, matching Elasticsearch.
- `extract_metric_from_response` flattens `Option<Option<f64>>` → `Option<f64>` so pipeline aggregations skip null entries per the gap-policy contract.
- Existing call sites updated to unwrap through `Option`.

### Tests
- `quantile_state_empty_percentile_returns_none` — unit test for the state methods.
- `bucket_metric_value_percentiles_null_entry_returns_none` / `…_percentile_ranks_…` — path lookup skips null entries.
- `avg_bucket_pipeline_skips_empty_percentile_buckets` — end-to-end reproduction of the issue's `43.5` expectation.
- `sum_bucket_pipeline_skips_empty_percentile_buckets` — sibling coverage for sum.
- `percentiles_response_serializes_null_for_empty_buckets` — JSON shape matches Elasticsearch (`{"50": null}`).

## Test plan

- [x] `cargo test -p searchlite-core --lib aggs::` — 81 passed
- [x] `cargo test -p searchlite-core --test aggregations` — 46 passed
- [x] `cargo test --workspace` — all suites green
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`