### PR TITLE
fix(score): field_value_factor Log* modifiers use log10 not natural log (BUG-307)

### DIFF
--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -198,21 +198,21 @@ fn apply_modifier(value: f64, modifier: &FieldValueModifier) -> f64 {
       if value <= 0.0 {
         0.0
       } else {
-        value.ln()
+        value.log10()
       }
     }
     FieldValueModifier::Log1p => {
       if value <= -1.0 {
         0.0
       } else {
-        value.ln_1p()
+        (1.0 + value).log10()
       }
     }
     FieldValueModifier::Log2p => {
       if value <= -2.0 {
         0.0
       } else {
-        (value + 2.0).ln()
+        (value + 2.0).log10()
       }
     }
     FieldValueModifier::Sqrt => {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -363,7 +363,7 @@ fn rank_feature_uses_numeric_fast_field() {
 }
 
 #[test]
-fn log2p_modifier_uses_natural_log_of_value_plus_two() {
+fn log2p_modifier_uses_log10_of_value_plus_two() {
   let reader = setup_reader();
   let req = base_request(QueryNode::FunctionScore {
     query: Box::new(QueryNode::MatchAll { boost: None }),
@@ -382,21 +382,101 @@ fn log2p_modifier_uses_natural_log_of_value_plus_two() {
   });
   let resp = reader.search(&req).unwrap();
   // popularity: doc-1=10, doc-3=5, doc-2=1
-  // Log2p = ln(value + 2): ln(12) ≈ 2.485, ln(7) ≈ 1.946, ln(3) ≈ 1.099
+  // Log2p = log10(value + 2): log10(12) ≈ 1.079, log10(7) ≈ 0.845, log10(3) ≈ 0.477
   assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
   let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
   assert!(
-    (scores[0] - 12_f32.ln()).abs() < 1e-6,
+    (scores[0] - 12_f32.log10()).abs() < 1e-6,
     "doc-1: {}",
     scores[0]
   );
   assert!(
-    (scores[1] - 7_f32.ln()).abs() < 1e-6,
+    (scores[1] - 7_f32.log10()).abs() < 1e-6,
     "doc-3: {}",
     scores[1]
   );
   assert!(
-    (scores[2] - 3_f32.ln()).abs() < 1e-6,
+    (scores[2] - 3_f32.log10()).abs() < 1e-6,
+    "doc-2: {}",
+    scores[2]
+  );
+}
+
+#[test]
+fn log_modifier_uses_log10_of_value() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::Log),
+      missing: None,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  // popularity: doc-1=10, doc-3=5, doc-2=1
+  // Log = log10(value): log10(10) = 1.0, log10(5) ≈ 0.699, log10(1) = 0.0
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert!(
+    (scores[0] - 10_f32.log10()).abs() < 1e-6,
+    "doc-1: {}",
+    scores[0]
+  );
+  assert!(
+    (scores[1] - 5_f32.log10()).abs() < 1e-6,
+    "doc-3: {}",
+    scores[1]
+  );
+  assert!(
+    (scores[2] - 1_f32.log10()).abs() < 1e-6,
+    "doc-2: {}",
+    scores[2]
+  );
+}
+
+#[test]
+fn log1p_modifier_uses_log10_of_one_plus_value() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::Log1p),
+      missing: None,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  // popularity: doc-1=10, doc-3=5, doc-2=1
+  // Log1p = log10(1 + value): log10(11) ≈ 1.041, log10(6) ≈ 0.778, log10(2) ≈ 0.301
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert!(
+    (scores[0] - 11_f32.log10()).abs() < 1e-6,
+    "doc-1: {}",
+    scores[0]
+  );
+  assert!(
+    (scores[1] - 6_f32.log10()).abs() < 1e-6,
+    "doc-3: {}",
+    scores[1]
+  );
+  assert!(
+    (scores[2] - 2_f32.log10()).abs() < 1e-6,
     "doc-2: {}",
     scores[2]
   );


### PR DESCRIPTION
## Summary

Fixes #307. Elasticsearch's `field_value_factor` `log`, `log1p`, and `log2p` modifiers are all defined as **base-10** logarithms (`Math.log10`), but searchlite's `FieldValueModifier::Log`, `Log1p`, and `Log2p` were computing **natural log**. This inflates absolute scores by a factor of `ln(10) ≈ 2.303`, which matters whenever the score isn't used in isolation:

- `min_score` filtering
- `boost_mode: sum` (additive combination with the query score)
- combination with other scoring functions

Relative ordering within a pure `field_value_factor` query is preserved (the factor is constant), so this was easy to miss, but scores at the API surface are still wrong.

### Change

`searchlite-core/src/query/score_functions.rs` — swap `.ln()` / `.ln_1p()` / `(value + 2.0).ln()` for the base-10 equivalents in the three `Log*` arms of `apply_modifier`:

| Modifier | Before | After |
|----------|--------|-------|
| `Log`    | `value.ln()`            | `value.log10()`           |
| `Log1p`  | `value.ln_1p()`         | `(1.0 + value).log10()`   |
| `Log2p`  | `(value + 2.0).ln()`    | `(value + 2.0).log10()`   |

This matches the Elasticsearch `FieldValueFactorFunction.Modifier` semantics for the `log`, `log1p`, `log2p` names.

### Scope

- `FieldValueModifier` only. `RankFeatureModifier::Log` / `Log1p` in `searchlite-core/src/api/scoring.rs` are unchanged — they drive a different query (`rank_feature`) with its own semantics and are out of scope for this bug.
- Adding `Ln` / `Ln1p` / `Ln2p` variants for natural-log parity is called out in the issue as a separate feature addition and is not included here.

## Test plan

- [x] Updated `log2p_modifier_uses_natural_log_of_value_plus_two` → `log2p_modifier_uses_log10_of_value_plus_two` with `log10` expectations.
- [x] Added `log_modifier_uses_log10_of_value` regression test.
- [x] Added `log1p_modifier_uses_log10_of_one_plus_value` regression test.
- [x] `cargo test -p searchlite-core` — 465+ tests pass, no regressions.
- [x] `cargo clippy -p searchlite-core --all-targets` — clean.