### PR TITLE
fix(sort): reject non-finite search_after _score after f64→f32 cast (BUG-342)

### DIFF
--- a/searchlite-core/src/query/sort.rs
+++ b/searchlite-core/src/query/sort.rs
@@ -261,7 +261,16 @@ impl SortPlan {
           let f = n
             .as_f64()
             .ok_or_else(|| anyhow::anyhow!("search_after sort value must be number"))?;
-          SortValue::Score(f as f32)
+          // Narrow from f64 to f32 explicitly so a finite JSON number larger
+          // than f32::MAX (which Rust's `as` cast saturates to ±f32::INFINITY)
+          // is rejected here rather than poisoning the sort key and silently
+          // corrupting pagination via `total_cmp`. Mirrors the write-side
+          // guards in BUG-330 (collect_vector_value) and BUG-336 (scoring).
+          let score = f as f32;
+          if !score.is_finite() {
+            bail!("search_after _score value must fit in a finite f32 (received {f})");
+          }
+          SortValue::Score(score)
         }
         (SortField::Keyword(_), Value::String(s)) => SortValue::Str(s.clone()),
         (SortField::I64(_), Value::Number(n)) => {
@@ -487,6 +496,76 @@ mod tests {
     };
     assert!(higher_asc > key_asc);
     assert!(higher_desc < key_desc);
+  }
+
+  fn score_sort_plan() -> SortPlan {
+    let schema = Schema {
+      doc_id_field: crate::index::manifest::default_doc_id_field(),
+      analyzers: Vec::new(),
+      text_fields: Vec::new(),
+      keyword_fields: Vec::new(),
+      numeric_fields: Vec::new(),
+      nested_fields: Vec::new(),
+      #[cfg(feature = "vectors")]
+      vector_fields: Vec::new(),
+    };
+    SortPlan::from_request(&schema, &[]).unwrap()
+  }
+
+  #[test]
+  fn values_from_json_rejects_score_overflow_to_positive_inf() {
+    // `1e40` is a valid finite JSON number (well within f64::MAX) but larger
+    // than f32::MAX, so `f as f32` saturates to `f32::INFINITY`. Feeding that
+    // poisoned value into the sort key via `search_after` silently corrupts
+    // pagination comparisons under `total_cmp`; the decode must bail.
+    let plan = score_sort_plan();
+    let raw = vec![serde_json::json!(1.0e40_f64)];
+    let err = plan.values_from_json(&raw).unwrap_err();
+    assert!(
+      err.to_string().contains("finite f32"),
+      "unexpected error: {err}"
+    );
+  }
+
+  #[test]
+  fn values_from_json_rejects_score_overflow_to_negative_inf() {
+    let plan = score_sort_plan();
+    let raw = vec![serde_json::json!(-1.0e40_f64)];
+    let err = plan.values_from_json(&raw).unwrap_err();
+    assert!(
+      err.to_string().contains("finite f32"),
+      "unexpected error: {err}"
+    );
+  }
+
+  #[test]
+  fn values_from_json_accepts_score_at_f32_max() {
+    // Boundary: `f32::MAX as f64` round-trips through the cast unchanged and
+    // must continue to be accepted so legitimate large-but-finite scores are
+    // not over-rejected.
+    let plan = score_sort_plan();
+    let raw = vec![serde_json::json!(f32::MAX as f64)];
+    let values = plan.values_from_json(&raw).unwrap();
+    assert_eq!(values.len(), 1);
+    match &values[0] {
+      SortValue::Score(v) => {
+        assert!(v.is_finite());
+        assert_eq!(*v, f32::MAX);
+      }
+      other => panic!("expected SortValue::Score, got {other:?}"),
+    }
+  }
+
+  #[test]
+  fn values_from_json_accepts_small_finite_score() {
+    let plan = score_sort_plan();
+    let raw = vec![serde_json::json!(0.5_f64)];
+    let values = plan.values_from_json(&raw).unwrap();
+    assert_eq!(values.len(), 1);
+    match &values[0] {
+      SortValue::Score(v) => assert_eq!(*v, 0.5_f32),
+      other => panic!("expected SortValue::Score, got {other:?}"),
+    }
   }
 
   #[test]


### PR DESCRIPTION
## Summary

Closes #342.

`SortPlan::values_from_json` in `searchlite-core/src/query/sort.rs` was decoding the `_score` value from a user-supplied `search_after` token by reading the JSON number as `f64` via `serde_json::Number::as_f64()` and unconditionally casting to `f32`. A finite JSON `f64` whose magnitude exceeds `f32::MAX` (~3.4e38) saturates to `±f32::INFINITY` under Rust's `as` cast, and the non-finite `SortValue::Score` was threaded into the cursor's `SortKey`, corrupting pagination via `f32::total_cmp`:

- **Descending sort (the common `_score` default):** `+INF` sorts strictly above every finite candidate, so the cursor treats every subsequent document as "already seen" and pagination silently ends early with empty pages.
- **Ascending sort:** `+INF` sorts above everything, so the cursor re-returns the same documents on each page.
- **`-1e40`:** symmetric `-INF` case that inverts the two outcomes.

The three sibling branches (`Keyword`, `I64`, `F64`) were already safe — `as_i64` rejects out-of-range numbers, `F64` stores the value as `f64` without a narrowing cast, and `Keyword` is string-typed. Only the `Score` branch was missing a guard because the `as f32` narrowing cast predated the BUG-330 / BUG-336 finitude-guard sweep.

This is the same class of bug as BUG-330 (`collect_vector_value` silent f64→f32 cast, PR #331) and BUG-336 (scoring-path f64→f32 cast, PR #337), but on the pagination decode path instead of indexing or scoring.

## Changes

- `searchlite-core/src/query/sort.rs`: narrow the f64 to f32 explicitly, then `bail!` if the result is non-finite, mirroring the existing `bail!` branches in the same function for wrong-type sort values. Error message echoes the offending input.

Policy choice: reject with error rather than clamp. The `search_after` token is a response-side artifact — clients are expected to echo back the `f32` value received in `next_search_after`, which is always finite (non-finite hit scores are already dropped by `evaluate_compiled_score` / the BUG-315 guard on `combine_function_scores`). A user-supplied out-of-range value is an API misuse and should surface as a diagnostic, matching the `script_score` / `bucket_script` params pattern (`script.rs:177-178`, `aggs/mod.rs:3657-3658`).

## Tests

Added regression tests in `searchlite-core/src/query/sort.rs::tests`:

- `values_from_json_rejects_score_overflow_to_positive_inf` — `1e40` is a valid finite JSON number (well within `f64::MAX`) but larger than `f32::MAX`; the cast saturates to `f32::INFINITY` and decode must `bail!`.
- `values_from_json_rejects_score_overflow_to_negative_inf` — symmetric `-1e40` / `f32::NEG_INFINITY` case.
- `values_from_json_accepts_score_at_f32_max` — boundary check: `f32::MAX as f64` round-trips through the cast unchanged and must continue to be accepted to avoid over-rejecting legitimate large scores.
- `values_from_json_accepts_small_finite_score` — sanity test for a typical finite score (`0.5`).

## Validation

- `cargo fmt --all` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core --lib` — 451 tests pass (includes 4 new `values_from_json_*` cases)
