### PR TITLE
fix(vectors): reject non-finite components in collect_vector_value (BUG-330)

### DIFF
--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -511,7 +511,11 @@ fn collect_vector_value(
     let Some(num) = v.as_f64() else {
       bail!("vector field {field} must contain numbers");
     };
-    vecvals.push(num as f32);
+    let num_f32 = num as f32;
+    if !num_f32.is_finite() {
+      bail!("vector field {field} contains non-finite component");
+    }
+    vecvals.push(num_f32);
   }
   if vecvals.len() != vf.dim {
     bail!(

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -691,3 +691,90 @@ fn rejects_global_cap_below_clause_count() {
     "expected validation error, got {err}"
   );
 }
+
+// BUG-330: `collect_vector_value` previously cast each JSON `f64` component
+// to `f32` via `num as f32` without validating the resulting `f32`. A finite
+// `f64` whose magnitude exceeds `f32::MAX` (~3.4e38) saturates to
+// `±f32::INFINITY` under Rust's `as` cast and was persisted into the segment,
+// then propagated through `metric_similarity` (and through `normalize_in_place`
+// on cosine, which produces an all-`NaN` vector). The fix bails when the
+// pending document is flushed to a segment, surfacing the bad input to the
+// writer instead of corrupting reads forever after.
+#[test]
+fn commit_rejects_vector_component_overflowing_f32_to_positive_inf() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  let mut writer = idx.writer().expect("writer");
+  // 1e40 is a valid JSON number; it parses to a finite f64 ≈ 1e40 but
+  // `1e40_f64 as f32` saturates to f32::INFINITY.
+  let doc = Document {
+    fields: [
+      ("_id".into(), serde_json::json!("inf-pos")),
+      ("body".into(), serde_json::json!("body")),
+      ("embedding".into(), serde_json::json!([1.0e40, 0.0])),
+    ]
+    .into_iter()
+    .collect(),
+  };
+  writer.add_document(&doc).expect("staging accepts the doc");
+  let err = writer.commit().unwrap_err().to_string();
+  assert!(
+    err.contains("non-finite"),
+    "expected non-finite component error, got {err}"
+  );
+}
+
+#[test]
+fn commit_rejects_vector_component_overflowing_f32_to_negative_inf() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  let mut writer = idx.writer().expect("writer");
+  let doc = Document {
+    fields: [
+      ("_id".into(), serde_json::json!("inf-neg")),
+      ("body".into(), serde_json::json!("body")),
+      ("embedding".into(), serde_json::json!([-1.0e40, 1.0])),
+    ]
+    .into_iter()
+    .collect(),
+  };
+  writer.add_document(&doc).expect("staging accepts the doc");
+  let err = writer.commit().unwrap_err().to_string();
+  assert!(
+    err.contains("non-finite"),
+    "expected non-finite component error, got {err}"
+  );
+}
+
+#[test]
+fn commit_accepts_vector_component_at_f32_max() {
+  // The boundary case: a value that fits in f32 (exactly f32::MAX cast to
+  // f64) must still be accepted to avoid over-rejecting legitimate inputs.
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  let mut writer = idx.writer().expect("writer");
+  let doc = Document {
+    fields: [
+      ("_id".into(), serde_json::json!("at-max")),
+      ("body".into(), serde_json::json!("body")),
+      (
+        "embedding".into(),
+        serde_json::json!([f32::MAX as f64, 0.0]),
+      ),
+    ]
+    .into_iter()
+    .collect(),
+  };
+  writer
+    .add_document(&doc)
+    .expect("finite component at f32::MAX must be accepted");
+  writer
+    .commit()
+    .expect("finite component at f32::MAX must commit");
+}


### PR DESCRIPTION
## Summary

Closes #330.

`collect_vector_value` in `searchlite-core/src/index/segment.rs` was casting each JSON `f64` vector component to `f32` via `num as f32` without validating the result. A finite `f64` whose magnitude exceeds `f32::MAX` (~3.4e38) saturates to `±f32::INFINITY` under Rust's `as` cast and was persisted into the segment, then propagated through `metric_similarity` (and through `normalize_in_place` on cosine — which yields an all-`NaN` vector after dividing by an `INF` norm) on every subsequent read.

BUG-328 patched the symptom downstream by dropping the affected candidate inside `compute_hybrid_score`, and the comment at `reader.rs:188-235` explicitly identifies this site as the still-unguarded root cause:

> `vector_sum` … can independently be non-finite because `collect_vector_value` (`index/segment.rs`) casts JSON `f64` components to `f32` without an `is_finite()` check, so a value past `f32::MAX` is persisted as `±INF` in the indexed vector and propagates through `metric_similarity`.

The corrupt vector still leaks through every read path that does not gate on the blended `final_score`: raw `vector_score` reporting, explanation payloads, and HNSW graph construction whose neighbor selection is poisoned for every doc indexed after the offending one. This PR fixes the root cause.

This is the same class of bug that BUG-287 fixed for `eval_rpn` (bucket_script), BUG-315 fixed for `combine_function_scores` (function_score), BUG-322 / BUG-324 fixed for the derivative/moving_avg and avg_bucket/sum_bucket pipelines, BUG-326 fixed for the rescore combination, and BUG-328 fixed for `compute_hybrid_score`.

## Changes

- `searchlite-core/src/index/segment.rs`: validate the cast `f32` result inside `collect_vector_value` and `bail!` on non-finite, mirroring the surrounding input-validation `bail!`s (`bail!("vector field {field} must contain numbers")` and the dimension-mismatch `bail!`). The check covers all four leak classes:
  - finite `f64` magnitude > `f32::MAX` saturating to `±f32::INFINITY` (the typical leak),
  - `f64::INFINITY` / `f64::NEG_INFINITY` (only reachable through a non-strict deserializer, but `is_finite()` covers it for free),
  - `f64::NAN` (same),
  - finite `f64` underflowing to `0.0` is intentionally allowed — `0.0` is finite and a legitimate component value.

The error surfaces at commit time (when staged docs flush through `collect_document` → `collect_vector_value`), keeping the error visible to the writer rather than corrupting the segment.

## Tests

Added regression tests in `searchlite-core/tests/vector_search.rs`:

- `commit_rejects_vector_component_overflowing_f32_to_positive_inf` — `1.0e40` is a valid JSON number that parses to a finite `f64` but saturates to `f32::INFINITY` on the cast; commit must bail.
- `commit_rejects_vector_component_overflowing_f32_to_negative_inf` — symmetric `-INF` case under the L2 metric.
- `commit_accepts_vector_component_at_f32_max` — boundary check: `f32::MAX as f64` round-trips through the cast as a finite `f32::MAX` and must still be accepted to avoid over-rejecting legitimate inputs.

## Validation

- `cargo fmt --all` — clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core --features vectors` — every suite passes (vector_search 13/13 including 3 new, plus all other suites)
