### PR TITLE
fix(query): enforce max_expansions globally across segments (BUG-316)

### DIFF
--- a/searchlite-core/src/api/term_expansion.rs
+++ b/searchlite-core/src/api/term_expansion.rs
@@ -369,11 +369,11 @@ fn expand_prefix(
   let mut qualified = Vec::new();
   let mut keys = Vec::new();
   let mut seen = HashSet::new();
-  for seg in segments.iter() {
-    let mut expanded = 0usize;
+  let mut expanded = 0usize;
+  'segments: for seg in segments.iter() {
     for key in seg.terms_with_prefix(&prefix_key) {
       if expanded >= max_expansions {
-        break;
+        break 'segments;
       }
       if key.len() <= field_prefix_len {
         continue;
@@ -442,11 +442,11 @@ fn expand_wildcard(
   let mut qualified = Vec::new();
   let mut keys = Vec::new();
   let mut seen = HashSet::new();
-  for seg in segments.iter() {
-    let mut expanded = 0usize;
+  let mut expanded = 0usize;
+  'segments: for seg in segments.iter() {
     for key in seg.terms_with_prefix(&prefix_key) {
       if expanded >= max_expansions {
-        break;
+        break 'segments;
       }
       if key.len() <= field_prefix_len {
         continue;
@@ -796,11 +796,11 @@ fn expand_regex(
   let mut qualified = Vec::new();
   let mut keys = Vec::new();
   let mut seen = HashSet::new();
-  for seg in segments.iter() {
-    let mut expanded = 0usize;
+  let mut expanded = 0usize;
+  'segments: for seg in segments.iter() {
     for key in seg.terms_with_prefix(&prefix_key) {
       if expanded >= max_expansions {
-        break;
+        break 'segments;
       }
       if key.len() <= field_prefix_len {
         continue;

--- a/searchlite-core/tests/regressions.rs
+++ b/searchlite-core/tests/regressions.rs
@@ -561,3 +561,108 @@ fn wildcard_query_matches_non_ascii_uppercase_with_default_tokenizer() {
     .collect();
   assert_eq!(match_ids, vec!["resume_doc".to_string()]);
 }
+
+/// Regression test for davidkelley/searchlite#316.
+///
+/// `expand_prefix`, `expand_wildcard`, and `expand_regex` previously reset
+/// their `expanded` counter at the top of each segment loop, applying
+/// `max_expansions` per-segment rather than as a global cap. On a multi-
+/// segment index with disjoint terms per segment, the total number of
+/// expanded terms could grow to `num_segments * max_expansions` — up to
+/// `(num_segments - 1) * max_expansions` over the caller-requested limit.
+///
+/// The fix moves the counter outside the segment loop and uses a labeled
+/// break, matching the pattern already in `expand_term_fuzzy`. This test
+/// builds a 3-segment index where each segment contains unique
+/// prefix-matching terms, runs each of the three expansion paths with
+/// `max_expansions = 2`, and asserts the total distinct matched terms
+/// never exceeds the requested limit.
+#[test]
+fn term_expansion_max_expansions_is_global_across_segments() {
+  let dir = tempdir().unwrap();
+  let path = dir.path().to_path_buf();
+  let idx = Index::create(&path, Schema::default_text_body(), opts(&path)).unwrap();
+  // Three segments, each holding disjoint terms that all match the prefix
+  // `ap`, wildcard `ap*`, and regex `^ap.*`. Committing between batches
+  // flushes a new segment per batch.
+  let segments: [&[(&str, &str)]; 3] = [
+    &[("s0a", "app"), ("s0b", "apple")],
+    &[("s1a", "apply"), ("s1b", "apt")],
+    &[("s2a", "apricot"), ("s2b", "apogee")],
+  ];
+  for batch in segments.iter() {
+    let mut writer = idx.writer().unwrap();
+    for (id, body) in batch.iter() {
+      writer
+        .add_document(&doc(id, vec![("body", json!(body))]))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+  let reader = idx.reader().unwrap();
+
+  // Helper to count distinct matched terms via the document id → term
+  // mapping we seeded above.
+  let max_expansions = 2usize;
+  let assert_global_cap = |hits: Vec<String>, label: &str| {
+    assert!(
+      hits.len() <= max_expansions,
+      "{label}: expected <= {max_expansions} matched docs (one per expanded term), got {} — {hits:?}",
+      hits.len()
+    );
+  };
+
+  let prefix_req = SearchRequest {
+    query: Query::Node(QueryNode::Prefix {
+      field: "body".into(),
+      value: "ap".into(),
+      max_expansions: Some(max_expansions),
+      boost: None,
+    }),
+    ..base_request("", None)
+  };
+  let prefix_hits: Vec<String> = reader
+    .search(&prefix_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_global_cap(prefix_hits, "prefix");
+
+  let wildcard_req = SearchRequest {
+    query: Query::Node(QueryNode::Wildcard {
+      field: "body".into(),
+      value: "ap*".into(),
+      max_expansions: Some(max_expansions),
+      boost: None,
+    }),
+    ..base_request("", None)
+  };
+  let wildcard_hits: Vec<String> = reader
+    .search(&wildcard_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_global_cap(wildcard_hits, "wildcard");
+
+  let regex_req = SearchRequest {
+    query: Query::Node(QueryNode::Regex {
+      field: "body".into(),
+      value: "ap.*".into(),
+      max_expansions: Some(max_expansions),
+      boost: None,
+    }),
+    ..base_request("", None)
+  };
+  let regex_hits: Vec<String> = reader
+    .search(&regex_req)
+    .unwrap()
+    .hits
+    .into_iter()
+    .map(|h| h.doc_id)
+    .collect();
+  assert_global_cap(regex_hits, "regex");
+}

--- a/searchlite-core/tests/regressions.rs
+++ b/searchlite-core/tests/regressions.rs
@@ -574,17 +574,20 @@ fn wildcard_query_matches_non_ascii_uppercase_with_default_tokenizer() {
 /// The fix moves the counter outside the segment loop and uses a labeled
 /// break, matching the pattern already in `expand_term_fuzzy`. This test
 /// builds a 3-segment index where each segment contains unique
-/// prefix-matching terms, runs each of the three expansion paths with
-/// `max_expansions = 2`, and asserts the total distinct matched terms
-/// never exceeds the requested limit.
+/// prefix-matching terms and each seeded term maps 1:1 to a distinct
+/// document, runs each of the three expansion paths with
+/// `max_expansions = 2`, and asserts the returned hit count never
+/// exceeds the requested limit.
 #[test]
 fn term_expansion_max_expansions_is_global_across_segments() {
   let dir = tempdir().unwrap();
   let path = dir.path().to_path_buf();
   let idx = Index::create(&path, Schema::default_text_body(), opts(&path)).unwrap();
   // Three segments, each holding disjoint terms that all match the prefix
-  // `ap`, wildcard `ap*`, and regex `^ap.*`. Committing between batches
-  // flushes a new segment per batch.
+  // `ap`, wildcard `ap*`, and regex `ap.*` (regex queries are anchored
+  // internally by `anchored_regex`, so no leading `^` is needed; adding
+  // one would also empty the literal-prefix optimisation). Committing
+  // between batches flushes a new segment per batch.
   let segments: [&[(&str, &str)]; 3] = [
     &[("s0a", "app"), ("s0b", "apple")],
     &[("s1a", "apply"), ("s1b", "apt")],
@@ -601,8 +604,8 @@ fn term_expansion_max_expansions_is_global_across_segments() {
   }
   let reader = idx.reader().unwrap();
 
-  // Helper to count distinct matched terms via the document id → term
-  // mapping we seeded above.
+  // Each seeded term occurs in exactly one document, so the number of
+  // returned hits is a direct proxy for the number of expanded terms.
   let max_expansions = 2usize;
   let assert_global_cap = |hits: Vec<String>, label: &str| {
     assert!(


### PR DESCRIPTION
## Summary

Fixes #316.

`expand_prefix`, `expand_wildcard`, and `expand_regex` in `term_expansion.rs` previously declared `let mut expanded = 0usize` **inside** the `for seg in segments.iter()` loop, resetting the counter at the start of every segment. On a multi-segment index with disjoint terms per segment the total number of expanded terms could grow to `num_segments * max_expansions`, up to `(num_segments - 1) * max_expansions` over the caller-requested limit. The `seen` HashSet deduplicates across segments but does not prevent the counter from re-accumulating unique terms.

Concrete repro (per the issue): a 3-segment index with disjoint prefix-matching terms and `max_expansions = 2` could return up to 5 expanded terms instead of the requested 2.

## Fix

Move the `expanded` counter outside the segment loop and use a labeled break, matching the pattern already in `expand_term_fuzzy` (the fuzzy path has always done this correctly). Single-segment indexes remain unaffected; multi-segment behaviour now matches the documented semantics and Elasticsearch's global cap on rewritten terms.

```rust
let mut expanded = 0usize;
'segments: for seg in segments.iter() {
  for key in seg.terms_with_prefix(&prefix_key) {
    if expanded >= max_expansions {
      break 'segments;
    }
    // ...
    expanded += 1;
  }
}
```

Applied to all three functions (`expand_prefix`, `expand_wildcard`, `expand_regex`).

## Test plan

- [x] New regression test `term_expansion_max_expansions_is_global_across_segments` in `searchlite-core/tests/regressions.rs` builds a 3-segment index with disjoint matching terms and asserts that `Prefix`, `Wildcard`, and `Regex` queries with `max_expansions = 2` produce at most 2 matched documents.
- [x] Verified the new test **fails** on the unfixed `expand_prefix` (6 hits returned) and **passes** with the fix (2 hits).
- [x] `cargo test -p searchlite-core` — full suite green.
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings`