### PR TITLE
fix(score): clamp f64→f32 cast in function_score, rank_feature, script_score (BUG-336)

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -14,7 +14,7 @@ use crate::query::score_functions::{
 };
 use crate::query::script::{compile_script, CompiledScript};
 use crate::query::sort::{SortKey, SortKeyPart, SortValue};
-use crate::query::util::ensure_numeric_fast as ensure_numeric_fast_field;
+use crate::query::util::{ensure_numeric_fast as ensure_numeric_fast_field, f64_to_finite_f32};
 use crate::DocId;
 
 pub(crate) fn score_sort_key(
@@ -404,7 +404,7 @@ pub(crate) fn evaluate_compiled_score(
       if !modified.is_finite() {
         return None;
       }
-      let score = (modified as f32) * *boost;
+      let score = f64_to_finite_f32(modified) * *boost;
       if !score.is_finite() {
         return None;
       }

--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -7,7 +7,7 @@ use crate::api::types::{
 use crate::index::fastfields::FastFieldsReader;
 use crate::index::manifest::Schema;
 use crate::query::filters::passes_filter;
-use crate::query::util::ensure_numeric_fast;
+use crate::query::util::{ensure_numeric_fast, f64_to_finite_f32};
 use crate::DocId;
 
 #[derive(Debug, Clone)]
@@ -161,7 +161,7 @@ impl CompiledFunction {
         if !modified.is_finite() {
           return None;
         }
-        Some(modified as f32)
+        Some(f64_to_finite_f32(modified))
       }
       CompiledFunction::Decay {
         field,
@@ -180,7 +180,7 @@ impl CompiledFunction {
         let norm = (distance.max(0.0)) / *scale;
         let score = decay_value(*decay, norm, function);
         if score.is_finite() {
-          Some(score as f32)
+          Some(f64_to_finite_f32(score))
         } else {
           None
         }

--- a/searchlite-core/src/query/script.rs
+++ b/searchlite-core/src/query/script.rs
@@ -7,7 +7,7 @@ use smallvec::SmallVec;
 
 use crate::index::fastfields::FastFieldsReader;
 use crate::index::manifest::Schema;
-use crate::query::util::ensure_numeric_fast;
+use crate::query::util::{ensure_numeric_fast, f64_to_finite_f32};
 use crate::DocId;
 
 const MAX_SCRIPT_LENGTH: usize = 512;
@@ -142,7 +142,7 @@ impl CompiledScript {
     if !value.is_finite() {
       return None;
     }
-    Some(value as f32)
+    Some(f64_to_finite_f32(value))
   }
 }
 

--- a/searchlite-core/src/query/util.rs
+++ b/searchlite-core/src/query/util.rs
@@ -18,3 +18,58 @@ pub(crate) fn ensure_numeric_fast(schema: &Schema, field: &str, ctx: &str) -> Re
 
   Ok(())
 }
+
+/// Narrow a finite `f64` to `f32`, clamping values outside the `f32`
+/// representable range to `f32::MIN` / `f32::MAX` instead of letting the
+/// narrowing cast saturate to `±f32::INFINITY`.
+///
+/// Rust's `value as f32` cast saturates to `±f32::INFINITY` for any finite
+/// `f64` whose magnitude exceeds `f32::MAX` (~3.4e38). Downstream score
+/// paths reject non-finite values and silently drop the document, so a
+/// legitimately large finite score would otherwise disappear from results.
+/// Clamping mirrors the policy used by the `finite_or_zero` helper in
+/// `query/aggs/mod.rs` for aggregation finalization.
+///
+/// `NaN` inputs propagate as-is (`clamp` is a no-op on `NaN`). Callers must
+/// validate finitude on the `f64` input first if they want to reject `NaN`.
+#[inline]
+pub(crate) fn f64_to_finite_f32(value: f64) -> f32 {
+  value.clamp(f32::MIN as f64, f32::MAX as f64) as f32
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn f64_to_finite_f32_clamps_overflow_to_f32_max() {
+    assert_eq!(f64_to_finite_f32(1.0e40), f32::MAX);
+    assert_eq!(f64_to_finite_f32(-1.0e40), f32::MIN);
+  }
+
+  #[test]
+  fn f64_to_finite_f32_preserves_in_range_values() {
+    assert_eq!(f64_to_finite_f32(0.0), 0.0);
+    assert_eq!(f64_to_finite_f32(1.5), 1.5);
+    assert_eq!(f64_to_finite_f32(-1.5), -1.5);
+    assert_eq!(f64_to_finite_f32(f32::MAX as f64), f32::MAX);
+    assert_eq!(f64_to_finite_f32(f32::MIN as f64), f32::MIN);
+  }
+
+  #[test]
+  fn f64_to_finite_f32_clamps_f64_infinity() {
+    assert_eq!(f64_to_finite_f32(f64::INFINITY), f32::MAX);
+    assert_eq!(f64_to_finite_f32(f64::NEG_INFINITY), f32::MIN);
+  }
+
+  #[test]
+  fn f64_to_finite_f32_propagates_nan() {
+    assert!(f64_to_finite_f32(f64::NAN).is_nan());
+  }
+
+  #[test]
+  fn f64_to_finite_f32_preserves_subnormals() {
+    let tiny = 1.0e-40_f64;
+    assert_eq!(f64_to_finite_f32(tiny), tiny as f32);
+  }
+}

--- a/searchlite-core/src/query/util.rs
+++ b/searchlite-core/src/query/util.rs
@@ -19,9 +19,7 @@ pub(crate) fn ensure_numeric_fast(schema: &Schema, field: &str, ctx: &str) -> Re
   Ok(())
 }
 
-/// Narrow a finite `f64` to `f32`, clamping values outside the `f32`
-/// representable range to `f32::MIN` / `f32::MAX` instead of letting the
-/// narrowing cast saturate to `±f32::INFINITY`.
+/// Narrow an `f64` to a finite `f32`.
 ///
 /// Rust's `value as f32` cast saturates to `±f32::INFINITY` for any finite
 /// `f64` whose magnitude exceeds `f32::MAX` (~3.4e38). Downstream score
@@ -30,10 +28,21 @@ pub(crate) fn ensure_numeric_fast(schema: &Schema, field: &str, ctx: &str) -> Re
 /// Clamping mirrors the policy used by the `finite_or_zero` helper in
 /// `query/aggs/mod.rs` for aggregation finalization.
 ///
-/// `NaN` inputs propagate as-is (`clamp` is a no-op on `NaN`). Callers must
-/// validate finitude on the `f64` input first if they want to reject `NaN`.
+/// Behavior is finite for every input:
+/// - finite `f64` within the `f32` range → narrowed as-is,
+/// - finite `f64` outside the range → clamped to `f32::MIN` / `f32::MAX`,
+/// - `±f64::INFINITY` → clamped to `f32::MIN` / `f32::MAX`,
+/// - `f64::NAN` → `0.0`, matching the `finite_or_zero` fallback.
+///
+/// All scoring-pipeline callers validate `is_finite()` on the `f64` input
+/// before calling this helper, so the `NaN` and `±∞` branches are
+/// defensive; they keep the post-cast value finite regardless of the
+/// caller.
 #[inline]
 pub(crate) fn f64_to_finite_f32(value: f64) -> f32 {
+  if value.is_nan() {
+    return 0.0;
+  }
   value.clamp(f32::MIN as f64, f32::MAX as f64) as f32
 }
 
@@ -63,8 +72,10 @@ mod tests {
   }
 
   #[test]
-  fn f64_to_finite_f32_propagates_nan() {
-    assert!(f64_to_finite_f32(f64::NAN).is_nan());
+  fn f64_to_finite_f32_collapses_nan_to_zero() {
+    let out = f64_to_finite_f32(f64::NAN);
+    assert!(out.is_finite(), "expected finite output, got {out}");
+    assert_eq!(out, 0.0);
   }
 
   #[test]

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1097,3 +1097,209 @@ fn rescore_sort_window_excludes_non_rescored_after_removal() {
     doc2.score
   );
 }
+
+// BUG-336: the f64 -> f32 narrowing cast in `FieldValueFactor::evaluate`,
+// `RankFeature` evaluation, and `CompiledScript::evaluate` saturates any
+// finite f64 whose magnitude exceeds `f32::MAX` (~3.4e38) to
+// `±f32::INFINITY`. Downstream non-finite guards in
+// `evaluate_compiled_score` then reject the hit, silently dropping it from
+// the result set. The fix clamps the f64 to the f32 representable range
+// before the cast so the document survives with the closest representable
+// score (`f32::MAX` / `f32::MIN`), matching the `finite_or_zero` policy used
+// in aggregations.
+
+fn weight_doc(id: &str, body: &str, weight: f64) -> Document {
+  Document {
+    fields: [
+      ("_id".to_string(), serde_json::json!(id)),
+      ("body".to_string(), serde_json::json!(body)),
+      ("weight".to_string(), serde_json::json!(weight)),
+    ]
+    .into_iter()
+    .collect(),
+  }
+}
+
+fn setup_reader_with_weight_field(weights: &[(&str, f64)]) -> searchlite_core::api::IndexReader {
+  let path = tempfile::tempdir().unwrap().path().join("idx");
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "weight".into(),
+    i64: false,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let opts = IndexOptions {
+    path: path.clone(),
+    create_if_missing: true,
+    enable_positions: true,
+    bm25_k1: 0.9,
+    bm25_b: 0.4,
+    storage: StorageType::Filesystem,
+    #[cfg(feature = "vectors")]
+    vector_defaults: None,
+  };
+  let idx = Index::create(&path, schema, opts).unwrap();
+  let mut writer = idx.writer().unwrap();
+  for (id, weight) in weights {
+    writer
+      .add_document(&weight_doc(id, "rust", *weight))
+      .unwrap();
+  }
+  writer.commit().unwrap();
+  idx.reader().unwrap()
+}
+
+#[test]
+fn field_value_factor_reciprocal_overflow_preserves_document_with_f32_max() {
+  // weight = 1e-40 is a finite f64 well within the f64 range. Taking its
+  // reciprocal yields 1e40, which is finite as f64 but exceeds f32::MAX
+  // (~3.4e38). Before the fix, `modified as f32` saturated to
+  // f32::INFINITY, which the downstream non-finite guards rejected,
+  // dropping the hit from the result set. After the fix, the value is
+  // clamped to f32::MAX and the hit survives.
+  let reader = setup_reader_with_weight_field(&[("doc-small", 1.0e-40), ("doc-normal", 1.0)]);
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "weight".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::Reciprocal),
+      missing: None,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  let hit_ids = ids(&resp);
+  assert!(
+    hit_ids.contains(&"doc-small".to_string()),
+    "doc-small must survive the f64->f32 narrowing cast, got hits {hit_ids:?}"
+  );
+  let doc_small = resp
+    .hits
+    .iter()
+    .find(|h| h.doc_id == "doc-small")
+    .expect("doc-small present");
+  assert!(
+    doc_small.score.is_finite(),
+    "doc-small score must be finite after clamp, got {}",
+    doc_small.score
+  );
+  assert_eq!(
+    doc_small.score,
+    f32::MAX,
+    "doc-small score must be clamped to f32::MAX, got {}",
+    doc_small.score
+  );
+}
+
+#[test]
+fn rank_feature_reciprocal_overflow_preserves_document_with_f32_max() {
+  // Same overflow trigger as above but routed through the RankFeature
+  // score node, which performs the `modified as f32` cast independently of
+  // the FunctionScore path.
+  let reader = setup_reader_with_weight_field(&[("doc-small", 1.0e-40), ("doc-normal", 1.0)]);
+  let req = base_request(QueryNode::RankFeature {
+    field: "weight".into(),
+    boost: Some(1.0),
+    modifier: Some(RankFeatureModifier::Reciprocal),
+    missing: Some(1.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  let hit_ids = ids(&resp);
+  assert!(
+    hit_ids.contains(&"doc-small".to_string()),
+    "doc-small must survive the f64->f32 narrowing cast, got hits {hit_ids:?}"
+  );
+  let doc_small = resp
+    .hits
+    .iter()
+    .find(|h| h.doc_id == "doc-small")
+    .expect("doc-small present");
+  assert!(
+    doc_small.score.is_finite(),
+    "doc-small score must be finite after clamp, got {}",
+    doc_small.score
+  );
+  assert_eq!(
+    doc_small.score,
+    f32::MAX,
+    "doc-small score must be clamped to f32::MAX, got {}",
+    doc_small.score
+  );
+}
+
+#[test]
+fn script_score_large_literal_overflow_preserves_document_with_f32_max() {
+  // The script tokenizer accepts params (validated finite at compile time)
+  // but a finite `f64` param larger than `f32::MAX` saturates to
+  // `f32::INFINITY` on the final `value as f32` cast at the end of
+  // `CompiledScript::evaluate`. Before the fix the hit was dropped; after
+  // the fix the score is clamped to `f32::MAX`.
+  let reader = setup_reader();
+  let mut params = BTreeMap::new();
+  params.insert("big".to_string(), 1.0e40_f64);
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script: "big".into(),
+    params: Some(params),
+    boost: Some(1.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "{} score must be finite after clamp, got {}",
+      hit.doc_id,
+      hit.score
+    );
+    assert_eq!(
+      hit.score,
+      f32::MAX,
+      "{} score must be clamped to f32::MAX, got {}",
+      hit.doc_id,
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn script_score_large_negative_literal_overflow_clamps_to_f32_min() {
+  // Symmetric negative overflow: a finite f64 below `f32::MIN` saturates
+  // to `f32::NEG_INFINITY` on the narrowing cast. The clamp should floor
+  // the result at `f32::MIN` so the hit survives with the closest
+  // representable negative score.
+  let reader = setup_reader();
+  let mut params = BTreeMap::new();
+  params.insert("big".to_string(), -1.0e40_f64);
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script: "big".into(),
+    params: Some(params),
+    boost: Some(1.0),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "{} score must be finite after clamp, got {}",
+      hit.doc_id,
+      hit.score
+    );
+    assert_eq!(
+      hit.score,
+      f32::MIN,
+      "{} score must be clamped to f32::MIN, got {}",
+      hit.doc_id,
+      hit.score
+    );
+  }
+}

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1120,8 +1120,14 @@ fn weight_doc(id: &str, body: &str, weight: f64) -> Document {
   }
 }
 
-fn setup_reader_with_weight_field(weights: &[(&str, f64)]) -> searchlite_core::api::IndexReader {
-  let path = tempfile::tempdir().unwrap().path().join("idx");
+fn setup_reader_with_weight_field(
+  weights: &[(&str, f64)],
+) -> (tempfile::TempDir, searchlite_core::api::IndexReader) {
+  // Keep the `TempDir` alive for the reader's lifetime so the index
+  // directory survives for the duration of the test and is cleaned up
+  // when the caller drops the returned guard.
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().join("idx");
   let mut schema = Schema::default_text_body();
   schema.numeric_fields.push(NumericField {
     name: "weight".into(),
@@ -1148,7 +1154,7 @@ fn setup_reader_with_weight_field(weights: &[(&str, f64)]) -> searchlite_core::a
       .unwrap();
   }
   writer.commit().unwrap();
-  idx.reader().unwrap()
+  (tmp, idx.reader().unwrap())
 }
 
 #[test]
@@ -1159,7 +1165,8 @@ fn field_value_factor_reciprocal_overflow_preserves_document_with_f32_max() {
   // f32::INFINITY, which the downstream non-finite guards rejected,
   // dropping the hit from the result set. After the fix, the value is
   // clamped to f32::MAX and the hit survives.
-  let reader = setup_reader_with_weight_field(&[("doc-small", 1.0e-40), ("doc-normal", 1.0)]);
+  let (_tmp, reader) =
+    setup_reader_with_weight_field(&[("doc-small", 1.0e-40), ("doc-normal", 1.0)]);
   let req = base_request(QueryNode::FunctionScore {
     query: Box::new(QueryNode::MatchAll { boost: None }),
     functions: vec![FunctionSpec::FieldValueFactor {
@@ -1204,7 +1211,8 @@ fn rank_feature_reciprocal_overflow_preserves_document_with_f32_max() {
   // Same overflow trigger as above but routed through the RankFeature
   // score node, which performs the `modified as f32` cast independently of
   // the FunctionScore path.
-  let reader = setup_reader_with_weight_field(&[("doc-small", 1.0e-40), ("doc-normal", 1.0)]);
+  let (_tmp, reader) =
+    setup_reader_with_weight_field(&[("doc-small", 1.0e-40), ("doc-normal", 1.0)]);
   let req = base_request(QueryNode::RankFeature {
     field: "weight".into(),
     boost: Some(1.0),


### PR DESCRIPTION
## Summary

Closes #336.

`CompiledFunction::evaluate`, `apply_rank_modifier`, and
`CompiledScript::evaluate` each validate finitude on the f64 score before
narrowing to `f32` via `as`, but a finite f64 whose magnitude exceeds
`f32::MAX` (~3.4e38) still saturates to `±f32::INFINITY` under Rust's
narrowing cast. Downstream callers in `evaluate_compiled_score` then reject
the non-finite score and silently drop the document from the result set (or,
with `max_boost` set, silently cap to `max_boost` regardless of the actual
field value — a loss of score resolution).

The trigger is reachable in practice via:

- `FieldValueFactor` with the `Reciprocal` modifier on a small field value
  (e.g. `1e-40` reciprocates to `1e40`, overflowing f32).
- `RankFeature` with the `Reciprocal` modifier — same shape, no factor.
- `ScriptScore` when the script evaluates to a finite f64 above `f32::MAX`
  (e.g. a param bound above `f32::MAX`).

This is the same class of bug as BUG-330 (which fixed
`collect_vector_value` for the vector indexing path); this PR covers the
scoring pipeline.

## Changes

- `searchlite-core/src/query/util.rs`: add `f64_to_finite_f32` helper that
  clamps the f64 to the f32 representable range before the cast, mirroring
  the `finite_or_zero` policy used for aggregation finalization.
- `searchlite-core/src/query/score_functions.rs`: use the helper in
  `FieldValueFactor` and `Decay` evaluation.
- `searchlite-core/src/api/scoring.rs`: use the helper in `RankFeature`
  evaluation. The subsequent `* boost` multiplication keeps its existing
  finitude guard for downstream overflow into `f32::INFINITY`.
- `searchlite-core/src/query/script.rs`: use the helper in
  `CompiledScript::evaluate`.

Documents with legitimately large finite f64 function/script/rank_feature
scores now survive with the closest representable f32 score (`f32::MAX` /
`f32::MIN`) instead of being silently dropped.

## Tests

Regression tests added in `searchlite-core/tests/function_score.rs`:

- `field_value_factor_reciprocal_overflow_preserves_document_with_f32_max`
  — weight `1e-40`, Reciprocal → `1e40`, clamp to `f32::MAX`.
- `rank_feature_reciprocal_overflow_preserves_document_with_f32_max` — same
  shape routed through the RankFeature score node.
- `script_score_large_literal_overflow_preserves_document_with_f32_max` —
  param `1e40` flows through `CompiledScript::evaluate`.
- `script_score_large_negative_literal_overflow_clamps_to_f32_min` —
  symmetric negative overflow clamps to `f32::MIN`.

Unit tests for `f64_to_finite_f32` in `searchlite-core/src/query/util.rs`
cover the positive / negative overflow, in-range, `f64::INFINITY`,
`f64::NAN`, and subnormal cases.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` —
  clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D
  warnings` — clean
- `cargo test -p searchlite-core` — every suite green (444 lib tests + 35
  function_score tests including 4 new + all other suites).
