### PR TITLE
fix(aggs): accept leading `+` sign in parse_interval_seconds (BUG-305)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4220,14 +4220,20 @@ pub(crate) fn parse_date(value: &str) -> Option<f64> {
 }
 
 pub(crate) fn parse_interval_seconds(spec: &str) -> Option<f64> {
-  // Accept an optional leading `-` so negative durations such as "-6h"
-  // parse correctly. Callers that only permit positive durations
+  // Accept an optional leading sign so negative durations such as "-6h"
+  // and explicitly-positive durations such as "+6h" parse correctly.
+  // Elasticsearch time-unit parsing accepts both `+` and `-` prefixes,
+  // so users migrating from Elasticsearch or following its documentation
+  // expect both. Callers that only permit positive durations
   // (e.g. `fixed_interval`) are responsible for rejecting negatives
   // via their own `secs > 0.0` guard; callers that accept negatives
   // (date_histogram `offset`) rely on this path.
-  let (negative, rest) = match spec.strip_prefix('-') {
-    Some(tail) => (true, tail),
-    None => (false, spec),
+  let (negative, rest) = if let Some(tail) = spec.strip_prefix('-') {
+    (true, tail)
+  } else if let Some(tail) = spec.strip_prefix('+') {
+    (false, tail)
+  } else {
+    (false, spec)
   };
   let mut idx = 0usize;
   for ch in rest.chars() {
@@ -4455,6 +4461,31 @@ mod tests {
     assert_eq!(parse_interval_seconds("--5h"), None);
     assert_eq!(parse_interval_seconds("-5x"), None);
     assert_eq!(parse_interval_seconds("-foo"), None);
+  }
+
+  #[test]
+  fn parse_interval_seconds_accepts_explicit_positive_sign() {
+    // Elasticsearch time-unit parsing accepts a leading `+` as a
+    // synonym for an unsigned positive duration. date_histogram
+    // `offset: "+6h"` must parse identically to `"6h"`.
+    assert_eq!(parse_interval_seconds("+6h"), Some(21_600.0));
+    assert_eq!(parse_interval_seconds("+30m"), Some(1_800.0));
+    assert_eq!(parse_interval_seconds("+1500ms"), Some(1.5));
+    assert_eq!(parse_interval_seconds("+2.5m"), Some(150.0));
+    assert_eq!(parse_interval_seconds("+1"), Some(1.0));
+    assert_eq!(parse_interval_seconds("+1s"), Some(1.0));
+  }
+
+  #[test]
+  fn parse_interval_seconds_rejects_malformed_positives() {
+    // A lone `+`, stacked signs, or a sign followed by an unknown
+    // unit must still fail — mirroring the negative malformed cases.
+    assert_eq!(parse_interval_seconds("+"), None);
+    assert_eq!(parse_interval_seconds("++5h"), None);
+    assert_eq!(parse_interval_seconds("+-5h"), None);
+    assert_eq!(parse_interval_seconds("-+5h"), None);
+    assert_eq!(parse_interval_seconds("+5x"), None);
+    assert_eq!(parse_interval_seconds("+foo"), None);
   }
 
   #[test]

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -1813,6 +1813,73 @@ mod bug_030 {
     }
   }
 
+  /// Regression test for BUG-305 — the BUG-295 fix added a strip for a
+  /// leading `-` but did not add the parallel `+` arm, so explicitly
+  /// positive offsets such as `"+6h"` still returned HTTP 400
+  /// `offset is invalid`. Elasticsearch accepts both signs, so users
+  /// following its docs or migrating queries hit the regression.
+  ///
+  /// With `interval = 1d` and `offset = +6h`, bucket boundaries fall at
+  /// `..., 6h, 30h, 54h, ...`. A `+6h` offset is semantically identical
+  /// to `6h` (no prefix), so the bucket layout must match the unsigned
+  /// variant.
+  #[test]
+  fn fixed_interval_accepts_explicit_positive_offset() {
+    const HOUR_MS: i64 = 3_600_000;
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = timestamp_index(tmp.path());
+    {
+      let mut writer = idx.writer().unwrap();
+      for (id, ts) in [
+        // 03:00 day 1 -> bucket key -18h (offset +6h places boundaries at
+        // ..., -18h, 6h, 30h, ...; 3h lives in the [-18h, 6h) bucket).
+        ("pre-offset", 3 * HOUR_MS),
+        // 07:00 day 1 -> bucket key 6h (inside [6h, 30h)).
+        ("post-offset", 7 * HOUR_MS),
+        // 23:59 day 1 -> bucket key 6h (still inside [6h, 30h)).
+        ("late-d1", DAY_MS - 60_000),
+      ] {
+        writer
+          .add_document(&doc(id, vec![("body", json!("rust")), ("ts", json!(ts))]))
+          .unwrap();
+      }
+      writer.commit().unwrap();
+    }
+
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: None,
+        fixed_interval: Some("1d".into()),
+        offset: Some("+6h".into()),
+        format: None,
+        min_doc_count: Some(1),
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+
+    let agg = run_date_histogram(&idx, aggs);
+    if let searchlite_core::api::types::AggregationResponse::DateHistogram { buckets, .. } = agg {
+      let observed: Vec<(serde_json::Value, u64)> = buckets
+        .iter()
+        .map(|b| (b.key.clone(), b.doc_count))
+        .collect();
+      assert_eq!(
+        observed,
+        vec![(json!(-18 * HOUR_MS), 1), (json!(6 * HOUR_MS), 2),],
+        "offset=+6h must parse identically to 6h and shift boundaries forward six hours"
+      );
+    } else {
+      panic!("expected date histogram response");
+    }
+  }
+
   /// `extended_bounds` drives empty-bucket fill via `bucket_start`. With the
   /// previous `.ceil()` implementation, the bounds themselves were rounded
   /// up, so fills spilled into the bucket *beyond* `max`. With `.floor()`


### PR DESCRIPTION
## Summary

Fixes #305. `parse_interval_seconds` accepted a leading `-` (added in BUG-295) but had no parallel `+` arm, so explicit-positive duration specs such as `"+6h"` or `"+30m"` fell through to the default branch and returned `None`. That surfaced as `date_histogram 'by_day' offset '+6h' is invalid` for requests that mirror Elasticsearch's accepted syntax (ES accepts both `+` and `-` prefixes on time-unit specs).

The fix adds a second `strip_prefix('+')` branch alongside the existing `-` arm. `+` is treated as a no-op sign — numeric scan and unit lookup are unchanged, so malformed specs (`"+"`, `"++5h"`, `"+-5h"`, `"-+5h"`, `"+5x"`) continue to return `None`.

## Changes

- `searchlite-core/src/query/aggs/mod.rs` — extend the leading-sign match with an explicit `+` arm; updated the adjacent doc comment to reflect that both signs are now accepted.
- `searchlite-core/src/query/aggs/mod.rs` (tests) — add `parse_interval_seconds_accepts_explicit_positive_sign` and `parse_interval_seconds_rejects_malformed_positives`, mirroring the BUG-295 coverage.
- `searchlite-core/tests/aggregation_bounds.rs` — add `fixed_interval_accepts_explicit_positive_offset` regression in `bug_030`, parallel to the existing `fixed_interval_accepts_negative_offset`, exercising the full request path (`offset: "+6h"` with `fixed_interval: 1d`).

## Test plan

- [x] `cargo test -p searchlite-core --lib parse_interval_seconds` — all six unit tests pass (including existing negative/malformed coverage).
- [x] `cargo test -p searchlite-core --test aggregation_bounds fixed_interval_accepts` — both negative (BUG-295) and positive (BUG-305) integration regressions pass.
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.