### PR TITLE
fix(aggs): reject non-finite and i64-overflow bucket ids in HistogramCollector (BUG-358)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -1277,8 +1277,27 @@ impl<'a> HistogramCollector<'a> {
     }
   }
 
-  fn bucket_key(&self, val: f64) -> i64 {
-    ((val - self.offset) / self.interval).floor() as i64
+  /// Map a document value to its bucket id, returning `None` when the quotient
+  /// cannot be represented as an `i64` without loss.
+  ///
+  /// `interval` is validated finite and positive in `validate_histogram_config`
+  /// and `offset` is validated finite, but the document value `val` comes
+  /// unvalidated from the fast-field store. Two independent overflow modes
+  /// must be rejected here so neither silently coalesces documents into a
+  /// saturated bucket id with a wrong reconstructed key (BUG-358):
+  ///
+  /// 1. `(val - offset) / interval` itself overflows f64 to `±Infinity` (for
+  ///    example `f64::MAX / 0.5`). `.floor() as i64` then saturates to
+  ///    `i64::MAX` / `i64::MIN`.
+  /// 2. The quotient stays a finite f64 but exceeds the `i64` representable
+  ///    range (for example `1e16 / 0.001 = 1e19 > i64::MAX ≈ 9.22e18`). The
+  ///    `as i64` saturating cast again silently coalesces to `i64::MAX`.
+  ///
+  /// Both shapes previously produced a bucket key orders of magnitude away
+  /// from the document value and coalesced unrelated documents. Matches the
+  /// composite-histogram finitude guard added in BUG-356.
+  fn bucket_key(&self, val: f64) -> Option<i64> {
+    finite_bucket_id(val, self.offset, self.interval)
   }
 
   fn collect(&mut self, doc_id: DocId, score: f32) {
@@ -1291,7 +1310,9 @@ impl<'a> HistogramCollector<'a> {
     }
     let mut seen = HashSet::new();
     for val in values {
-      let bucket_id = self.bucket_key(val);
+      let Some(bucket_id) = self.bucket_key(val) else {
+        continue;
+      };
       if let Some((min, max)) = self.hard_bounds {
         let bucket_val = bucket_id as f64 * self.interval + self.offset;
         if bucket_val < min || bucket_val >= max {
@@ -1329,7 +1350,7 @@ impl<'a> HistogramCollector<'a> {
     let extended_bounds = self.extended_bounds;
     let hard_bounds = self.hard_bounds;
     let mut buckets = self.buckets;
-    let bucket_key = |val: f64| ((val - offset) / interval).floor() as i64;
+    let bucket_key = |val: f64| finite_bucket_id(val, offset, interval);
     let bucket_value = |bucket_id: i64| bucket_id as f64 * interval + offset;
     // Defense-in-depth: the request validator rejects non-finite / non-positive
     // intervals (see `validate_histogram_config`). Skip bounds materialization
@@ -1346,29 +1367,37 @@ impl<'a> HistogramCollector<'a> {
     // violate the hard cap even if that validation is ever weakened or bypassed.
     let fill_range = intersect_fill_range_f64(extended_bounds, hard_bounds);
     if bounds_materializable {
+      // Mirror the collector-side BUG-358 guard: both fill-range endpoints must
+      // map to a representable `i64` bucket id. The request validator rejects
+      // non-finite `extended_bounds` / `hard_bounds` values and caps the span
+      // at `MAX_BUCKETS`, so in practice both endpoints are finite; this guard
+      // is belt-and-braces so a degenerate combination (e.g. a bounds value
+      // whose quotient saturates `as i64`) cannot materialize a bucket at a
+      // wrong reconstructed key.
       if let Some((min, max)) = fill_range {
-        let mut bucket_id = bucket_key(min);
-        let end = bucket_key(max);
-        let mut materialized: usize = 0;
-        while bucket_id <= end {
-          buckets.entry(bucket_id).or_insert_with(|| BucketState {
-            key: serde_json::Value::Number(
-              serde_json::Number::from_f64(bucket_value(bucket_id))
-                .unwrap_or_else(|| serde_json::Number::from(0)),
-            ),
-            doc_count: 0,
-            aggs: BTreeMap::new(),
-          });
-          // Guard against saturating-cast + wrapping addition producing an
-          // infinite loop if somehow `end == i64::MAX` (belt-and-braces: the
-          // validator caps the span well below this).
-          let Some(next) = bucket_id.checked_add(1) else {
-            break;
-          };
-          bucket_id = next;
-          materialized = materialized.saturating_add(1);
-          if materialized >= MAX_BUCKETS {
-            break;
+        if let (Some(start), Some(end)) = (bucket_key(min), bucket_key(max)) {
+          let mut bucket_id = start;
+          let mut materialized: usize = 0;
+          while bucket_id <= end {
+            buckets.entry(bucket_id).or_insert_with(|| BucketState {
+              key: serde_json::Value::Number(
+                serde_json::Number::from_f64(bucket_value(bucket_id))
+                  .unwrap_or_else(|| serde_json::Number::from(0)),
+              ),
+              doc_count: 0,
+              aggs: BTreeMap::new(),
+            });
+            // Guard against saturating-cast + wrapping addition producing an
+            // infinite loop if somehow `end == i64::MAX` (belt-and-braces: the
+            // validator caps the span well below this).
+            let Some(next) = bucket_id.checked_add(1) else {
+              break;
+            };
+            bucket_id = next;
+            materialized = materialized.saturating_add(1);
+            if materialized >= MAX_BUCKETS {
+              break;
+            }
           }
         }
       }
@@ -4056,6 +4085,34 @@ fn default_percentiles_list() -> Vec<f64> {
   vec![1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0]
 }
 
+/// Map `(val - offset) / interval` to a bucket id, returning `None` when the
+/// quotient cannot be represented as an `i64` without loss (BUG-358).
+///
+/// Two overflow modes must be rejected for histogram arithmetic so that
+/// documents whose bucket id would saturate the `as i64` cast are dropped
+/// rather than silently coalesced into a shared `i64::MAX` / `i64::MIN` bucket
+/// with a wrong reconstructed key:
+///
+/// 1. The quotient itself overflows f64 to `±Infinity` (for example
+///    `f64::MAX / 0.5`); `is_finite()` rejects this shape.
+/// 2. The quotient stays a finite f64 but exceeds the `i64` representable
+///    range (for example `1e16 / 0.001 = 1e19 > i64::MAX ≈ 9.22e18`); the
+///    magnitude comparison against `i64::MAX as f64 = 2^63` rejects this
+///    shape.
+///
+/// Note: `i64::MAX as f64` rounds up to `2^63` because `2^63 - 1` is not
+/// representable in f64, so the upper bound uses `>=` to keep every `q` whose
+/// saturating cast would exceed `i64::MAX`. The lower bound uses the exactly
+/// representable `i64::MIN as f64 = -2^63`; a `q` equal to that bound is
+/// still a valid id because `(-2^63) as i64 == i64::MIN`.
+fn finite_bucket_id(val: f64, offset: f64, interval: f64) -> Option<i64> {
+  let q = ((val - offset) / interval).floor();
+  if !q.is_finite() || q >= (i64::MAX as f64) || q < (i64::MIN as f64) {
+    return None;
+  }
+  Some(q as i64)
+}
+
 /// Compute the effective fill range for `HistogramCollector::finish`.
 ///
 /// When both `extended_bounds` and `hard_bounds` are set, the empty-bucket fill
@@ -5439,6 +5496,57 @@ mod tests {
     let a = sampler.sample_value(0, 42);
     let b = sampler.sample_value(1, 42);
     assert_ne!(a, b);
+  }
+
+  /// BUG-358: `finite_bucket_id` must reject quotients that overflow f64 to
+  /// `±Infinity` and finite quotients that exceed the `i64` representable
+  /// range. Both shapes would otherwise saturate via `as i64` and coalesce
+  /// documents into a wrong bucket.
+  #[test]
+  fn finite_bucket_id_rejects_quotient_overflow_to_infinity() {
+    // f64::MAX / 0.5 saturates the division to f64::INFINITY.
+    assert_eq!(finite_bucket_id(f64::MAX, 0.0, 0.5), None);
+    assert_eq!(finite_bucket_id(-f64::MAX, 0.0, 0.5), None);
+  }
+
+  #[test]
+  fn finite_bucket_id_rejects_finite_quotient_above_i64_max() {
+    // 1e16 / 0.001 = 1e19 — finite f64 but above i64::MAX ≈ 9.22e18.
+    assert_eq!(finite_bucket_id(1e16, 0.0, 0.001), None);
+    assert_eq!(finite_bucket_id(-1e16, 0.0, 0.001), None);
+  }
+
+  #[test]
+  fn finite_bucket_id_rejects_non_finite_inputs() {
+    // Non-finite `val` propagates to a non-finite quotient.
+    assert_eq!(finite_bucket_id(f64::INFINITY, 0.0, 1.0), None);
+    assert_eq!(finite_bucket_id(f64::NEG_INFINITY, 0.0, 1.0), None);
+    assert_eq!(finite_bucket_id(f64::NAN, 0.0, 1.0), None);
+  }
+
+  #[test]
+  fn finite_bucket_id_accepts_values_inside_i64_range() {
+    // Simple in-range cases round-trip as expected.
+    assert_eq!(finite_bucket_id(5.0, 0.0, 1.0), Some(5));
+    assert_eq!(finite_bucket_id(25.0, 0.0, 10.0), Some(2));
+    assert_eq!(finite_bucket_id(-0.5, 0.0, 1.0), Some(-1));
+    // Offsets are applied before the division.
+    assert_eq!(finite_bucket_id(25.0, 5.0, 10.0), Some(2));
+    // Large-but-safe quotient (well below i64::MAX ≈ 9.22e18).
+    assert_eq!(finite_bucket_id(1e10, 0.0, 1.0), Some(1e10 as i64));
+  }
+
+  #[test]
+  fn finite_bucket_id_boundary_is_rejected() {
+    // `i64::MAX as f64` == `2^63` (rounded up because `2^63 - 1` is not
+    // representable in f64). A `q` exactly at this boundary would saturate
+    // to `i64::MAX` under `as i64`, so the guard must reject it via `>=`.
+    let boundary = i64::MAX as f64;
+    assert_eq!(finite_bucket_id(boundary, 0.0, 1.0), None);
+    // `i64::MIN as f64` == `-2^63`, which is exactly representable and
+    // casts back to `i64::MIN` — legitimate, so the guard accepts it.
+    let neg_boundary = i64::MIN as f64;
+    assert_eq!(finite_bucket_id(neg_boundary, 0.0, 1.0), Some(i64::MIN));
   }
 
   #[test]

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -3587,3 +3587,211 @@ mod bug_251 {
     assert_eq!(total, 2, "total doc_count must equal indexed docs");
   }
 }
+
+/// Regression tests for BUG-358 — `HistogramCollector::bucket_key` computed
+/// `((val - offset) / interval).floor() as i64` without guarding the
+/// intermediate float against overflow to `±Infinity` or against a finite
+/// quotient above `i64::MAX`. Under either shape the saturating `as i64` cast
+/// silently coalesced documents into an `i64::MAX` / `i64::MIN` bucket with
+/// a reconstructed key orders of magnitude away from the document value.
+///
+/// Two independent overflow modes are exercised:
+///
+/// 1. Quotient overflows f64 to `±Infinity` (`f64::MAX / 0.5`).
+/// 2. Quotient stays finite f64 but exceeds `i64::MAX`
+///    (`1e16 / 0.001 = 1e19 > i64::MAX ≈ 9.22e18`).
+///
+/// The fix drops affected documents from the histogram, matching the
+/// composite-histogram finitude filter added in BUG-356 and the
+/// finitude / range policy used across adjacent numeric sites.
+mod bug_358 {
+  use super::*;
+
+  fn f64_score_index(path: &std::path::Path) -> searchlite_core::api::Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "score".into(),
+      i64: false,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    Index::create(path, schema, build_base_options(path)).unwrap()
+  }
+
+  fn index_scores(idx: &searchlite_core::api::Index, scores: &[f64]) {
+    let mut writer = idx.writer().unwrap();
+    for (i, score) in scores.iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("d-{i}"),
+          vec![("body", json!("rust")), ("score", json!(score))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+
+  fn run_histogram(
+    idx: &searchlite_core::api::Index,
+    interval: f64,
+  ) -> searchlite_core::api::types::AggregationResponse {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+    let mut req = SearchRequest::new("rust");
+    req.aggs = aggs;
+    let resp = idx.reader().unwrap().search(&req).expect("search");
+    resp.aggregations.get("hist").cloned().expect("histogram")
+  }
+
+  fn extract_histogram(
+    resp: &searchlite_core::api::types::AggregationResponse,
+  ) -> &[searchlite_core::api::types::BucketResponse] {
+    match resp {
+      searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } => buckets,
+      _ => panic!("expected histogram aggregation response"),
+    }
+  }
+
+  /// Scenario 2 from the bug report: `f64::MAX / 0.5` saturates the quotient
+  /// to `f64::INFINITY`. Before the fix the `.floor() as i64` cast clamped
+  /// the bucket id to `i64::MAX`, then the reconstructed key
+  /// `i64::MAX as f64 * 0.5 ≈ 4.61e18` landed nearly 290 orders of magnitude
+  /// away from the document's actual value.
+  #[test]
+  fn histogram_drops_document_when_quotient_overflows_to_infinity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    index_scores(&idx, &[f64::MAX]);
+
+    let resp = run_histogram(&idx, 0.5);
+    let buckets = extract_histogram(&resp);
+    assert!(
+      buckets.is_empty(),
+      "document whose bucket arithmetic overflows to infinity must be dropped, got {buckets:?}"
+    );
+  }
+
+  /// Scenario 1 from the bug report: quotient stays a finite f64 but exceeds
+  /// `i64::MAX`. `1e16 / 0.001 = 1e19 > i64::MAX ≈ 9.22e18`. Before the fix
+  /// the `as i64` cast saturated to `i64::MAX`, reconstructing a key at
+  /// `~9.22e15` — wrong by roughly 8% and liable to coalesce with every
+  /// other over-`i64::MAX` document in the same bucket.
+  #[test]
+  fn histogram_drops_document_when_quotient_overflows_i64_range() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    // Quotient = 1e19 (finite f64) > i64::MAX ≈ 9.22e18.
+    index_scores(&idx, &[1e16]);
+
+    let resp = run_histogram(&idx, 0.001);
+    let buckets = extract_histogram(&resp);
+    assert!(
+      buckets.is_empty(),
+      "document whose quotient exceeds i64::MAX must be dropped, got {buckets:?}"
+    );
+  }
+
+  /// Symmetric negative overflow: `-f64::MAX / 0.5 = -Infinity`. The same
+  /// finitude guard must reject this shape or the saturating `as i64` would
+  /// land the document in an `i64::MIN` bucket.
+  #[test]
+  fn histogram_drops_document_when_quotient_overflows_to_neg_infinity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    index_scores(&idx, &[-f64::MAX]);
+
+    let resp = run_histogram(&idx, 0.5);
+    let buckets = extract_histogram(&resp);
+    assert!(
+      buckets.is_empty(),
+      "document with negative-overflow quotient must be dropped, got {buckets:?}"
+    );
+  }
+
+  /// Coalescing regression: two documents whose quotients both saturate to
+  /// `i64::MAX` previously ended up in the same `i64::MAX` bucket despite
+  /// having different source values. After the fix they are both dropped
+  /// rather than silently merged.
+  #[test]
+  fn histogram_does_not_coalesce_multiple_overflow_documents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    // 1e16 / 0.001 = 1e19 (saturates) and 2e16 / 0.001 = 2e19 (saturates) —
+    // both would collapse to the same i64::MAX bucket under the old code.
+    index_scores(&idx, &[1e16, 2e16]);
+
+    let resp = run_histogram(&idx, 0.001);
+    let buckets = extract_histogram(&resp);
+    assert!(
+      buckets.is_empty(),
+      "distinct overflow documents must not coalesce into a saturated bucket, got {buckets:?}"
+    );
+  }
+
+  /// Mixed input: overflow docs are dropped, finite-quotient docs land in
+  /// their expected buckets. Locks in per-document (rather than per-segment)
+  /// application of the finitude gate.
+  #[test]
+  fn histogram_mixed_overflow_and_finite_documents() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    // `f64::MAX` overflows with interval `0.5`; `0.25` and `1.25` stay
+    // finite and land in distinct buckets at keys 0.0 and 1.0.
+    index_scores(&idx, &[f64::MAX, 0.25, 1.25]);
+
+    let resp = run_histogram(&idx, 0.5);
+    let buckets = extract_histogram(&resp);
+    assert_eq!(
+      buckets.len(),
+      2,
+      "expected two finite-bucket entries (overflow doc dropped), got {buckets:?}"
+    );
+    for bucket in buckets {
+      assert!(
+        bucket.key.is_number(),
+        "every emitted histogram bucket must have a numeric key (got {:?})",
+        bucket.key
+      );
+      assert_eq!(bucket.doc_count, 1);
+    }
+  }
+
+  /// Regression lock: a document whose raw value is large but whose quotient
+  /// stays well within `i64` range must still be emitted. Guards against
+  /// the finitude filter over-rejecting legitimate large-but-finite values.
+  #[test]
+  fn histogram_keeps_document_with_large_finite_quotient() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    // 1e10 / 1.0 = 1e10 (finite f64 well below i64::MAX ≈ 9.22e18).
+    index_scores(&idx, &[1e10]);
+
+    let resp = run_histogram(&idx, 1.0);
+    let buckets = extract_histogram(&resp);
+    assert_eq!(
+      buckets.len(),
+      1,
+      "expected exactly one finite-bucket entry, got {buckets:?}"
+    );
+    assert!(
+      buckets[0].key.is_number(),
+      "finite-quotient document must produce a numeric bucket key (got {:?})",
+      buckets[0].key
+    );
+    assert_eq!(buckets[0].doc_count, 1);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #358.

`HistogramCollector::bucket_key` computed `((val - offset) / interval).floor() as i64` without guarding the intermediate against two independent overflow modes that both silently coalesced documents into a saturated bucket id with a wrong reconstructed key:

1. `(val - offset) / interval` overflows f64 to `±Infinity` (e.g. `f64::MAX / 0.5`); `.floor() as i64` saturates to `i64::MAX` / `i64::MIN`.
2. The quotient stays finite f64 but exceeds the `i64` representable range (e.g. `1e16 / 0.001 = 1e19 > i64::MAX ≈ 9.22e18`); the `as i64` saturating cast coalesces again.

The reconstructed bucket key in the response (`bucket_id as f64 * interval + offset`) was then orders of magnitude away from the actual document value, and multiple documents with different large values collapsed into the same saturated bucket.

BUG-356 (PR #357) fixed the same class of bug for the composite histogram source by dropping non-finite bucket values via `filter_map`. This PR applies the equivalent guard to the regular `HistogramCollector`, matching the finitude-policy chain used across adjacent numeric sites (BUG-287 / 315 / 322 / 324 / 326 / 328 / 330 / 332 / 338 / 340 / 342 / 344 / 345 / 346 / 352 / 354 / 356).

## Changes

- `searchlite-core/src/query/aggs/mod.rs`:
  - New `finite_bucket_id(val, offset, interval)` helper returning `Option<i64>`. Rejects non-finite quotients and finite quotients whose magnitude lies outside the `i64` representable range. The upper bound uses `>= (i64::MAX as f64)` because `i64::MAX as f64` rounds up to `2^63` (since `2^63 - 1` is not representable in f64), so any `q` at that boundary would saturate under `as i64`; the lower bound `i64::MIN as f64 = -2^63` is exactly representable and is accepted.
  - `HistogramCollector::bucket_key` now returns `Option<i64>` and delegates to the helper.
  - `HistogramCollector::collect` skips documents whose bucket id cannot be represented losslessly, mirroring the composite histogram's `filter_map` pattern from BUG-356.
  - `HistogramCollector::finish` uses the same guard for the fill-range loop. If either endpoint cannot map to a representable bucket id the fill is skipped. The request validator already rejects non-finite `extended_bounds`/`hard_bounds` and caps the span at `MAX_BUCKETS`, so this is belt-and-braces.

- `searchlite-core/tests/aggregation_bounds.rs` — new `bug_358` module:
  - `histogram_drops_document_when_quotient_overflows_to_infinity` — `f64::MAX / 0.5` overflow to `+Infinity`.
  - `histogram_drops_document_when_quotient_overflows_i64_range` — finite `1e19` quotient above `i64::MAX`.
  - `histogram_drops_document_when_quotient_overflows_to_neg_infinity` — symmetric negative overflow.
  - `histogram_does_not_coalesce_multiple_overflow_documents` — lock in that two distinct over-`i64::MAX` documents don't end up in the same saturated bucket.
  - `histogram_mixed_overflow_and_finite_documents` — overflow docs dropped, finite docs emitted with numeric keys.
  - `histogram_keeps_document_with_large_finite_quotient` — regression lock that the new finitude filter doesn't over-reject legitimate large-but-finite values (`1e10 / 1.0`).

- Unit tests for `finite_bucket_id` cover: `±Infinity`, `NaN`, finite-but-above-`i64::MAX` (both signs), in-range values with and without offset, and the `i64::MAX as f64 = 2^63` boundary where `>=` is required to stop saturation and `i64::MIN as f64` is accepted.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core` — all 18 test binaries green, including 6 new regression tests and 5 new unit tests
- `cargo test -p searchlite-core --features vectors` — all 18 test binaries green

## Test plan

- [x] Regression tests in `searchlite-core/tests/aggregation_bounds.rs::bug_358` pass
- [x] Unit tests for `finite_bucket_id` pass
- [x] Existing aggregation tests unaffected (65/65 pass in `aggregation_bounds`)
- [x] Full `searchlite-core` suite green with and without the `vectors` feature