### PR TITLE
fix(aggs): bucket_script div guard rejects only exact zero (BUG-346)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -3682,7 +3682,11 @@ fn eval_rpn(tokens: Vec<ScriptToken>, vars: &BTreeMap<String, f64>) -> Option<f6
           '-' => a - b,
           '*' => a * b,
           '/' => {
-            if b.abs() < 1e-12 {
+            // Only reject exact zero divisors. Small-but-valid non-zero divisors
+            // (e.g. `1e-13`) produce legitimate finite quotients and must be
+            // preserved. Overflow to infinity is handled by the post-operation
+            // `!result.is_finite()` guard below. Mirrors script.rs (BUG-346).
+            if b == 0.0 {
               return None;
             }
             a / b
@@ -4785,10 +4789,47 @@ mod tests {
   }
 
   #[test]
-  fn bucket_script_rejects_near_zero_division() {
+  fn bucket_script_rejects_exact_zero_division() {
     let mut vars = BTreeMap::new();
     vars.insert("a".to_string(), 1.0);
-    vars.insert("b".to_string(), 1e-14);
+    vars.insert("b".to_string(), 0.0);
+    assert!(eval_bucket_script("a / b", &vars).is_none());
+  }
+
+  #[test]
+  fn bucket_script_rejects_negative_zero_division() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 1.0);
+    vars.insert("b".to_string(), -0.0);
+    assert!(eval_bucket_script("a / b", &vars).is_none());
+  }
+
+  // BUG-346: previously the epsilon guard `b.abs() < 1e-12` silently rejected
+  // valid small divisors. Division by a small but non-zero finite divisor must
+  // produce the correct finite quotient.
+  #[test]
+  fn bucket_script_accepts_small_non_zero_divisor() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 1.0);
+    vars.insert("b".to_string(), 1e-13);
+    let value = eval_bucket_script("a / b", &vars).unwrap();
+    assert!((value - 1e13).abs() < 1.0);
+  }
+
+  #[test]
+  fn bucket_script_accepts_tiny_numerator_and_denominator() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), 1e-20);
+    vars.insert("b".to_string(), 1e-13);
+    let value = eval_bucket_script("a / b", &vars).unwrap();
+    assert!((value - 1e-7).abs() < 1e-15);
+  }
+
+  #[test]
+  fn bucket_script_rejects_overflow_to_infinity() {
+    let mut vars = BTreeMap::new();
+    vars.insert("a".to_string(), f64::MAX);
+    vars.insert("b".to_string(), f64::MIN_POSITIVE);
     assert!(eval_bucket_script("a / b", &vars).is_none());
   }
 


### PR DESCRIPTION
Closes #346

## Summary

`eval_rpn`'s division branch in `bucket_script` used `b.abs() < 1e-12` as its divisor guard, which silently rejected **valid** small-but-non-zero divisors. The sibling evaluator in `query/script.rs` already does the correct thing: reject only exact zero and rely on the post-operation `!result.is_finite()` check to catch overflow.

### Before (buggy)

```rust
'/' => {
    if b.abs() < 1e-12 {   // rejects any |b| < 1e-12, including valid divisors
        return None;
    }
    a / b
}
```

`eval_bucket_script("a / b", {a: 1.0, b: 1e-13})` returned `None` even though the quotient `1e13` is a perfectly finite `f64`. In a pipeline-aggregation context this surfaced as a silently-missing metric on the affected bucket, with no error.

### After (fixed)

```rust
'/' => {
    if b == 0.0 {
        return None;
    }
    a / b
}
```

Overflow to infinity (e.g. `f64::MAX / f64::MIN_POSITIVE`) is still caught by the existing `!result.is_finite()` guard immediately below the match.

## Changes

- `searchlite-core/src/query/aggs/mod.rs` — replace epsilon divisor guard with `b == 0.0`, mirroring `script.rs`.
- Replace the `bucket_script_rejects_near_zero_division` test (which codified the wrong behavior) with:
  - `bucket_script_rejects_exact_zero_division` — `b = 0.0` still returns None.
  - `bucket_script_rejects_negative_zero_division` — `b = -0.0` still returns None.
  - `bucket_script_accepts_small_non_zero_divisor` — `1.0 / 1e-13 ≈ 1e13` now succeeds.
  - `bucket_script_accepts_tiny_numerator_and_denominator` — `1e-20 / 1e-13 ≈ 1e-7` now succeeds.
  - `bucket_script_rejects_overflow_to_infinity` — overflow still rejected by the existing finite guard.

## Test plan

- [x] `cargo test -p searchlite-core --lib bucket_script` — 28 passed, 0 failed
- [x] `cargo test --workspace --all-features` — all green
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean