### PR TITLE
fix(score): reject non-finite combined scores in function_score (BUG-315)

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -354,20 +354,36 @@ pub(crate) fn evaluate_compiled_score(
       }
       let mut combined =
         if let Some(func_score) = combine_function_scores(&function_values, *score_mode) {
+          // `func_score` can be non-finite if the combine step (Sum,
+          // Multiply, or Avg) overflowed past f32::MAX to infinity, even
+          // when every individual function value was finite. `max_boost`,
+          // when set, caps infinity to a finite value because
+          // `f32::INFINITY.min(finite) == finite`; when absent, we must
+          // reject the doc rather than let infinity leak into the sort
+          // key. Mirrors the RankFeature guards below and script.rs/aggs.
           let capped = match max_boost {
             Some(max) => func_score.min(*max),
             None => func_score,
           };
+          if !capped.is_finite() {
+            return None;
+          }
           apply_boost_mode(effective_base, capped, *boost_mode)
         } else {
           effective_base
         };
+      if !combined.is_finite() {
+        return None;
+      }
       if let Some(min) = min_score {
         if combined < *min {
           return None;
         }
       }
       combined *= *boost;
+      if !combined.is_finite() {
+        return None;
+      }
       if collect_functions {
         out_functions.extend(fn_expls);
       }

--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -115,10 +115,11 @@ pub(crate) fn combine_function_scores(values: &[f32], mode: FunctionScoreMode) -
     FunctionScoreMode::Min => values.iter().copied().reduce(|a, b| a.min(b)).unwrap(),
     FunctionScoreMode::Avg => values.iter().copied().sum::<f32>() / values.len() as f32,
   };
-  // Non-finite values (Sum/Multiply/Avg overflow past f32::MAX to infinity)
-  // must not leak into the sort key. Callers that care about distinguishing
-  // "overflow" from "no function values" must check `values.is_empty()` or
-  // the finitude of individual values themselves.
+  // `None` means "no function values"; `Some(result)` is the combined value
+  // and may be non-finite when Sum/Multiply/Avg overflow past f32::MAX to
+  // infinity. Callers are responsible for rejecting non-finite results; we
+  // preserve the overflow here so `max_boost` can still cap infinity to a
+  // finite value (`f32::INFINITY.min(max) == max`) before rejection.
   Some(result)
 }
 

--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -108,13 +108,18 @@ pub(crate) fn combine_function_scores(values: &[f32], mode: FunctionScoreMode) -
   if values.is_empty() {
     return None;
   }
-  match mode {
-    FunctionScoreMode::Sum => Some(values.iter().copied().sum()),
-    FunctionScoreMode::Multiply => Some(values.iter().copied().product()),
-    FunctionScoreMode::Max => Some(values.iter().copied().reduce(|a, b| a.max(b)).unwrap()),
-    FunctionScoreMode::Min => Some(values.iter().copied().reduce(|a, b| a.min(b)).unwrap()),
-    FunctionScoreMode::Avg => Some(values.iter().copied().sum::<f32>() / values.len() as f32),
-  }
+  let result = match mode {
+    FunctionScoreMode::Sum => values.iter().copied().sum(),
+    FunctionScoreMode::Multiply => values.iter().copied().product(),
+    FunctionScoreMode::Max => values.iter().copied().reduce(|a, b| a.max(b)).unwrap(),
+    FunctionScoreMode::Min => values.iter().copied().reduce(|a, b| a.min(b)).unwrap(),
+    FunctionScoreMode::Avg => values.iter().copied().sum::<f32>() / values.len() as f32,
+  };
+  // Non-finite values (Sum/Multiply/Avg overflow past f32::MAX to infinity)
+  // must not leak into the sort key. Callers that care about distinguishing
+  // "overflow" from "no function values" must check `values.is_empty()` or
+  // the finitude of individual values themselves.
+  Some(result)
 }
 
 pub(crate) fn apply_boost_mode(base: f32, func_score: f32, mode: FunctionBoostMode) -> f32 {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -887,6 +887,153 @@ fn max_boost_caps_function_score_before_boost_mode_multiply() {
   }
 }
 
+// Regression: `combine_function_scores` and the `FunctionScore` branch of
+// `evaluate_compiled_score` previously lacked finitude guards. When
+// individually finite function values overflow `f32` during combine (e.g.
+// Multiply of two 1e20 weights → 1e40 > f32::MAX), the result leaked out
+// as `Some(f32::INFINITY)` and corrupted sort ordering. The fix is to
+// reject non-finite combined scores (return `None`) so overflowing hits
+// are excluded from the result set, mirroring the RankFeature guard. See
+// BUG-315.
+#[test]
+fn function_score_multiply_overflow_is_excluded() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![
+      FunctionSpec::Weight {
+        weight: 1.0e20,
+        filter: None,
+      },
+      FunctionSpec::Weight {
+        weight: 1.0e20,
+        filter: None,
+      },
+    ],
+    score_mode: Some(FunctionScoreMode::Multiply),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  // 1e20 * 1e20 = 1e40 overflows f32 → combine returns None → hits excluded.
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when combine overflows to infinity, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+  // Sanity: no score leaks out as non-finite.
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "non-finite score leaked into result: {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn function_score_sum_overflow_is_excluded() {
+  let reader = setup_reader();
+  // Two Weight functions whose Sum overflows f32::MAX (≈ 3.4e38).
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![
+      FunctionSpec::Weight {
+        weight: f32::MAX,
+        filter: None,
+      },
+      FunctionSpec::Weight {
+        weight: f32::MAX,
+        filter: None,
+      },
+    ],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when Sum combine overflows to infinity, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn function_score_boost_multiplier_overflow_is_excluded() {
+  let reader = setup_reader();
+  // A single function value that is finite, but the final `combined *= boost`
+  // step overflows. The second finitude guard (after boost) must catch it.
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 1.0e30,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: Some(1.0e30),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when final boost multiply overflows, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn function_score_max_boost_caps_combine_overflow_to_finite() {
+  let reader = setup_reader();
+  // When `max_boost` is set, it must cap the combined function score even
+  // if the combine step overflowed to `f32::INFINITY`. This works because
+  // `f32::INFINITY.min(finite) == finite`, so the doc survives with a
+  // finite, capped score. This test documents that `max_boost` protects
+  // against combine overflow, which was the existing workaround noted in
+  // BUG-315 for users who were aware of the issue.
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![
+      FunctionSpec::Weight {
+        weight: 1.0e20,
+        filter: None,
+      },
+      FunctionSpec::Weight {
+        weight: 1.0e20,
+        filter: None,
+      },
+    ],
+    score_mode: Some(FunctionScoreMode::Multiply),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: Some(100.0),
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "expected finite score after max_boost capping, got {}",
+      hit.score
+    );
+    assert!(
+      (hit.score - 100.0).abs() < 1e-6,
+      "expected score to be capped at max_boost=100.0, got {}",
+      hit.score
+    );
+  }
+}
+
 #[test]
 fn rescore_sort_window_excludes_non_rescored_after_removal() {
   // Regression test for BUG-291: when rescore drops hits from within the

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -917,21 +917,15 @@ fn function_score_multiply_overflow_is_excluded() {
     boost: None,
   });
   let resp = reader.search(&req).unwrap();
-  // 1e20 * 1e20 = 1e40 overflows f32 → combine returns None → hits excluded.
+  // 1e20 * 1e20 = 1e40 overflows f32 to infinity; the combined score is
+  // non-finite after capping, so evaluate_compiled_score returns None and
+  // every hit is excluded from the result set.
   assert!(
     resp.hits.is_empty(),
     "expected no hits when combine overflows to infinity, got {} hits with scores {:?}",
     resp.hits.len(),
     resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
   );
-  // Sanity: no score leaks out as non-finite.
-  for hit in &resp.hits {
-    assert!(
-      hit.score.is_finite(),
-      "non-finite score leaked into result: {}",
-      hit.score
-    );
-  }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `combine_function_scores` previously leaked non-finite results (Sum/Multiply/Avg overflow past `f32::MAX` to infinity) into the sort key, and the `FunctionScore` branch of `evaluate_compiled_score` had no finitude guard. When `max_boost` was unset (the default), infinity propagated through `apply_boost_mode` and the final boost multiplication, corrupting result ordering. Contrast with the `RankFeature` branch at `scoring.rs:388-394`, which checks finitude twice.
- Added finitude rejection **after** the `max_boost` cap (so `max_boost.min(infinity) == max_boost` still caps to a finite value, preserving existing behavior), **after** `apply_boost_mode`, and **after** the final boost multiplication — mirroring the RankFeature guards and the equivalent checks in `script.rs` and `aggs/mod.rs`.
- Added regression tests for Multiply combine overflow, Sum combine overflow, final-boost multiplication overflow, and the `max_boost` capping path.

## Test plan

- [x] `cargo test --test function_score` — all 31 tests pass (4 new)
- [x] `cargo test` — full workspace green, no regressions
- [x] `cargo clippy --all-targets` — no new warnings
- [x] Manual verification against the reproduction in the issue: `field_value_factor` × `field_value_factor` with Multiply score_mode no longer returns `Some(f32::INFINITY)`

Closes #315