### PR TITLE
fix(score): reject f64-overflow number literals in script_score (BUG-352)

### DIFF
--- a/searchlite-core/src/query/script.rs
+++ b/searchlite-core/src/query/script.rs
@@ -251,9 +251,20 @@ fn read_number_literal(first: char, chars: &mut Peekable<Chars<'_>>) -> Result<f
   if digit_count == 0 {
     bail!("invalid number literal `{num}`");
   }
-  num
+  // `str::parse::<f64>` returns `Ok(f64::INFINITY)` for decimal strings whose
+  // magnitude exceeds `f64::MAX` (~1.8e308) instead of surfacing an error, so
+  // a 309+ digit literal would otherwise compile to `Instruction::PushConst(
+  // f64::INFINITY)` and silently drop the document at evaluate time. Reject
+  // the overflow here, matching the parse-time policy used by `params`
+  // validation below (`"script_score param must be finite"`) and by BUG-334 /
+  // BUG-338 / BUG-344 for sibling `str::parse::<f64>` sites.
+  let value: f64 = num
     .parse::<f64>()
-    .map_err(|_| anyhow!("invalid number literal `{num}`"))
+    .map_err(|_| anyhow!("invalid number literal `{num}`"))?;
+  if !value.is_finite() {
+    bail!("number literal `{num}` overflows to infinity");
+  }
+  Ok(value)
 }
 
 fn tokenize(input: &str) -> Result<Vec<Token>> {

--- a/searchlite-core/src/query/script.rs
+++ b/searchlite-core/src/query/script.rs
@@ -256,7 +256,7 @@ fn read_number_literal(first: char, chars: &mut Peekable<Chars<'_>>) -> Result<f
   // a 309+ digit literal would otherwise compile to `Instruction::PushConst(
   // f64::INFINITY)` and silently drop the document at evaluate time. Reject
   // the overflow here, matching the parse-time policy used by `params`
-  // validation below (`"script_score param must be finite"`) and by BUG-334 /
+  // validation below, which also rejects non-finite values, and by BUG-334 /
   // BUG-338 / BUG-344 for sibling `str::parse::<f64>` sites.
   let value: f64 = num
     .parse::<f64>()

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1097,3 +1097,120 @@ fn rescore_sort_window_excludes_non_rescored_after_removal() {
     doc2.score
   );
 }
+
+// BUG-352: `read_number_literal` called `num.parse::<f64>()` without
+// validating that the parsed value was finite. Rust's `str::parse::<f64>`
+// returns `Ok(f64::INFINITY)` for decimal strings whose magnitude exceeds
+// `f64::MAX` (~1.8e308) instead of surfacing an error, so a 309+ digit
+// literal embedded in a script compiled to `Instruction::PushConst(
+// f64::INFINITY)`. The eval-time guards in `CompiledScript::evaluate` then
+// rejected the value and returned `None`, silently dropping every matching
+// document with no error surfaced to the caller. The fix rejects the
+// literal at compile time, matching the policy already used for
+// `script_score` `params` validation and the BUG-334/BUG-338/BUG-344
+// sibling `str::parse::<f64>` fixes.
+
+fn overflow_literal(extra_zeros: usize) -> String {
+  // A plain digit string long enough to exceed f64::MAX (~1.8e308). 309
+  // digits is the minimum; pad further so we are well above the boundary
+  // and still well under `MAX_SCRIPT_LENGTH = 512`.
+  let mut s = String::with_capacity(1 + extra_zeros);
+  s.push('1');
+  s.extend(std::iter::repeat_n('0', extra_zeros));
+  s
+}
+
+#[test]
+fn script_score_overflow_number_literal_is_rejected_at_compile_time() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script: overflow_literal(310),
+    params: None,
+    boost: Some(1.0),
+  });
+  let err = reader.search(&req).expect_err(
+    "script_score with an f64-overflow number literal must surface a clear error, not silently drop hits",
+  );
+  let msg = format!("{err:#}");
+  assert!(
+    msg.contains("overflows to infinity"),
+    "error should mention overflow to infinity, got: {msg}"
+  );
+}
+
+#[test]
+fn script_score_overflow_number_literal_in_expression_is_rejected_at_compile_time() {
+  // The overflow surfaces regardless of where the literal appears in the
+  // script: an operator-embedded literal would previously have compiled
+  // cleanly and been caught only by an eval-time op guard, silently
+  // dropping the hit.
+  let reader = setup_reader();
+  let script = format!("{} - popularity", overflow_literal(310));
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script,
+    params: None,
+    boost: Some(1.0),
+  });
+  let err = reader
+    .search(&req)
+    .expect_err("operator-embedded f64-overflow literal must also surface a compile-time error");
+  let msg = format!("{err:#}");
+  assert!(
+    msg.contains("overflows to infinity"),
+    "error should mention overflow to infinity, got: {msg}"
+  );
+}
+
+#[test]
+fn script_score_negative_overflow_number_literal_is_rejected_at_compile_time() {
+  // Unary `-` consumes the digit string via `read_number_literal` before
+  // negating, so the finitude check in `read_number_literal` catches the
+  // overflow before the negation site ever sees the infinity.
+  let reader = setup_reader();
+  let script = format!("-{}", overflow_literal(310));
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script,
+    params: None,
+    boost: Some(1.0),
+  });
+  let err = reader
+    .search(&req)
+    .expect_err("negated f64-overflow literal must surface a compile-time error");
+  let msg = format!("{err:#}");
+  assert!(
+    msg.contains("overflows to infinity"),
+    "error should mention overflow to infinity, got: {msg}"
+  );
+}
+
+#[test]
+fn script_score_large_but_finite_literal_is_accepted() {
+  // Boundary check: a large-but-finite literal within f64 range must still
+  // compile and execute. Guards against an over-eager finitude check that
+  // would reject legitimate scripts. The literal used here is ~1e50 which
+  // parses to a finite f64; multiplying by 0 collapses it before the f32
+  // narrowing cast, so the final score is `popularity` which fits in f32.
+  let reader = setup_reader();
+  let script = format!("{} * 0 + popularity", "1".to_string() + &"0".repeat(50));
+  let req = base_request(QueryNode::ScriptScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    script,
+    params: None,
+    boost: Some(1.0),
+  });
+  let resp = reader
+    .search(&req)
+    .expect("finite large literal must compile and execute cleanly");
+  assert_eq!(resp.hits.len(), 3);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "{} score must be finite, got {}",
+      hit.doc_id,
+      hit.score
+    );
+  }
+}

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1111,9 +1111,11 @@ fn rescore_sort_window_excludes_non_rescored_after_removal() {
 // sibling `str::parse::<f64>` fixes.
 
 fn overflow_literal(extra_zeros: usize) -> String {
-  // A plain digit string long enough to exceed f64::MAX (~1.8e308). 309
-  // digits is the minimum; pad further so we are well above the boundary
-  // and still well under `MAX_SCRIPT_LENGTH = 512`.
+  // Construct `1` followed by `extra_zeros` zeros (i.e. `10^extra_zeros`).
+  // For this specific pattern overflow to f64::INFINITY starts at
+  // `extra_zeros >= 309` (310 digits total, since `10^309 > f64::MAX`);
+  // pad further so we are well above the boundary and still well under
+  // `MAX_SCRIPT_LENGTH = 512`.
   let mut s = String::with_capacity(1 + extra_zeros);
   s.push('1');
   s.extend(std::iter::repeat_n('0', extra_zeros));


### PR DESCRIPTION
## Summary

Closes #352.

`read_number_literal` in `searchlite-core/src/query/script.rs` called
`num.parse::<f64>()` and returned the result verbatim, but Rust's
`str::parse::<f64>` returns `Ok(f64::INFINITY)` for decimal strings whose
magnitude exceeds `f64::MAX` (~1.8e308) rather than surfacing an error.
A 309+ digit literal therefore compiled cleanly to
`Instruction::PushConst(f64::INFINITY)`, which the eval-time finitude
guards in `CompiledScript::evaluate` then caught and converted to
`None` — silently dropping every matching document with no error
surfaced to the caller. The overflow surfaces regardless of where the
literal appears in the script: operator-embedded variants
(`HUGE - x`, `HUGE * 0`, `HUGE / HUGE`) drop hits through the same path
because `INF - x`, `INF * 0 = NaN`, and `INF / INF = NaN` all fail the
op-level guards.

The parse-time policy for `script_score` `params` at
`script.rs:177-179` (`bail!("script_score param must be finite")`)
already rejects non-finite values. Every sibling `str::parse::<f64>`
site in the codebase — BUG-334 (`missing`), BUG-338 (`parse_date`
fallback), BUG-344 (`parse_interval_seconds`) — was likewise fixed by
adding an `is_finite()` gate. The script_score number literal parser
was the only remaining `str::parse::<f64>` site in the scoring
pipeline without the same gate.

## Changes

- `searchlite-core/src/query/script.rs`: after `num.parse::<f64>()` in
  `read_number_literal`, reject a non-finite result with
  `bail!("number literal `{num}` overflows to infinity")`. The check
  runs before the value is wrapped in `Token::Number(..)` so the
  compiler surfaces a specific, actionable error that references the
  offending literal rather than silently compiling an
  `Instruction::PushConst(f64::INFINITY)` that drops documents at
  evaluate time.

The change is minimal (one guard + a rationale comment) and mirrors
the `params`-validation style immediately below in the same file.

## Tests

Four regression tests added to
`searchlite-core/tests/function_score.rs`:

- `script_score_overflow_number_literal_is_rejected_at_compile_time`
  — bare 310-digit literal surfaces the new compile-time error instead
  of a silently empty result set.
- `script_score_overflow_number_literal_in_expression_is_rejected_at_compile_time`
  — operator-embedded overflow (`HUGE - popularity`) is caught at
  parse time, before the eval-level op guard has a chance to mask it
  as a silent drop.
- `script_score_negative_overflow_number_literal_is_rejected_at_compile_time`
  — unary negation of an overflowing literal surfaces the error via
  the same `read_number_literal` path (negation consumes the digit
  string before negating).
- `script_score_large_but_finite_literal_is_accepted` — boundary
  check that a large-but-finite literal (~1e50) still compiles and
  runs cleanly, guarding against an over-eager finitude filter.

## Validation

- `cargo fmt --all` — clean.
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings`
  — clean.
- `cargo clippy -p searchlite-core --features vectors --all-targets --
  -D warnings` — clean.
- `cargo test -p searchlite-core` — every suite green (468 lib tests +
  35 `function_score` tests including 4 new + every other suite
  passes).
