### PR TITLE
fix(aggs): reject non-finite values in stats and extended_stats (BUG-332)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3007,8 +3007,8 @@ fn finalize_response(intermediate: AggregationIntermediate) -> AggregationRespon
       };
       AggregationResponse::Stats(StatsResponse {
         count: stats.count,
-        min: stats.min,
-        max: stats.max,
+        min: finite_or_zero(stats.min),
+        max: finite_or_zero(stats.max),
         sum: finite_or_zero(stats.sum),
         avg: finite_or_zero(avg),
       })
@@ -3027,8 +3027,8 @@ fn finalize_response(intermediate: AggregationIntermediate) -> AggregationRespon
       let std_deviation = variance.sqrt();
       AggregationResponse::ExtendedStats(crate::api::types::ExtendedStatsResponse {
         count: stats.count,
-        min: stats.min,
-        max: stats.max,
+        min: finite_or_zero(stats.min),
+        max: finite_or_zero(stats.max),
         sum: finite_or_zero(stats.sum),
         avg: finite_or_zero(avg),
         variance: finite_or_zero(variance),
@@ -4849,11 +4849,14 @@ mod tests {
   }
 
   // Regression tests for BUG-332: `Stats` and `ExtendedStats` finalization
-  // must collapse non-finite `sum`, `avg`, `variance`, and `std_deviation`
-  // values to `0.0`. `serde_json` cannot emit `NaN` / `Infinity` as JSON
-  // numbers, so leaking them fails response serialization. `merge_stats` must
-  // likewise not produce a `NaN` `m2` via an `INF - INF` delta when segments'
-  // averages sit at opposite `f64` extremes.
+  // must collapse non-finite `sum`, `avg`, `variance`, `std_deviation`,
+  // `min`, and `max` values to `0.0`. `serde_json` cannot emit `NaN` /
+  // `Infinity` as JSON numbers, so leaking them fails response
+  // serialization. `merge_stats` must likewise not produce a `NaN` `m2` via
+  // an `INF - INF` delta when segments' averages sit at opposite `f64`
+  // extremes. `min` / `max` are also guarded because a request-supplied
+  // `missing` value parsed via `str::parse::<f64>` accepts `"NaN"` /
+  // `"inf"` and would otherwise reach the response unchecked.
 
   #[test]
   fn stats_finalize_replaces_non_finite_sum_and_avg_with_zero() {
@@ -4901,6 +4904,52 @@ mod tests {
       }
       other => panic!("expected ExtendedStats, got {other:?}"),
     }
+  }
+
+  #[test]
+  fn stats_finalize_replaces_non_finite_min_and_max_with_zero() {
+    // `missing: "NaN"` / `"inf"` strings are accepted by
+    // `f64::from_str` (see `StatsCollector::new`), producing a non-finite
+    // `StatsState.min` / `StatsState.max` that would otherwise fail
+    // `serde_json` serialization.
+    let stats = StatsState {
+      count: 5,
+      min: f64::NEG_INFINITY,
+      max: f64::INFINITY,
+      sum: 0.0,
+      m2: 0.0,
+    };
+    let response = finalize_response(AggregationIntermediate::Stats(stats));
+    match &response {
+      AggregationResponse::Stats(r) => {
+        assert_eq!(r.min, 0.0);
+        assert_eq!(r.max, 0.0);
+        assert!(r.min.is_finite());
+        assert!(r.max.is_finite());
+      }
+      other => panic!("expected Stats, got {other:?}"),
+    }
+    assert!(serde_json::to_string(&response).is_ok());
+  }
+
+  #[test]
+  fn extended_stats_finalize_replaces_nan_min_and_max_with_zero() {
+    let stats = StatsState {
+      count: 3,
+      min: f64::NAN,
+      max: f64::NAN,
+      sum: 0.0,
+      m2: 0.0,
+    };
+    let response = finalize_response(AggregationIntermediate::ExtendedStats(stats));
+    match &response {
+      AggregationResponse::ExtendedStats(r) => {
+        assert_eq!(r.min, 0.0);
+        assert_eq!(r.max, 0.0);
+      }
+      other => panic!("expected ExtendedStats, got {other:?}"),
+    }
+    assert!(serde_json::to_string(&response).is_ok());
   }
 
   #[test]

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -2301,6 +2301,20 @@ fn split_pipeline_aggs(
   (bucket_aggs, pipeline_aggs)
 }
 
+/// Collapse a non-finite `f64` (`±INF` / `NaN`) to `0.0`, matching the
+/// empty-state fallback already used in `finalize_response` for `Stats` and
+/// `ExtendedStats`. Keeps the response serializable (`serde_json` cannot emit
+/// `NaN` or `Infinity` as a JSON number) without introducing an API-breaking
+/// `Option<f64>` on the response types.
+#[inline]
+fn finite_or_zero(value: f64) -> f64 {
+  if value.is_finite() {
+    value
+  } else {
+    0.0
+  }
+}
+
 fn merge_stats(a: StatsState, b: StatsState) -> StatsState {
   if a.count == 0 {
     return b;
@@ -2313,7 +2327,17 @@ fn merge_stats(a: StatsState, b: StatsState) -> StatsState {
   let sum = a.sum + b.sum;
   let min = a.min.min(b.min);
   let max = a.max.max(b.max);
-  let m2 = a.m2 + b.m2 + delta * delta * (a.count as f64 * b.count as f64 / count as f64);
+  // Drop the cross-term if `delta` overflows to `±INF` (or evaluates to `NaN`
+  // via `INF - INF`). Preserving `a.m2 + b.m2` retains the within-segment
+  // variance contributions and keeps `m2` finite, matching the finitude policy
+  // already applied by `eval_rpn` (BUG-287), `combine_function_scores`
+  // (BUG-315), and sibling pipeline aggregations (BUG-322, BUG-324).
+  let cross_term = delta * delta * (a.count as f64 * b.count as f64 / count as f64);
+  let m2 = if cross_term.is_finite() {
+    a.m2 + b.m2 + cross_term
+  } else {
+    a.m2 + b.m2
+  };
   StatsState {
     count,
     min,
@@ -2975,35 +2999,40 @@ fn finalize_response(intermediate: AggregationIntermediate) -> AggregationRespon
         sampled,
       }
     }
-    AggregationIntermediate::Stats(stats) => AggregationResponse::Stats(StatsResponse {
-      count: stats.count,
-      min: stats.min,
-      max: stats.max,
-      sum: stats.sum,
-      avg: if stats.count > 0 {
+    AggregationIntermediate::Stats(stats) => {
+      let avg = if stats.count > 0 {
         stats.sum / stats.count as f64
       } else {
         0.0
-      },
-    }),
+      };
+      AggregationResponse::Stats(StatsResponse {
+        count: stats.count,
+        min: stats.min,
+        max: stats.max,
+        sum: finite_or_zero(stats.sum),
+        avg: finite_or_zero(avg),
+      })
+    }
     AggregationIntermediate::ExtendedStats(stats) => {
+      let avg = if stats.count > 0 {
+        stats.sum / stats.count as f64
+      } else {
+        0.0
+      };
       let variance = if stats.count > 0 {
         stats.m2 / stats.count as f64
       } else {
         0.0
       };
+      let std_deviation = variance.sqrt();
       AggregationResponse::ExtendedStats(crate::api::types::ExtendedStatsResponse {
         count: stats.count,
         min: stats.min,
         max: stats.max,
-        sum: stats.sum,
-        avg: if stats.count > 0 {
-          stats.sum / stats.count as f64
-        } else {
-          0.0
-        },
-        variance,
-        std_deviation: variance.sqrt(),
+        sum: finite_or_zero(stats.sum),
+        avg: finite_or_zero(avg),
+        variance: finite_or_zero(variance),
+        std_deviation: finite_or_zero(std_deviation),
       })
     }
     AggregationIntermediate::ValueCount(val) => {
@@ -4817,6 +4846,140 @@ mod tests {
     // string long enough to overflow `f64` on parse (`f64::MAX` ≈ 1.8e308).
     let inf_literal = format!("1{}", "0".repeat(309));
     assert!(eval_bucket_script(&inf_literal, &vars).is_none());
+  }
+
+  // Regression tests for BUG-332: `Stats` and `ExtendedStats` finalization
+  // must collapse non-finite `sum`, `avg`, `variance`, and `std_deviation`
+  // values to `0.0`. `serde_json` cannot emit `NaN` / `Infinity` as JSON
+  // numbers, so leaking them fails response serialization. `merge_stats` must
+  // likewise not produce a `NaN` `m2` via an `INF - INF` delta when segments'
+  // averages sit at opposite `f64` extremes.
+
+  #[test]
+  fn stats_finalize_replaces_non_finite_sum_and_avg_with_zero() {
+    let stats = StatsState {
+      count: 20,
+      min: 0.0,
+      max: f64::MAX,
+      sum: f64::INFINITY,
+      m2: 0.0,
+    };
+    let response = finalize_response(AggregationIntermediate::Stats(stats));
+    match response {
+      AggregationResponse::Stats(r) => {
+        assert_eq!(r.count, 20);
+        assert_eq!(r.sum, 0.0);
+        assert_eq!(r.avg, 0.0);
+        assert!(r.sum.is_finite());
+        assert!(r.avg.is_finite());
+      }
+      other => panic!("expected Stats, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn extended_stats_finalize_replaces_non_finite_fields_with_zero() {
+    let stats = StatsState {
+      count: 20,
+      min: 0.0,
+      max: f64::MAX,
+      sum: f64::INFINITY,
+      m2: f64::NAN,
+    };
+    let response = finalize_response(AggregationIntermediate::ExtendedStats(stats));
+    match response {
+      AggregationResponse::ExtendedStats(r) => {
+        assert_eq!(r.count, 20);
+        assert_eq!(r.sum, 0.0);
+        assert_eq!(r.avg, 0.0);
+        assert_eq!(r.variance, 0.0);
+        assert_eq!(r.std_deviation, 0.0);
+        assert!(r.sum.is_finite());
+        assert!(r.avg.is_finite());
+        assert!(r.variance.is_finite());
+        assert!(r.std_deviation.is_finite());
+      }
+      other => panic!("expected ExtendedStats, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn stats_finalize_serializes_to_valid_json_when_sum_overflows() {
+    // The primary user-visible failure: `serde_json::to_string` on a
+    // response with `sum = INFINITY` returns `Err`. After the fix the
+    // response serializes cleanly.
+    let stats = StatsState {
+      count: 20,
+      min: 0.0,
+      max: f64::MAX,
+      sum: f64::INFINITY,
+      m2: 0.0,
+    };
+    let response = finalize_response(AggregationIntermediate::Stats(stats));
+    assert!(serde_json::to_string(&response).is_ok());
+  }
+
+  #[test]
+  fn extended_stats_finalize_serializes_to_valid_json_when_variance_is_nan() {
+    let stats = StatsState {
+      count: 2,
+      min: -f64::MAX,
+      max: f64::MAX,
+      sum: 0.0,
+      m2: f64::NAN,
+    };
+    let response = finalize_response(AggregationIntermediate::ExtendedStats(stats));
+    assert!(serde_json::to_string(&response).is_ok());
+  }
+
+  #[test]
+  fn merge_stats_drops_cross_term_when_delta_overflows() {
+    // Two segments with averages at opposite `f64` extremes: `delta` would
+    // overflow to `-INF`, producing a `NaN` `m2` via `delta * delta`. The
+    // guard must fall back to `a.m2 + b.m2` so `m2` stays finite.
+    let a = StatsState {
+      count: 1,
+      min: 1e308,
+      max: 1e308,
+      sum: 1e308,
+      m2: 0.0,
+    };
+    let b = StatsState {
+      count: 1,
+      min: -1e308,
+      max: -1e308,
+      sum: -1e308,
+      m2: 0.0,
+    };
+    let merged = merge_stats(a, b);
+    assert_eq!(merged.count, 2);
+    assert!(merged.m2.is_finite());
+    assert_eq!(merged.m2, 0.0);
+  }
+
+  #[test]
+  fn merge_stats_preserves_finite_cross_term_for_normal_inputs() {
+    // Sanity check: the guard must not regress the standard accumulation
+    // for finite inputs. Two segments of {1.0} and {3.0} should yield
+    // count=2, m2=2.0 (variance=1.0), matching the pre-guard behavior.
+    let a = StatsState {
+      count: 1,
+      min: 1.0,
+      max: 1.0,
+      sum: 1.0,
+      m2: 0.0,
+    };
+    let b = StatsState {
+      count: 1,
+      min: 3.0,
+      max: 3.0,
+      sum: 3.0,
+      m2: 0.0,
+    };
+    let merged = merge_stats(a, b);
+    assert_eq!(merged.count, 2);
+    assert_eq!(merged.sum, 4.0);
+    assert!((merged.m2 - 2.0).abs() < 1e-9);
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Closes #332.

`finalize_response` for `Stats` and `ExtendedStats` now collapses non-finite `sum`, `avg`, `variance`, and `std_deviation` values to `0.0`, matching the finitude policy already enforced by `eval_rpn` (BUG-287), `combine_function_scores` (BUG-315), `apply_derivative_pipeline` / `apply_moving_avg_pipeline` (BUG-322), `AvgBucket` / `SumBucket` (BUG-324), the rescore combination (BUG-326), and `compute_hybrid_score` (BUG-328). `serde_json` cannot emit `NaN` or `Infinity` as a JSON number, so leaking these values into `StatsResponse` / `ExtendedStatsResponse` breaks response serialization and surfaces as an opaque HTTP 500.

`merge_stats` is also hardened: when the cross-segment `delta = b_avg - a_avg` overflows to `±INF` (two segments with averages at opposite `f64` extremes) or evaluates to `NaN` via `INF - INF`, the cross-term `delta * delta * (a.count * b.count / count)` would poison `m2` even though every per-doc value was finite. The guard falls back to `a.m2 + b.m2`, preserving within-segment variance contributions and keeping `m2` finite.

## Changes

- `searchlite-core/src/query/aggs/mod.rs`:
  - Add a `finite_or_zero` helper that collapses `±INF` / `NaN` to `0.0`.
  - `Stats` finalization now routes `sum` and the computed `avg` through `finite_or_zero`.
  - `ExtendedStats` finalization now routes `sum`, `avg`, `variance`, and `std_deviation` through `finite_or_zero`.
  - `merge_stats` guards the cross-term against non-finite `delta`; falls back to `a.m2 + b.m2` when the cross-term is not finite, dropping the inter-segment variance contribution rather than emitting a `NaN` `m2` that would poison every subsequent read.

The response struct fields remain `f64` (not `Option<f64>`) to keep the public API backwards-compatible. `0.0` is already the empty-state fallback for `avg`, `variance`, and `std_deviation`, so collapsing non-finite values to the same sentinel is consistent with existing semantics.

## Tests

Added regression tests under `searchlite-core/src/query/aggs/mod.rs` `mod tests`:

- `stats_finalize_replaces_non_finite_sum_and_avg_with_zero` — `sum = INFINITY` → response `sum` and `avg` are `0.0` and finite.
- `extended_stats_finalize_replaces_non_finite_fields_with_zero` — `sum = INFINITY`, `m2 = NaN` → `sum`, `avg`, `variance`, `std_deviation` all `0.0` and finite.
- `stats_finalize_serializes_to_valid_json_when_sum_overflows` — proves the primary user-visible symptom (`serde_json::to_string` failing on `NaN`/`Infinity`) is fixed end-to-end.
- `extended_stats_finalize_serializes_to_valid_json_when_variance_is_nan` — same end-to-end check for the `NaN` variance path.
- `merge_stats_drops_cross_term_when_delta_overflows` — two segments with averages at opposite `f64` extremes must produce a finite `m2`.
- `merge_stats_preserves_finite_cross_term_for_normal_inputs` — sanity check: the guard does not regress standard accumulation ({1.0} ∪ {3.0} still yields `m2 = 2.0`).

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core --lib` — 431 passed, 0 failed
- `cargo test -p searchlite-core --lib query::aggs` — 104 passed (98 existing + 6 new)
