### PR TITLE
fix(aggs): reject non-finite values in parse_interval_seconds (BUG-344)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4348,6 +4348,23 @@ pub(crate) fn parse_interval_seconds(spec: &str) -> Option<f64> {
     return None;
   }
   let value: f64 = rest[..idx].parse().ok()?;
+  // Rust's `f64::from_str` returns `Ok(f64::INFINITY)` for numeric
+  // strings whose decimal magnitude exceeds the `f64` range (~1e308),
+  // rather than `Err`. The digit-and-dot prefix filter above prevents
+  // literal `"inf"`/`"NaN"` strings from reaching the parser, but a
+  // sufficiently long all-digit prefix (e.g. 310+ digits) still parses
+  // to infinity. Downstream call sites cast the result to `i64` via
+  // `as i64`, which saturates `f64::INFINITY` to `i64::MAX` — silently
+  // producing `DateInterval::Fixed(i64::MAX)` (all documents collapse
+  // into a single bucket) or an `i64::MAX` offset (every document is
+  // dropped from the aggregation), with no diagnostic for the caller.
+  // Reject non-finite parse results so overflowed intervals/offsets
+  // surface as a parse failure in the caller, mirroring the
+  // `.filter(|f| f.is_finite())` guard added to `parse_date` for
+  // BUG-338.
+  if !value.is_finite() {
+    return None;
+  }
   let suffix = &rest[idx..];
   let mult = match suffix {
     "" | "s" => 1.0,
@@ -4359,6 +4376,12 @@ pub(crate) fn parse_interval_seconds(spec: &str) -> Option<f64> {
     _ => return None,
   };
   let magnitude = value * mult;
+  // Also reject non-finite scaled magnitudes: a finite `value` close to
+  // `f64::MAX` can still overflow to infinity after multiplication by
+  // the unit multiplier (e.g. `604_800.0` for weeks).
+  if !magnitude.is_finite() {
+    return None;
+  }
   Some(if negative { -magnitude } else { magnitude })
 }
 
@@ -4380,6 +4403,43 @@ mod tests {
   fn parse_interval_seconds_rejects_unknown_units() {
     assert_eq!(parse_interval_seconds("5x"), None);
     assert_eq!(parse_interval_seconds("10foo"), None);
+  }
+
+  // Regression tests for BUG-344: `parse_interval_seconds` must reject
+  // non-finite `f64` parse results. Rust's `f64::from_str` returns
+  // `Ok(f64::INFINITY)` for decimal strings whose magnitude exceeds the
+  // `f64` range (~1e308). Without a finitude guard, the infinity
+  // propagates through the unit-multiplier and the downstream
+  // `as i64` cast saturates to `i64::MAX`, silently producing a
+  // degenerate `date_histogram` aggregation (a single bucket at the
+  // offset, or all documents dropped via `i64::MAX` offset).
+  #[test]
+  fn parse_interval_seconds_rejects_overflowing_magnitude() {
+    // A 310-digit integer prefix overflows `f64::MAX` (~1.8e308) and
+    // `f64::from_str` returns `Ok(f64::INFINITY)` rather than `Err`.
+    let huge = "9".repeat(310);
+    assert_eq!(parse_interval_seconds(&huge), None);
+    assert_eq!(parse_interval_seconds(&format!("{huge}h")), None);
+    assert_eq!(parse_interval_seconds(&format!("{huge}ms")), None);
+    assert_eq!(parse_interval_seconds(&format!("-{huge}h")), None);
+    assert_eq!(parse_interval_seconds(&format!("+{huge}h")), None);
+  }
+
+  #[test]
+  fn parse_interval_seconds_rejects_overflow_after_multiplier() {
+    // A finite value close to `f64::MAX` can still overflow to
+    // infinity after scaling by a unit multiplier (weeks = 604_800.0).
+    // The digit-and-dot prefix filter forbids scientific notation, so
+    // we construct the value as `1` followed by 305 zeros (≈1e305),
+    // which is finite. Multiplying by `604_800.0` (weeks) yields
+    // ≈6.048e310, which exceeds `f64::MAX` (~1.7976e308) and rounds to
+    // `f64::INFINITY`.
+    let value = format!("1{}", "0".repeat(305));
+    assert_eq!(parse_interval_seconds(&format!("{value}w")), None);
+    assert_eq!(parse_interval_seconds(&format!("-{value}w")), None);
+    // Sanity check: the same value with a smaller multiplier (ms,
+    // which scales by 0.001) should still parse to a finite result.
+    assert!(parse_interval_seconds(&format!("{value}ms")).is_some_and(|f| f.is_finite()));
   }
 
   // Regression tests for BUG-296: `bucket_sort` by `_key` must compare numeric

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -815,6 +815,164 @@ fn date_histogram_rejects_non_finite_bound_strings() {
   }
 }
 
+// Regression test for BUG-344: `parse_interval_seconds` previously
+// returned `Some(f64::INFINITY)` for duration strings whose numeric
+// prefix overflowed `f64` (~1e308). The callers cast the result to
+// `i64` via `as i64`, which saturates `f64::INFINITY` to `i64::MAX`,
+// silently producing `DateInterval::Fixed(i64::MAX)` (a single bucket
+// at the offset) or an `i64::MAX` offset (every document dropped). The
+// planner-side validator in `validate_date_histogram_config` already
+// rejects `fixed_interval` whose `parse_interval_seconds` result is
+// non-finite, but for `offset` it only checks `parse_interval_seconds
+// .is_none()` — so without the in-function finitude guard, an overflow
+// returned `Some(INFINITY)` and bypassed the check. After the fix,
+// overflow strings parse to `None` and both call sites surface the
+// expected `InvalidConfig` error.
+#[test]
+fn date_histogram_rejects_overflowing_interval_strings() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+  let reader = idx.reader().unwrap();
+
+  // A 310-digit integer prefix overflows `f64::MAX` and `f64::from_str`
+  // returns `Ok(f64::INFINITY)` rather than `Err`.
+  let overflow_digits: String = "9".repeat(310);
+  let overflow_hours = format!("{overflow_digits}h");
+
+  fn base_request(aggs: BTreeMap<String, Aggregation>) -> SearchRequest {
+    SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    }
+  }
+
+  // fixed_interval overflow → "must be a positive duration of at least 1ms"
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "hist".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: None,
+      fixed_interval: Some(overflow_hours.clone()),
+      offset: None,
+      format: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+  let resp = reader.search(&base_request(aggs));
+  assert!(
+    resp.is_err(),
+    "fixed_interval overflow should surface InvalidConfig"
+  );
+  let msg = resp.err().unwrap().to_string();
+  assert!(
+    msg.contains("fixed_interval") && msg.contains("positive duration"),
+    "fixed_interval overflow: expected message about positive duration, got `{msg}`",
+  );
+
+  // offset overflow → "offset `...` is invalid"
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "hist".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: Some("day".into()),
+      fixed_interval: None,
+      offset: Some(overflow_hours.clone()),
+      format: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+  let resp = reader.search(&base_request(aggs));
+  assert!(
+    resp.is_err(),
+    "offset overflow should surface InvalidConfig"
+  );
+  let msg = resp.err().unwrap().to_string();
+  assert!(
+    msg.contains("offset") && msg.contains("invalid"),
+    "offset overflow: expected message about invalid offset, got `{msg}`",
+  );
+
+  // Also exercise the post-multiplier overflow path: a finite `value`
+  // close to `f64::MAX` that overflows after being multiplied by a unit
+  // multiplier (`604_800.0` for weeks).
+  let post_mult_overflow = format!("1{}w", "0".repeat(305));
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "hist".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: Some("day".into()),
+      fixed_interval: None,
+      offset: Some(post_mult_overflow),
+      format: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+  let resp = reader.search(&base_request(aggs));
+  assert!(
+    resp.is_err(),
+    "offset with post-multiplier overflow should surface InvalidConfig",
+  );
+  let msg = resp.err().unwrap().to_string();
+  assert!(
+    msg.contains("offset") && msg.contains("invalid"),
+    "post-mult offset overflow: expected message about invalid offset, got `{msg}`",
+  );
+}
+
 #[test]
 fn top_hits_returns_requested_docs() {
   let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes #344.

`parse_interval_seconds` parses the numeric prefix of a duration string (e.g. `"1h"`, `"30m"`) via `f64::from_str`, which returns `Ok(f64::INFINITY)` — not `Err` — for decimal magnitudes exceeding `f64::MAX` (~1.8e308). The digit-and-dot prefix filter prevents literal `"inf"`/`"NaN"` from reaching the parser, but a sufficiently long all-digit prefix still parses to infinity.

Callers in `DateHistogramCollector::new` cast the result to `i64` via `as i64`, which saturates `f64::INFINITY` to `i64::MAX`, silently producing:
- `DateInterval::Fixed(i64::MAX)` — every document collapses into a single bucket at the offset (`div_euclid(i64::MAX) == 0`), and the fill loop exits immediately on `checked_add` overflow.
- `offset == i64::MAX` — every document is dropped from the aggregation (`value.checked_sub(i64::MAX)` returns `None`).

`validate_date_histogram_config` already guarded `fixed_interval` via `secs.is_finite() && secs > 0.0 && (secs * 1000.0) as i64 >= 1`, but the `offset` branch only checks `parse_interval_seconds(offset).is_none()` — so an overflow previously returned `Some(INFINITY)` and bypassed validation entirely.

## Fix

Reject non-finite results inside `parse_interval_seconds` at two sites, mirroring the guard added to `parse_date` for BUG-338:
1. After `f64::from_str` — catches long digit prefixes that parse directly to infinity.
2. After the unit multiplication — catches finite values close to `f64::MAX` that overflow when scaled by a unit multiplier (e.g. `604_800.0` for weeks).

With this guard, overflow surfaces as `None` at the call site, so both the `fixed_interval` and `offset` validators produce the expected `InvalidConfig` error instead of silently corrupting bucket membership.

## Test plan

- [x] New unit tests `parse_interval_seconds_rejects_overflowing_magnitude` and `parse_interval_seconds_rejects_overflow_after_multiplier` cover the post-parse and post-multiplier overflow paths.
- [x] New integration test `date_histogram_rejects_overflowing_interval_strings` in `aggregation_bounds.rs` verifies that a `date_histogram` request with an overflowing `fixed_interval` or `offset` surfaces the expected `InvalidConfig` error at the planner level.
- [x] All existing `searchlite-core` lib tests and `aggregation_bounds` tests pass.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p searchlite-core --all-targets --no-deps -- -D warnings` clean.