### PR TITLE
fix(score): handle unary `+` in script_score tokenizer (BUG-309)

### DIFF
--- a/searchlite-core/src/query/script.rs
+++ b/searchlite-core/src/query/script.rs
@@ -276,9 +276,26 @@ fn tokenize(input: &str) -> Result<Vec<Token>> {
         expect_operand = false;
       }
       '+' => {
-        tokens.push(Token::Op(Op::Add));
         chars.next();
-        expect_operand = true;
+        if expect_operand {
+          // Unary plus is a no-op. If followed by a digit or `.`, parse
+          // it as a positive number literal; otherwise skip the `+` and
+          // let the next iteration handle the operand. `expect_operand`
+          // stays true so the subsequent token is still parsed as an
+          // operand.
+          if let Some(next) = chars.peek() {
+            if next.is_ascii_digit() || *next == '.' {
+              let first = chars.next().unwrap();
+              let value = read_number_literal(first, &mut chars)?;
+              tokens.push(Token::Number(value));
+              expect_operand = false;
+              continue;
+            }
+          }
+        } else {
+          tokens.push(Token::Op(Op::Add));
+          expect_operand = true;
+        }
       }
       '-' => {
         chars.next();

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -418,8 +418,9 @@ fn script_score_evaluates_expression_with_score_and_field() {
 }
 
 // Regression: unary `+` in operand position was emitted as binary `Add`,
-// which underflowed the RPN stack and silently produced a zero score.
-// See BUG-309.
+// which underflowed the RPN stack. `CompiledScript::evaluate()` returned
+// `None`, so the script_score function contributed no score and the hit
+// was effectively dropped from the result set. See BUG-309.
 #[test]
 fn script_score_accepts_unary_plus_on_number_literal() {
   let reader = setup_reader();

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -417,6 +417,63 @@ fn script_score_evaluates_expression_with_score_and_field() {
   assert!(scores[0] > scores[1] && scores[1] > scores[2]);
 }
 
+// Regression: unary `+` in operand position was emitted as binary `Add`,
+// which underflowed the RPN stack and silently produced a zero score.
+// See BUG-309.
+#[test]
+fn script_score_accepts_unary_plus_on_number_literal() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script: "+1 + +popularity".into(),
+    params: None,
+    boost: Some(1.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  // Expected: 1 + popularity → doc-1=11, doc-3=6, doc-2=2
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert!((scores[0] - 11.0).abs() < 1e-6, "doc-1: {}", scores[0]);
+  assert!((scores[1] - 6.0).abs() < 1e-6, "doc-3: {}", scores[1]);
+  assert!((scores[2] - 2.0).abs() < 1e-6, "doc-2: {}", scores[2]);
+}
+
+#[test]
+fn script_score_accepts_unary_plus_in_parenthesized_group() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script: "(-popularity) + (+popularity) + 100".into(),
+    params: None,
+    boost: Some(1.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  // (-pop) + (+pop) + 100 = 100 for every doc
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert_eq!(scores.len(), 3);
+  for s in &scores {
+    assert!((s - 100.0).abs() < 1e-6, "expected 100.0, got {s}");
+  }
+}
+
+#[test]
+fn script_score_accepts_binary_plus_after_unary_plus() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script: "1 + +2".into(),
+    params: None,
+    boost: Some(1.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  // 1 + (+2) = 3 for every doc
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert_eq!(scores.len(), 3);
+  for s in &scores {
+    assert!((s - 3.0).abs() < 1e-6, "expected 3.0, got {s}");
+  }
+}
+
 #[test]
 fn rescore_multiply_zeros_non_matching_docs() {
   let reader = setup_reader();


### PR DESCRIPTION
## Summary

Fixes BUG-309. The `+` arm in the `script_score` tokenizer (`searchlite-core/src/query/script.rs:278`) unconditionally emitted `Op(Add)` without consulting `expect_operand`. Whenever `+` appeared in operand position — at the start of an expression, after another operator, or after `(` — it produced a spurious binary `Add` that underflowed the RPN stack. The evaluator silently returned `None`, so the `script_score` function contributed no score to the document.

The `-` arm (`script.rs:283-300`) already handled this correctly by branching on `expect_operand` to distinguish unary `Neg` / negative-literal cases from binary `Sub`. This change mirrors that structure for `+`:

- When `expect_operand` is true and the next character is a digit or `.`, parse a positive number literal directly.
- When `expect_operand` is true otherwise, consume the `+` as a no-op and let the next iteration handle the operand.
- When `expect_operand` is false, emit `Op(Add)` as before.

## Test plan

- [x] New regression tests in `searchlite-core/tests/function_score.rs`:
  - `script_score_accepts_unary_plus_on_number_literal` — `+1 + +popularity`
  - `script_score_accepts_unary_plus_in_parenthesized_group` — `(-popularity) + (+popularity) + 100`
  - `script_score_accepts_binary_plus_after_unary_plus` — `1 + +2`
- [x] `cargo test -p searchlite-core` — all 412+ tests pass
- [x] `cargo clippy -p searchlite-core --tests --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #309