### PR TITLE
fix(rescore): reject non-finite combined scores in rescore (BUG-326)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2112,11 +2112,12 @@ impl IndexReader {
         let combined = combine_rescore_scores(rescore.score_mode, orig_score, rescore_score);
         // Reject non-finite combined scores (BUG-326). Even though `rescore_score`
         // is guarded finite by `evaluate_compiled_score` (BUG-315) and `orig_score`
-        // is a finite f32, the combination itself can still overflow — a Sum or
-        // Multiply of two large finite values exceeds f32::MAX and yields +/-inf,
-        // and prior Multiply passes can seed inf * 0.0 = NaN on chained rescores.
-        // A non-finite value would otherwise leak into `hit.score`, `hit.key`, and
-        // the serialized JSON response; drop the doc instead, matching the
+        // is a finite f32, combining the two can still produce a non-finite value:
+        // a Sum/Total or Multiply of two large finite inputs can exceed `f32::MAX`
+        // and yield +/-inf, and a saturating Sum/Multiply that produces +inf against
+        // a finite operand of the opposite sign can then fall out as NaN. A
+        // non-finite value would otherwise leak into `hit.score`, `hit.key`, and the
+        // serialized JSON response; drop the doc instead, matching the
         // "evaluate_compiled_score returned None" branch above and the policy used
         // by `eval_rpn` (BUG-287), `combine_function_scores` (BUG-315), and the
         // pipeline-agg paths (BUG-322, BUG-324).

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -2110,6 +2110,20 @@ impl IndexReader {
         let hit = hits.get_mut(hit_idx).unwrap();
         let orig_score = hit.score;
         let combined = combine_rescore_scores(rescore.score_mode, orig_score, rescore_score);
+        // Reject non-finite combined scores (BUG-326). Even though `rescore_score`
+        // is guarded finite by `evaluate_compiled_score` (BUG-315) and `orig_score`
+        // is a finite f32, the combination itself can still overflow — a Sum or
+        // Multiply of two large finite values exceeds f32::MAX and yields +/-inf,
+        // and prior Multiply passes can seed inf * 0.0 = NaN on chained rescores.
+        // A non-finite value would otherwise leak into `hit.score`, `hit.key`, and
+        // the serialized JSON response; drop the doc instead, matching the
+        // "evaluate_compiled_score returned None" branch above and the policy used
+        // by `eval_rpn` (BUG-287), `combine_function_scores` (BUG-315), and the
+        // pipeline-agg paths (BUG-322, BUG-324).
+        if !combined.is_finite() {
+          to_remove.push(hit_idx);
+          continue;
+        }
         hit.score = combined;
         hit.key = sort_plan.build_key(seg, doc_id, combined, segment_ord);
         if req.explain {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1028,6 +1028,158 @@ fn function_score_max_boost_caps_combine_overflow_to_finite() {
   }
 }
 
+// Regression for BUG-326: the rescore `combine_rescore_scores` step had no
+// finitude guard on its output. Two individually-finite inputs (each within
+// `f32::MAX`) can still overflow when combined under `Multiply` or `Sum`, and
+// the resulting `±INF` / `NaN` would flow into `hit.score`, the sort key, and
+// the JSON response — bypassing the per-input guards that BUG-315 added to
+// `evaluate_compiled_score`. Mirrors the policy in `eval_rpn` (BUG-287),
+// `combine_function_scores` (BUG-315), and the pipeline-agg paths (BUG-322,
+// BUG-324): drop the doc when the combination is non-finite.
+#[test]
+fn rescore_multiply_overflow_excludes_hit() {
+  let reader = setup_reader();
+  // Base query: every doc scores 1.0e20 (finite f32). This survives the
+  // per-function-score finitude guard (BUG-315) because 1e20 < f32::MAX.
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 1.0e20,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore: every doc scores 1.0e20 (also finite). The combine step
+  // 1e20 * 1e20 = 1e40 overflows f32 to +INF, which must exclude the doc.
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::FunctionScore {
+      query: Box::new(QueryNode::MatchAll { boost: None }),
+      functions: vec![FunctionSpec::Weight {
+        weight: 1.0e20,
+        filter: None,
+      }],
+      score_mode: Some(FunctionScoreMode::Sum),
+      boost_mode: Some(FunctionBoostMode::Replace),
+      max_boost: None,
+      min_score: None,
+      boost: None,
+    },
+    score_mode: RescoreMode::Multiply,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when rescore Multiply overflows to infinity, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn rescore_sum_overflow_excludes_hit() {
+  let reader = setup_reader();
+  // Base query: every doc scores f32::MAX (finite, at the edge of f32).
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: f32::MAX,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Rescore: every doc scores f32::MAX. `RescoreMode::Total` aliases `Sum`
+  // (documented in the definition of `combine_rescore_scores`), so
+  // f32::MAX + f32::MAX = +INF. With the fix, the non-finite combined
+  // result drops every rescored hit.
+  req.rescore = Some(RescoreRequest {
+    window_size: 10,
+    query: QueryNode::FunctionScore {
+      query: Box::new(QueryNode::MatchAll { boost: None }),
+      functions: vec![FunctionSpec::Weight {
+        weight: f32::MAX,
+        filter: None,
+      }],
+      score_mode: Some(FunctionScoreMode::Sum),
+      boost_mode: Some(FunctionBoostMode::Replace),
+      max_boost: None,
+      min_score: None,
+      boost: None,
+    },
+    score_mode: RescoreMode::Total,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when rescore Sum overflows to infinity, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+}
+
+// A non-rescored doc (outside `window_size`) must keep its original finite
+// score even when the rescored docs in the window are dropped because their
+// combined score overflowed. Documents the interaction with the sort-window
+// shrink behaviour from BUG-291.
+#[test]
+fn rescore_multiply_overflow_preserves_non_rescored_hits() {
+  let reader = setup_reader();
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 1.0e20,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // Window only covers the first two hits; the third doc is untouched by
+  // rescore and must keep its finite original score.
+  req.rescore = Some(RescoreRequest {
+    window_size: 2,
+    query: QueryNode::FunctionScore {
+      query: Box::new(QueryNode::MatchAll { boost: None }),
+      functions: vec![FunctionSpec::Weight {
+        weight: 1.0e20,
+        filter: None,
+      }],
+      score_mode: Some(FunctionScoreMode::Sum),
+      boost_mode: Some(FunctionBoostMode::Replace),
+      max_boost: None,
+      min_score: None,
+      boost: None,
+    },
+    score_mode: RescoreMode::Multiply,
+  });
+  let resp = reader.search(&req).unwrap();
+  // The two rescored hits overflow and are dropped; the one outside-window
+  // hit survives at its original finite score.
+  assert_eq!(resp.hits.len(), 1);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "outside-window hit must keep a finite score, got {}",
+      hit.score
+    );
+    assert!(
+      (hit.score - 1.0e20).abs() < 1.0e14,
+      "outside-window hit should keep its original 1e20 score, got {}",
+      hit.score
+    );
+  }
+}
+
 #[test]
 fn rescore_sort_window_excludes_non_rescored_after_removal() {
   // Regression test for BUG-291: when rescore drops hits from within the


### PR DESCRIPTION
## Summary

Closes #326.

The rescore pass in `IndexReader::rescore_hits` was combining the original hit score with the per-doc rescore score via `combine_rescore_scores` (Sum/Total/Multiply/Max/Min) and storing the result directly in `hit.score` and the sort key without a finitude check. Even though the inputs are individually guarded — BM25 scores are bounded, and `evaluate_compiled_score` rejects non-finite rescore values (BUG-315) — the combination itself can still overflow `f32` when both inputs are large finite values. A `Multiply` of two ~1e20 scores yields 1e40 = `+INF`, and `f32::MAX + f32::MAX` under `Sum`/`Total` does the same. The non-finite combined value was flowing into:

- `hit.score` — propagated to the response payload.
- `hit.key` via `sort_plan.build_key(..)` — corrupts the sort key (`NaN` breaks strict ordering, `±INF` forces the doc to a sort extreme).
- `serde_json` serialization — `NaN`/`Infinity` are not valid JSON numbers, so the whole response fails to serialize.
- `expl.final_score` when `explain` is set.

This is the same class of bug that BUG-287 fixed for `eval_rpn` (bucket_script), BUG-315 fixed for `combine_function_scores` (function_score), and BUG-322 / BUG-324 fixed for the derivative/moving_avg and avg_bucket/sum_bucket pipelines.

## Changes

- `searchlite-core/src/api/reader.rs`: add an `is_finite()` guard on `combined` after `combine_rescore_scores`; on failure push the hit onto `to_remove` and `continue`, mirroring the adjacent branch that drops docs when `evaluate_compiled_score` returns `None`. The symmetric non-matching-doc branch (`reader.rs:2048`) combines with `0.0` and therefore stays finite under every `RescoreMode`, so no guard is needed there.

## Tests

Regression tests added in `searchlite-core/tests/function_score.rs`:

- `rescore_multiply_overflow_excludes_hit` — both inputs are 1e20 (finite f32, well within `f32::MAX`); the product 1e40 overflows to `+INF` and every rescored hit must be dropped.
- `rescore_sum_overflow_excludes_hit` — both inputs are `f32::MAX` under `RescoreMode::Total` (alias for Sum); `f32::MAX + f32::MAX = +INF`.
- `rescore_multiply_overflow_preserves_non_rescored_hits` — documents that non-rescored hits outside `window_size` keep their original finite score when rescored docs inside the window are dropped, interacting correctly with the BUG-291 sort-window shrink.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core` — all suites green (425 lib tests + 34 function_score tests + every other suite pass)
