### PR TITLE
fix(score): rank_feature Log/Log1p modifiers use log10 not natural log (BUG-311)

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -52,14 +52,14 @@ pub(crate) fn apply_rank_modifier(value: f64, modifier: &RankFeatureModifier) ->
       if value <= 0.0 {
         0.0
       } else {
-        value.ln()
+        value.log10()
       }
     }
     RankFeatureModifier::Log1p => {
       if value <= -1.0 {
         0.0
       } else {
-        value.ln_1p()
+        (1.0 + value).log10()
       }
     }
     RankFeatureModifier::Sqrt => {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -363,6 +363,68 @@ fn rank_feature_uses_numeric_fast_field() {
 }
 
 #[test]
+fn rank_feature_log_modifier_uses_log10_of_value() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::RankFeature {
+    field: "popularity".into(),
+    boost: Some(1.0),
+    modifier: Some(RankFeatureModifier::Log),
+    missing: Some(0.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  // popularity: doc-1=10, doc-3=5, doc-2=1
+  // Log = log10(value): log10(10) = 1.0, log10(5) ≈ 0.699, log10(1) = 0.0
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert!(
+    (scores[0] - 10_f32.log10()).abs() < 1e-6,
+    "doc-1: {}",
+    scores[0]
+  );
+  assert!(
+    (scores[1] - 5_f32.log10()).abs() < 1e-6,
+    "doc-3: {}",
+    scores[1]
+  );
+  assert!(
+    (scores[2] - 1_f32.log10()).abs() < 1e-6,
+    "doc-2: {}",
+    scores[2]
+  );
+}
+
+#[test]
+fn rank_feature_log1p_modifier_uses_log10_of_one_plus_value() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::RankFeature {
+    field: "popularity".into(),
+    boost: Some(1.0),
+    modifier: Some(RankFeatureModifier::Log1p),
+    missing: Some(0.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  // popularity: doc-1=10, doc-3=5, doc-2=1
+  // Log1p = log10(1 + value): log10(11) ≈ 1.041, log10(6) ≈ 0.778, log10(2) ≈ 0.301
+  assert_eq!(ids(&resp), vec!["doc-1", "doc-3", "doc-2"]);
+  let scores: Vec<f32> = resp.hits.iter().map(|h| h.score).collect();
+  assert!(
+    (scores[0] - 11_f32.log10()).abs() < 1e-6,
+    "doc-1: {}",
+    scores[0]
+  );
+  assert!(
+    (scores[1] - 6_f32.log10()).abs() < 1e-6,
+    "doc-3: {}",
+    scores[1]
+  );
+  assert!(
+    (scores[2] - 2_f32.log10()).abs() < 1e-6,
+    "doc-2: {}",
+    scores[2]
+  );
+}
+
+#[test]
 fn log2p_modifier_uses_log10_of_value_plus_two() {
   let reader = setup_reader();
   let req = base_request(QueryNode::FunctionScore {


### PR DESCRIPTION
## Summary

- `RankFeatureModifier::Log` and `Log1p` in `searchlite-core/src/api/scoring.rs` were computing `value.ln()` / `value.ln_1p()` (natural logarithm), diverging from `field_value_factor`'s `FieldValueModifier` path which was corrected to `log10` in BUG-307 (#308).
- This fix updates the two arms to `value.log10()` and `(1.0 + value).log10()`, restoring behavioural parity between `rank_feature` and `field_value_factor` for identically-named modifiers.
- Added two regression tests under `searchlite-core/tests/function_score.rs` that mirror the BUG-307 tests, asserting `log10`-based scores for the `Log` and `Log1p` modifiers on `rank_feature`.

## Impact

Users applying a shared `Log` / `Log1p` modifier across both query types were receiving scores roughly `ln(10) ≈ 2.3×` larger from `rank_feature`, distorting combined score signals when scores from the two paths are blended. `Sqrt` and `Reciprocal` were already consistent — only `Log` / `Log1p` diverged.

Closes #311

## Test plan

- [x] `cargo test -p searchlite-core --test function_score rank_feature` — 3 tests pass
- [x] `cargo test -p searchlite-core --test function_score` — full file (24 tests) pass
- [ ] CI green