### PR TITLE
fix(analysis): emit multi-token synonyms at first-match position (BUG-347)

### DIFF
--- a/searchlite-core/src/analysis/analyzer.rs
+++ b/searchlite-core/src/analysis/analyzer.rs
@@ -398,9 +398,11 @@ fn expand_synonyms(tokens: Vec<Token>, rules: &[SynonymRule]) -> Vec<Token> {
         .zip(tokens[i..].iter())
         .all(|(from, tok)| from == &tok.text)
       {
-        for offset in 0..rule.from.len() {
-          out.push(tokens[i + offset].clone());
-        }
+        // Emit the first matched token, then the synonyms sharing its
+        // position, then the remaining matched tokens. Placing the synonyms
+        // immediately after the first match keeps the position sequence
+        // monotonic so `resequence_positions` coalesces them correctly.
+        out.push(tokens[i].clone());
         if !rule.to.is_empty() {
           let pos = tokens[i].position;
           for to in rule.to.iter() {
@@ -409,6 +411,9 @@ fn expand_synonyms(tokens: Vec<Token>, rules: &[SynonymRule]) -> Vec<Token> {
               position: pos,
             });
           }
+        }
+        for offset in 1..rule.from.len() {
+          out.push(tokens[i + offset].clone());
         }
         i += rule.from.len();
         matched = true;
@@ -556,6 +561,93 @@ mod tests {
         ("new".into(), 0),
         ("york".into(), 0),
         ("subway".into(), 1)
+      ]
+    );
+  }
+
+  #[test]
+  fn synonyms_multi_token_from_shares_first_match_position() {
+    let tokens = analyze_with(
+      vec![TokenFilterDef::Synonyms(vec![SynonymRule {
+        from: vec!["new".into(), "york".into()],
+        to: vec!["nyc".into()],
+      }])],
+      "hello new york subway",
+    );
+    let texts: Vec<(String, u32)> = tokens.into_iter().map(|t| (t.text, t.position)).collect();
+    assert_eq!(
+      texts,
+      vec![
+        ("hello".into(), 0),
+        ("new".into(), 1),
+        ("nyc".into(), 1),
+        ("york".into(), 2),
+        ("subway".into(), 3),
+      ]
+    );
+  }
+
+  #[test]
+  fn synonyms_multi_token_from_multi_token_to_shares_first_match_position() {
+    let tokens = analyze_with(
+      vec![TokenFilterDef::Synonyms(vec![SynonymRule {
+        from: vec!["new".into(), "york".into()],
+        to: vec!["big".into(), "apple".into()],
+      }])],
+      "hello new york subway",
+    );
+    let texts: Vec<(String, u32)> = tokens.into_iter().map(|t| (t.text, t.position)).collect();
+    assert_eq!(
+      texts,
+      vec![
+        ("hello".into(), 0),
+        ("new".into(), 1),
+        ("big".into(), 1),
+        ("apple".into(), 1),
+        ("york".into(), 2),
+        ("subway".into(), 3),
+      ]
+    );
+  }
+
+  #[test]
+  fn synonyms_multi_token_from_at_input_start() {
+    let tokens = analyze_with(
+      vec![TokenFilterDef::Synonyms(vec![SynonymRule {
+        from: vec!["new".into(), "york".into()],
+        to: vec!["nyc".into()],
+      }])],
+      "new york city",
+    );
+    let texts: Vec<(String, u32)> = tokens.into_iter().map(|t| (t.text, t.position)).collect();
+    assert_eq!(
+      texts,
+      vec![
+        ("new".into(), 0),
+        ("nyc".into(), 0),
+        ("york".into(), 1),
+        ("city".into(), 2),
+      ]
+    );
+  }
+
+  #[test]
+  fn synonyms_multi_token_from_empty_to_drops_nothing() {
+    let tokens = analyze_with(
+      vec![TokenFilterDef::Synonyms(vec![SynonymRule {
+        from: vec!["new".into(), "york".into()],
+        to: vec![],
+      }])],
+      "hello new york subway",
+    );
+    let texts: Vec<(String, u32)> = tokens.into_iter().map(|t| (t.text, t.position)).collect();
+    assert_eq!(
+      texts,
+      vec![
+        ("hello".into(), 0),
+        ("new".into(), 1),
+        ("york".into(), 2),
+        ("subway".into(), 3),
       ]
     );
   }

--- a/searchlite-core/tests/analyzers.rs
+++ b/searchlite-core/tests/analyzers.rs
@@ -122,6 +122,65 @@ fn search_analyzer_expands_synonyms() {
 }
 
 #[test]
