### PR TITLE
fix(vectors): reject non-finite components in query vector (BUG-340)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -487,6 +487,20 @@ impl IndexReader {
           vector_query.vector.len()
         );
       }
+      // Reject non-finite query vector components before they reach
+      // `normalize_in_place` (which yields NaN for cosine when any component
+      // overflows to ±INF) or `metric_similarity` (where L2 surfaces the raw
+      // ±INF into `hit.vector_score` and fails JSON serialization). Mirrors
+      // the write-side guard in `collect_vector_value` (BUG-330).
+      for (idx, value) in vector_query.vector.iter().enumerate() {
+        if !value.is_finite() {
+          bail!(
+            "vector query for field `{}` contains non-finite component at index {}",
+            vector_query.field,
+            idx
+          );
+        }
+      }
       let mut query_vec = vector_query.vector.clone();
       if matches!(
         schema_field.metric,

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -691,3 +691,162 @@ fn rejects_global_cap_below_clause_count() {
     "expected validation error, got {err}"
   );
 }
+
+#[test]
+fn vector_query_with_positive_inf_component_is_rejected() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("rust search")),
+        ("embedding".into(), serde_json::json!([1.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![f32::INFINITY, 0.0],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("non-finite component") && err.contains("embedding"),
+    "expected non-finite component error, got {err}"
+  );
+}
+
+#[test]
+fn vector_query_with_negative_inf_component_is_rejected_for_l2() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("rust vector")),
+        ("embedding".into(), serde_json::json!([0.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    vector_query: Some(VectorQuerySpec::Structured(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![f32::NEG_INFINITY, 0.0],
+      k: Some(3),
+      alpha: Some(0.5),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_filter: None,
+    ..base_request(Query::String("rust".into()), 3)
+  };
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("non-finite component") && err.contains("embedding"),
+    "expected non-finite component error, got {err}"
+  );
+}
+
+#[test]
+fn vector_query_with_nan_component_is_rejected() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("rust search")),
+        ("embedding".into(), serde_json::json!([1.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![0.0, f32::NAN],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("non-finite component") && err.contains("embedding"),
+    "expected non-finite component error, got {err}"
+  );
+}
+
+#[test]
+fn vector_query_with_finite_boundary_components_is_accepted() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("rust vector")),
+        ("embedding".into(), serde_json::json!([0.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  // f32::MAX and f32::MIN are finite boundary values; the validation guard
+  // must not reject them. The downstream L2 distance may saturate to INF
+  // inside `metric_similarity`, but that's a separate concern — this test
+  // only asserts that the request passes the finitude guard.
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![f32::MAX, f32::MIN],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let _ = reader.search(&req).expect("boundary f32 values are finite");
+}


### PR DESCRIPTION
## Summary

Closes #340.

`IndexReader::plan_vectors` in `searchlite-core/src/api/reader.rs` was accepting the caller-provided `VectorQuery::vector` verbatim and passing it through `normalize_in_place` (for the Cosine metric) and into `metric_similarity` / HNSW `search` without validating that each component was finite. An over-range JSON number (e.g. `1e40`) deserializes to a finite `f64` and narrows to `f32` via the default `Deserialize for f32` impl, saturating to `±f32::INFINITY`. Direct Rust/FFI/WASM callers can also construct a `VectorQuery` with `f32::NAN` or `±f32::INFINITY` components.

For the L2 metric the raw `±INF` persists into `hit.vector_score`, which then breaks JSON serialization (`NaN` / `Infinity` are not valid JSON numbers). For Cosine, `normalize_in_place` computes `norm = INF.sqrt() = INF`, then `v /= INF` yields `0.0` for finite components and `NaN` for the offending one; the downstream `dot.is_nan()` guard in `metric_similarity` silently coerces the result to `0.0`, hiding malformed inputs rather than surfacing them.

This is the read/query-side sibling of BUG-330 (PR #331), which added the same-class guard in `collect_vector_value` at insert time. The two guards together keep the contract symmetric — invalid inputs are rejected at the write and read boundaries rather than silently corrupting downstream similarity computations, HNSW traversal, or response serialization.

## Changes

- `searchlite-core/src/api/reader.rs`: validate each component of `vector_query.vector` for finitude inside `plan_vectors`, immediately after the dimension check and before the Cosine `normalize_in_place` call / storage on `VectorClausePlan`. On a non-finite component the function `bail!`s with a message naming the field and the offending index, mirroring the surrounding `bail!` pattern already applied to `alpha` and `boost`.

The check covers all three leak classes:
- finite `f64` magnitude > `f32::MAX` saturating to `±f32::INFINITY` on JSON → `f32` narrowing (the typical leak),
- `f32::NAN` from any caller,
- direct `±f32::INFINITY` construction from FFI / WASM / Rust callers.

A finite `0.0` component is intentionally allowed — a zero query vector is a legitimate edge case that the downstream `norm > 0.0` guard in `normalize_in_place` already handles (skips normalization and returns the zero vector unchanged).

## Tests

Regression tests added in `searchlite-core/tests/vector_search.rs`:

- `vector_query_with_positive_inf_component_is_rejected` — Cosine metric, `QueryNode::Vector` path, `f32::INFINITY` in the first component.
- `vector_query_with_negative_inf_component_is_rejected_for_l2` — L2 metric, `VectorQuerySpec::Structured` hybrid path, `f32::NEG_INFINITY` component.
- `vector_query_with_nan_component_is_rejected` — explicit `f32::NAN` case (not reachable from JSON but reachable from FFI / WASM / Rust callers).
- `vector_query_with_finite_boundary_components_is_accepted` — locks in the boundary so `f32::MAX` / `f32::MIN` pass the guard unchanged, preventing over-rejection of legitimate inputs.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core --features vectors --test vector_search` — 14 / 14 (including 4 new)
- `cargo test -p searchlite-core --features vectors --lib` — 459 / 459
