### PR TITLE
fix(hybrid): reject non-finite blended final_score in compute_hybrid_score (BUG-328)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -190,7 +190,7 @@ fn compute_hybrid_score(
   bm25_score: f32,
   plan: &VectorPlan,
   vector_scores: &[HashMap<(u32, DocId), f32>],
-) -> (f32, Option<f32>, bool) {
+) -> Option<(f32, Option<f32>, bool)> {
   let mut blended_sum = 0.0_f32;
   let mut vector_sum = 0.0_f32;
   let mut has_vector = false;
@@ -212,7 +212,20 @@ fn compute_hybrid_score(
   }
   let denom = plan.clauses.len().max(1) as f32;
   let final_score = blended_sum / denom;
-  (final_score, has_vector.then_some(vector_sum), has_vector)
+  // `blended_sum` accumulates per-clause contributions that are individually
+  // bounded but can still overflow f32 past `±f32::MAX` to `±INF` once summed
+  // across multiple clauses — notably when a doc is missing its vector in
+  // multiple L2 clauses, since `missing_vector_score(L2) = f32::MIN` is
+  // already at the edge of representable f32. A non-finite `final_score`
+  // would leak into `hit.score`, the explanation payload, and the sort key
+  // (breaking strict ordering under `NaN` and pinning the doc to a sort
+  // extreme under `±INF`). Drop the candidate instead, matching the policy
+  // enforced by `evaluate_compiled_score` (BUG-315) and the rescore
+  // combination branch (BUG-326).
+  if !final_score.is_finite() {
+    return None;
+  }
+  Some((final_score, has_vector.then_some(vector_sum), has_vector))
 }
 
 use super::scoring::{
@@ -652,7 +665,10 @@ impl IndexReader {
       for doc_id in seg_docs.into_iter() {
         let key_tuple = (segment_ord as u32, doc_id);
         let (final_score, vector_score, _) =
-          compute_hybrid_score(key_tuple, 0.0, plan, &vector_scores);
+          match compute_hybrid_score(key_tuple, 0.0, plan, &vector_scores) {
+            Some(t) => t,
+            None => continue,
+          };
         let key = if req.return_hits {
           let key = sort_plan.build_key(seg, doc_id, final_score, segment_ord as u32);
           if let Some(cur) = &cursor_key {
@@ -982,7 +998,10 @@ impl IndexReader {
         explanation = existing.explanation;
       }
       let (final_score, vector_score, has_vector) =
-        compute_hybrid_score((seg_ord, doc_id), bm25_score, plan, vector_scores);
+        match compute_hybrid_score((seg_ord, doc_id), bm25_score, plan, vector_scores) {
+          Some(t) => t,
+          None => continue,
+        };
       if all_vector_only && !has_vector {
         continue;
       }
@@ -5112,6 +5131,99 @@ mod tests {
       source.get("body").and_then(|v| v.as_str()),
       Some("second version"),
       "mget should return the most recent version"
+    );
+  }
+
+  #[cfg(feature = "vectors")]
+  #[test]
+  fn compute_hybrid_score_drops_candidate_on_negative_infinity() {
+    // Regression test for BUG-328. Two L2 clauses where the candidate doc is
+    // absent from both vector postings: `missing_vector_score(L2)` is
+    // `f32::MIN ≈ -3.4e38`, so `f32::MIN + f32::MIN` saturates to
+    // `f32::NEG_INFINITY` when accumulated, and the division by the clause
+    // count preserves that infinity. Before the fix the non-finite
+    // `final_score` leaked into `hit.score`, the sort key, and the
+    // `expl.final_score` payload.
+    let plan = VectorPlan {
+      clauses: vec![
+        VectorClausePlan {
+          field: "vec_a".into(),
+          vector: vec![0.1, 0.2],
+          k: 10,
+          alpha: 0.0,
+          ef_search: 16,
+          candidate_size: 16,
+          boost: 1.0,
+          metric: VectorMetric::L2,
+        },
+        VectorClausePlan {
+          field: "vec_b".into(),
+          vector: vec![0.3, 0.4],
+          k: 10,
+          alpha: 0.0,
+          ef_search: 16,
+          candidate_size: 16,
+          boost: 1.0,
+          metric: VectorMetric::L2,
+        },
+      ],
+      candidate_size: 32,
+      vector_only: true,
+    };
+    let vector_scores: Vec<HashMap<(u32, DocId), f32>> = vec![HashMap::new(), HashMap::new()];
+    let result = compute_hybrid_score((0, 1), 0.0, &plan, &vector_scores);
+    assert!(
+      result.is_none(),
+      "candidate with saturating blended_sum must be dropped rather than leaking non-finite score"
+    );
+  }
+
+  #[cfg(feature = "vectors")]
+  #[test]
+  fn compute_hybrid_score_keeps_candidate_when_finite() {
+    // Same plan shape, but both clauses have a vector score for the doc, so
+    // `blended_sum` stays bounded and a finite score flows through.
+    let plan = VectorPlan {
+      clauses: vec![
+        VectorClausePlan {
+          field: "vec_a".into(),
+          vector: vec![0.1, 0.2],
+          k: 10,
+          alpha: 0.0,
+          ef_search: 16,
+          candidate_size: 16,
+          boost: 1.0,
+          metric: VectorMetric::L2,
+        },
+        VectorClausePlan {
+          field: "vec_b".into(),
+          vector: vec![0.3, 0.4],
+          k: 10,
+          alpha: 0.0,
+          ef_search: 16,
+          candidate_size: 16,
+          boost: 1.0,
+          metric: VectorMetric::L2,
+        },
+      ],
+      candidate_size: 32,
+      vector_only: true,
+    };
+    let mut scores_a: HashMap<(u32, DocId), f32> = HashMap::new();
+    scores_a.insert((0, 1), -0.5);
+    let mut scores_b: HashMap<(u32, DocId), f32> = HashMap::new();
+    scores_b.insert((0, 1), -0.25);
+    let vector_scores = vec![scores_a, scores_b];
+    let result =
+      compute_hybrid_score((0, 1), 0.0, &plan, &vector_scores).expect("finite result expected");
+    assert!(
+      result.0.is_finite(),
+      "finite inputs should yield a finite final_score, got {}",
+      result.0
+    );
+    assert!(
+      result.2,
+      "has_vector should be true when both clauses contribute"
     );
   }
 }

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -219,10 +219,16 @@ fn compute_hybrid_score(
   // already at the edge of representable f32. A non-finite `final_score`
   // would leak into `hit.score`, the explanation payload, and the sort key
   // (breaking strict ordering under `NaN` and pinning the doc to a sort
-  // extreme under `±INF`). Drop the candidate instead, matching the policy
-  // enforced by `evaluate_compiled_score` (BUG-315) and the rescore
-  // combination branch (BUG-326).
-  if !final_score.is_finite() {
+  // extreme under `±INF`). `vector_sum` accumulates the raw per-clause
+  // vector scores separately and flows into `hit.vector_score`; it can
+  // independently be non-finite because `collect_vector_value`
+  // (`index/segment.rs`) casts JSON `f64` components to `f32` without an
+  // `is_finite()` check, so a value past `f32::MAX` is persisted as `±INF`
+  // in the indexed vector and propagates through `metric_similarity`. Drop
+  // the candidate in either case, matching the policy enforced by
+  // `evaluate_compiled_score` (BUG-315) and the rescore combination branch
+  // (BUG-326).
+  if !final_score.is_finite() || (has_vector && !vector_sum.is_finite()) {
     return None;
   }
   Some((final_score, has_vector.then_some(vector_sum), has_vector))
@@ -5175,6 +5181,44 @@ mod tests {
     assert!(
       result.is_none(),
       "candidate with saturating blended_sum must be dropped rather than leaking non-finite score"
+    );
+  }
+
+  #[cfg(feature = "vectors")]
+  #[test]
+  fn compute_hybrid_score_drops_candidate_when_vector_sum_is_non_finite() {
+    // Regression guard for the symmetric leak path flagged during review of
+    // BUG-328: `collect_vector_value` casts JSON `f64` components to `f32`
+    // without an `is_finite()` check, so a doc indexed with a component
+    // past `f32::MAX` surfaces as `±INF` in the cached `vector_scores` map.
+    // `compute_hybrid_score` threads that raw per-clause value through
+    // `vector_sum`, which then flows into `hit.vector_score` — `Hit` serializes
+    // `vector_score` as a bare number when `Some`, so a non-finite value
+    // would break JSON serialization even when `final_score` is finite
+    // (e.g. `alpha >= 1.0` makes `final_score` equal to the finite
+    // `bm25_score`). The candidate must be dropped.
+    let plan = VectorPlan {
+      clauses: vec![VectorClausePlan {
+        field: "vec_a".into(),
+        vector: vec![0.1, 0.2],
+        k: 10,
+        alpha: 1.0,
+        ef_search: 16,
+        candidate_size: 16,
+        boost: 1.0,
+        metric: VectorMetric::Cosine,
+      }],
+      candidate_size: 16,
+      vector_only: false,
+    };
+    let mut scores: HashMap<(u32, DocId), f32> = HashMap::new();
+    scores.insert((0, 1), f32::INFINITY);
+    let vector_scores = vec![scores];
+    let result = compute_hybrid_score((0, 1), 1.0, &plan, &vector_scores);
+    assert!(
+      result.is_none(),
+      "candidate whose raw vector_sum is non-finite must be dropped so \
+       hit.vector_score cannot leak ±INF into JSON serialization"
     );
   }
 


### PR DESCRIPTION
## Summary

Closes #328.

`compute_hybrid_score` in `searchlite-core/src/api/reader.rs` accumulated per-clause blended contributions into `blended_sum` and returned `blended_sum / denom` as `final_score` without a finitude check. The per-clause `blended` values are individually bounded (BM25 scores are bounded, vector similarities are in `[-1, 1]` for cosine and `[f32::MIN, 0]` for L2), but the across-clause sum can still saturate past `±f32::MAX` to `±INF` — notably when a doc is absent from multiple L2 clauses, since `missing_vector_score(L2) = f32::MIN ≈ -3.4e38`, so two missing clauses sum to `-INF` in `f32` and the division preserves that infinity.

Before the fix, the non-finite `final_score` flowed into:

- `RankedHit.score` — response-visible hit score; `serde_json` cannot serialize `NaN`/`Infinity` as JSON numbers, so the whole response fails to serialize.
- `sort_plan.build_key(..)` — corrupts the sort key (`NaN` breaks strict ordering, `±INF` pins the doc to a sort extreme).
- `expl.final_score` when `explain` is set.

This is the same class of bug that BUG-287 fixed for `eval_rpn` (bucket_script), BUG-315 fixed for `combine_function_scores` (function_score), and BUG-322 / BUG-324 / BUG-326 fixed for the derivative/moving_avg, avg_bucket/sum_bucket, and rescore combination paths.

## Changes

- `searchlite-core/src/api/reader.rs`: change `compute_hybrid_score` to return `Option<(f32, Option<f32>, bool)>` and return `None` when `final_score` is not finite. Both call sites (the vector-only merge path at ~line 655 and the hybrid BM25+vector merge path at ~line 985) now `continue` past the candidate when `compute_hybrid_score` returns `None`, mirroring the adjacent branch that drops docs when `evaluate_compiled_score` returns `None`.

## Tests

Added regression tests in the existing `api::reader::tests` module, gated on `#[cfg(feature = "vectors")]`:

- `compute_hybrid_score_drops_candidate_on_negative_infinity` — two L2 clauses with the doc absent from both vector postings; `missing_vector_score(L2) + missing_vector_score(L2) = -INF` in `f32`, so the candidate must be dropped.
- `compute_hybrid_score_keeps_candidate_when_finite` — same plan shape, but both clauses contribute a bounded vector score for the doc; the final score stays finite and `has_vector` is preserved.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --features vectors --lib --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core --features vectors` — all suites green, including the 10 existing `vector_search` integration tests and the 2 new unit tests.