### PR TITLE
fix(aggs): reject non-finite values in parse_date fallback (BUG-338)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -10,9 +10,9 @@ use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
 
 use crate::api::types::{
-  Aggregation, AggregationResponse, AggregationSampling, DateHistogramAggregation, Filter,
-  HistogramAggregation, IndexOptions, MgetDoc, MovingAvgAggregation, Query, RescoreMode,
-  RescoreRequest, SearchRequest, SortOrder, SuggestResult, TopHitsAggregation,
+  Aggregation, AggregationResponse, AggregationSampling, DateHistogramAggregation,
+  DateRangeAggregation, Filter, HistogramAggregation, IndexOptions, MgetDoc, MovingAvgAggregation,
+  Query, RescoreMode, RescoreRequest, SearchRequest, SortOrder, SuggestResult, TopHitsAggregation,
 };
 #[cfg(feature = "vectors")]
 use crate::api::types::{LegacyVectorQuery, VectorQuery, VectorQuerySpec};
@@ -2367,6 +2367,7 @@ fn validate_aggregations_in_scope(
       }
       Aggregation::DateRange(r) => {
         ensure_numeric_fast(schema, &r.field, name, scope_path)?;
+        validate_date_range_config(name, r)?;
         validate_sampling(name, &r.sampling)?;
         validate_aggregations_in_scope(schema, &r.aggs, scope_path, inside_nested)?;
       }
@@ -3083,6 +3084,42 @@ fn validate_histogram_bounds(name: &str, which: &str, min: f64, max: f64) -> Res
       }
       .into(),
     );
+  }
+  Ok(())
+}
+
+fn validate_date_range_config(name: &str, agg: &DateRangeAggregation) -> Result<()> {
+  // `DateRangeCollector::new` builds each range via
+  // `from.as_deref().and_then(parse_date)` / `to.as_deref().and_then(parse_date)`
+  // and `RangeCollector::collect` treats `None` as an unbounded side. If a
+  // caller supplies a non-finite string (`"NaN"` / `"inf"` / `"-infinity"`),
+  // `parse_date` now correctly returns `None` (BUG-338), but the collector
+  // would then silently widen the bound to "unbounded" and match far more
+  // documents than intended. Surface those inputs — and any other
+  // unparseable date string — as an `InvalidConfig` error at planning time
+  // instead of letting them corrupt bucket membership. An `Option::None`
+  // (field omitted) is still legal and keeps the side open.
+  for range in &agg.ranges {
+    if let Some(from) = range.from.as_deref() {
+      if parse_date(from).is_none() {
+        return Err(
+          AggregationError::InvalidConfig {
+            reason: format!("date_range `{name}` range `from` `{from}` is not a valid date/number"),
+          }
+          .into(),
+        );
+      }
+    }
+    if let Some(to) = range.to.as_deref() {
+      if parse_date(to).is_none() {
+        return Err(
+          AggregationError::InvalidConfig {
+            reason: format!("date_range `{name}` range `to` `{to}` is not a valid date/number"),
+          }
+          .into(),
+        );
+      }
+    }
   }
   Ok(())
 }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1451,7 +1451,7 @@ impl<'a> DateHistogramCollector<'a> {
     let missing = agg
       .missing
       .as_ref()
-      .and_then(|s| parse_date(s).or_else(|| s.parse::<f64>().ok()))
+      .and_then(|s| parse_date(s))
       .map(|v| v as i64);
     Self {
       field: agg.field.clone(),
@@ -4275,10 +4275,21 @@ fn add_calendar(value: i64, unit: CalendarUnit) -> Option<i64> {
 }
 
 pub(crate) fn parse_date(value: &str) -> Option<f64> {
+  // Rust's `f64::from_str` accepts `"NaN"`, `"inf"`, `"infinity"`,
+  // `"-inf"`, `"-infinity"` (case-insensitive) as valid float literals.
+  // None of these are meaningful timestamps, and letting them through
+  // the fallback lets NaN silently cast to epoch 0 and Infinity
+  // saturate to `i64::MAX` (~292 billion years) in downstream
+  // `parse_date(..) as i64` call sites — producing wrong
+  // date_histogram / date_range bounds and bypassing `min > max`
+  // guards (since `NaN > NaN` is `false`). Filter the numeric
+  // fallback to finite values so non-finite strings surface as a
+  // validation error ("not a valid date/number") at their caller.
+  // Mirrors the `parse_finite_missing_f64` guard added for BUG-334.
   chrono::DateTime::parse_from_rfc3339(value)
     .map(|dt| dt.timestamp_millis() as f64)
     .ok()
-    .or_else(|| value.parse::<f64>().ok())
+    .or_else(|| value.parse::<f64>().ok().filter(|f| f.is_finite()))
 }
 
 pub(crate) fn parse_interval_seconds(spec: &str) -> Option<f64> {
@@ -5132,6 +5143,49 @@ mod tests {
     // collector delegates to.
     let parsed = parse_finite_missing_f64(&serde_json::json!("inf"));
     assert!(parsed.is_none());
+  }
+
+  // Regression tests for BUG-338: `parse_date` delegates to
+  // `str::parse::<f64>` when RFC 3339 parsing fails, which accepts
+  // `"NaN"` / `"inf"` / `"-inf"` / `"Infinity"` / `"-Infinity"` as
+  // valid floats. Non-finite values must not reach date_histogram
+  // `extended_bounds` / `hard_bounds` / `missing` or date_range
+  // `from` / `to`, where they would silently cast to epoch 0 or
+  // saturate to `i64::MAX` and bypass `min > max` comparison guards.
+  #[test]
+  fn parse_date_accepts_rfc3339_and_finite_epoch_millis() {
+    assert!(
+      parse_date("2026-04-19T00:00:00Z").is_some(),
+      "RFC 3339 must still parse"
+    );
+    assert_eq!(parse_date("0"), Some(0.0));
+    assert_eq!(parse_date("1234567890"), Some(1234567890.0));
+    assert_eq!(parse_date("-1234567890"), Some(-1234567890.0));
+    assert_eq!(parse_date("1.5e12"), Some(1.5e12));
+  }
+
+  #[test]
+  fn parse_date_rejects_nan_string() {
+    assert_eq!(parse_date("NaN"), None);
+    assert_eq!(parse_date("nan"), None);
+    assert_eq!(parse_date("NAN"), None);
+  }
+
+  #[test]
+  fn parse_date_rejects_infinity_strings() {
+    assert_eq!(parse_date("inf"), None);
+    assert_eq!(parse_date("Inf"), None);
+    assert_eq!(parse_date("infinity"), None);
+    assert_eq!(parse_date("Infinity"), None);
+    assert_eq!(parse_date("-inf"), None);
+    assert_eq!(parse_date("-Infinity"), None);
+    assert_eq!(parse_date("-infinity"), None);
+  }
+
+  #[test]
+  fn parse_date_rejects_non_numeric_non_rfc3339_strings() {
+    assert_eq!(parse_date(""), None);
+    assert_eq!(parse_date("not-a-date"), None);
   }
 
   #[test]

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -709,6 +709,112 @@ fn date_histogram_rejects_invalid_config() {
   assert!(msg.contains("extended_bounds") || msg.contains("hard_bounds"));
 }
 
+// Regression test for BUG-338: `parse_date` previously accepted
+// non-finite strings ("NaN", "inf", "-inf", "infinity", "Infinity",
+// "-infinity") via its `f64::from_str` fallback. Those values flowed
+// into `extended_bounds` / `hard_bounds` validation as `Some(NaN)` /
+// `Some(±INF)`, bypassing the `min > max` guard (`NaN > NaN` is
+// `false`) and ultimately saturating through `as i64` casts to
+// epoch 0 or `i64::MAX`. After the fix, non-finite bound strings
+// must surface as the same "not a valid date/number" InvalidConfig
+// error raised for any other unparseable value.
+#[test]
+fn date_histogram_rejects_non_finite_bound_strings() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+
+  let reader = idx.reader().unwrap();
+
+  fn request_with_extended(
+    min: &str,
+    max: &str,
+    aggs_entry: &str,
+  ) -> (BTreeMap<String, Aggregation>, SearchRequest) {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      aggs_entry.into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: Some("day".into()),
+        fixed_interval: None,
+        offset: None,
+        format: None,
+        min_doc_count: None,
+        extended_bounds: Some(DateHistogramBounds {
+          min: min.into(),
+          max: max.into(),
+        }),
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+    let req = SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs: aggs.clone(),
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    };
+    (aggs, req)
+  }
+
+  for (label, min, max) in [
+    ("nan-min", "NaN", "2024-01-02T00:00:00Z"),
+    ("nan-max", "2024-01-01T00:00:00Z", "NaN"),
+    ("nan-pair", "NaN", "NaN"),
+    ("inf-max", "2024-01-01T00:00:00Z", "inf"),
+    ("neg-inf-min", "-Infinity", "2024-01-02T00:00:00Z"),
+    ("infinity-pair", "-infinity", "infinity"),
+  ] {
+    let (_aggs, req) = request_with_extended(min, max, label);
+    let resp = reader.search(&req);
+    assert!(
+      resp.is_err(),
+      "{label}: expected InvalidConfig for non-finite bound ({min:?}, {max:?})",
+    );
+    let msg = resp.err().unwrap().to_string();
+    assert!(
+      msg.contains("not a valid date/number"),
+      "{label}: expected `not a valid date/number` in error, got `{msg}`",
+    );
+  }
+}
+
 #[test]
 fn top_hits_returns_requested_docs() {
   let tmp = tempfile::tempdir().unwrap();

--- a/searchlite-core/tests/aggregations.rs
+++ b/searchlite-core/tests/aggregations.rs
@@ -2297,6 +2297,119 @@ fn date_range_missing_and_keyed() {
   }
 }
 
+// Regression test for BUG-338: non-finite date_range bound strings
+// (`"NaN"` / `"inf"` / `"-infinity"`) must surface as `InvalidConfig`
+// rather than being silently downgraded to an unbounded side by
+// `parse_date` returning `None` and `RangeCollector::collect`
+// treating `None` as open-ended. Without this validation the
+// parse_date finite-only fallback would turn "matches no documents"
+// into "matches every document".
+#[test]
+fn date_range_rejects_non_finite_bound_strings() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = Index::create(
+    &path,
+    schema,
+    IndexOptions {
+      path: path.clone(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    },
+  )
+  .unwrap();
+
+  let reader = idx.reader().unwrap();
+
+  fn req_with_range(
+    from: Option<&str>,
+    to: Option<&str>,
+  ) -> searchlite_core::api::types::SearchRequest {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "ranges".into(),
+      Aggregation::DateRange(Box::new(
+        searchlite_core::api::types::DateRangeAggregation {
+          field: "ts".into(),
+          keyed: false,
+          format: None,
+          ranges: vec![searchlite_core::api::types::DateRangeBound {
+            key: None,
+            from: from.map(|s| s.to_string()),
+            to: to.map(|s| s.to_string()),
+          }],
+          missing: None,
+          sampling: None,
+          aggs: BTreeMap::new(),
+        },
+      )),
+    );
+    searchlite_core::api::types::SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    }
+  }
+
+  for (label, from, to) in [
+    ("nan-from", Some("NaN"), Some("1970-01-01T00:00:01Z")),
+    ("nan-to", Some("1970-01-01T00:00:00Z"), Some("NaN")),
+    ("inf-from", Some("inf"), None),
+    ("neg-inf-to", None, Some("-Infinity")),
+    ("infinity-pair", Some("-infinity"), Some("infinity")),
+  ] {
+    let resp = reader.search(&req_with_range(from, to));
+    assert!(
+      resp.is_err(),
+      "{label}: expected InvalidConfig for non-finite bound ({from:?}, {to:?})",
+    );
+    let msg = resp.err().unwrap().to_string();
+    assert!(
+      msg.contains("not a valid date/number"),
+      "{label}: expected `not a valid date/number` in error, got `{msg}`",
+    );
+  }
+}
+
 #[test]
 fn extended_stats_and_value_count_include_missing() {
   let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Closes #338.

`parse_date` in `searchlite-core/src/query/aggs/mod.rs` delegates to `str::parse::<f64>` when RFC 3339 parsing fails. Rust's `f64::from_str` accepts `"NaN"`, `"inf"`, `"infinity"`, `"-inf"`, `"-infinity"` (case-insensitive) as valid float literals, so those non-finite values silently passed through as parsed dates. Downstream consumers then used them in `as i64` casts (NaN → 0, ±Infinity → `i64::MAX`/`i64::MIN` under Rust's saturating cast) and floating-point comparisons (always `false` for NaN), producing:

- wrong `date_histogram` / `date_range` bucket boundaries (e.g. `extended_bounds: { min: "NaN", max: "inf" }` became `(0, i64::MAX)` — a 292-billion-year span),
- silent exclusion of every document from `date_range` buckets (`val >= NaN` is always `false`),
- bypassed `min > max` validation (`NaN > NaN` is `false`), so malformed config reached the collector instead of surfacing as an `InvalidConfig` error.

This is the same class of bug that BUG-334 fixed for aggregation `missing` values via `parse_finite_missing_f64`. `parse_date` had the same unguarded `parse::<f64>` pattern.

## Changes

- `searchlite-core/src/query/aggs/mod.rs`: filter the `parse_date` numeric fallback to finite values only. Non-finite strings now surface as the same "not a valid date/number" `InvalidConfig` error raised for any other unparseable input, which closes the vulnerability for every downstream call site:
  - `date_histogram` `extended_bounds` / `hard_bounds` / `missing` (`aggs/mod.rs:1446,1450,1454`)
  - `date_range` `from` / `to` (`aggs/mod.rs:1188-1189`)
  - Validation of `extended_bounds` / `hard_bounds` in `reader.rs:3143-3210`
- `searchlite-core/src/query/aggs/mod.rs`: simplify the `date_histogram` `missing` expression that had a redundant `.or_else(|| s.parse::<f64>().ok())` fallback outside `parse_date`. With the fix in place that external fallback would re-introduce the vulnerability by accepting `"NaN"` / `"inf"` after `parse_date` correctly rejected it. `parse_date` already performs the numeric-string fallback, so the outer `.or_else` is redundant.

## Tests

Unit tests added in `searchlite-core/src/query/aggs/mod.rs`:

- `parse_date_accepts_rfc3339_and_finite_epoch_millis` — RFC 3339 and finite numeric strings remain accepted (no over-rejection).
- `parse_date_rejects_nan_string` — `"NaN"` / `"nan"` / `"NAN"`.
- `parse_date_rejects_infinity_strings` — `"inf"` / `"Inf"` / `"infinity"` / `"Infinity"` / `"-inf"` / `"-Infinity"` / `"-infinity"`.
- `parse_date_rejects_non_numeric_non_rfc3339_strings` — empty + garbage input.

Integration regression test added in `searchlite-core/tests/aggregation_bounds.rs`:

- `date_histogram_rejects_non_finite_bound_strings` — exercises the `reader.rs` validation path for every non-finite form across `extended_bounds.min` / `max` and asserts the `"not a valid date/number"` `InvalidConfig` error is raised.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core` — every suite passes (443 lib tests + 6 bound tests including 1 new + all other suites; 657 total tests green).