+fn multi_token_synonym_preserves_phrase_matching() {
+  let dir = tempfile::tempdir().unwrap();
+  let path = dir.path().join("idx");
+  let schema = Schema {
+    doc_id_field: "_id".into(),
+    analyzers: vec![AnalyzerDef {
+      name: "synonyms".into(),
+      tokenizer: "default".into(),
+      filters: vec![TokenFilterDef::Synonyms(vec![SynonymRule {
+        from: vec!["new".into(), "york".into()],
+        to: vec!["nyc".into()],
+      }])],
+    }],
+    text_fields: vec![TextField {
+      name: "body".into(),
+      analyzer: "synonyms".into(),
+      search_analyzer: Some("default".into()),
+      stored: true,
+      indexed: true,
+      nullable: false,
+      search_as_you_type: None,
+    }],
+    keyword_fields: Vec::new(),
+    numeric_fields: Vec::new(),
+    nested_fields: Vec::new(),
+    #[cfg(feature = "vectors")]
+    vector_fields: Vec::new(),
+  };
+  let idx = Index::create(&path, schema, opts(&path)).unwrap();
+  let mut writer = idx.writer().unwrap();
+  let docs = vec![
+    Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("hello new york subway")),
+      ]
+      .into_iter()
+      .collect(),
+    },
+    Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-2")),
+        ("body".into(), serde_json::json!("boston metro")),
+      ]
+      .into_iter()
+      .collect(),
+    },
+  ];
+  for doc in docs {
+    writer.add_document(&doc).unwrap();
+  }
+  writer.commit().unwrap();
+  let reader = idx.reader().unwrap();
+  let resp = reader.search(&request("\"hello nyc\"")).unwrap();
+  let got = ids(&resp);
+  assert_eq!(got, vec!["doc-1".to_string()]);
+}
+
+#[test]
 fn edge_ngram_index_analyzer_supports_prefix_queries() {
   let dir = tempfile::tempdir().unwrap();
   let path = dir.path().join("idx");


### PR DESCRIPTION
## Summary

Closes #347.

`expand_synonyms` emitted multi-token `from` matches followed by their synonym replacements, producing a non-monotonic position sequence (e.g. `[hello(0), new(1), york(2), nyc(1), subway(3)]`). `resequence_positions` only coalesces consecutive tokens that share a source position, so it assigned the synonym token a new sequential position (3) instead of sharing position 1 with the first matched token. Phrase queries spanning a multi-token compound synonym silently returned zero hits.

Concrete trigger: a document indexed as `"hello new york subway"` under a `from=[new, york], to=[nyc]` rule would not match the phrase query `"hello nyc"` because `nyc` landed at position 3 instead of 1, making the hello→nyc gap `3` instead of `1` (rejected by the default slop-0 phrase matcher).

### Fix

Emit the first matched token, then the synonym tokens sharing its position, then the remaining matched tokens. The resulting pre-resequencing sequence becomes `[hello(0), new(1), nyc(1), york(2), subway(3)]` — monotonic, so `resequence_positions` coalesces `nyc` with `new` at position 1.

Behavior for single-token `from` rules is unchanged: the first (and only) matched token is emitted, then the synonyms at its position, then nothing — identical to the previous code.

## Changes

- `searchlite-core/src/analysis/analyzer.rs` — `expand_synonyms` now interleaves synonyms between the first and remaining matched tokens.

## Tests

- `searchlite-core/src/analysis/analyzer.rs`:
  - `synonyms_multi_token_from_shares_first_match_position` — `[new, york] -> [nyc]` at non-start position.
  - `synonyms_multi_token_from_multi_token_to_shares_first_match_position` — `[new, york] -> [big, apple]` all share pos 1.
  - `synonyms_multi_token_from_at_input_start` — match at index 0 aligns with `hello`-style sequence.
  - `synonyms_multi_token_from_empty_to_drops_nothing` — `to=[]` leaves the matched tokens intact.
  - Existing `synonyms_expand_without_position_gap` still passes (single-token `from` path).
- `searchlite-core/tests/analyzers.rs`:
  - `multi_token_synonym_preserves_phrase_matching` — end-to-end phrase query `"hello nyc"` against `"hello new york subway"` indexed with `from=[new, york] to=[nyc]` now matches. Verified this test fails without the fix and passes with it.

## Validation

- `cargo test -p searchlite-core` — all suites green (457 lib + every integration suite passes).
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — clean.