### PR TITLE
fix(score): gate function_score zero-base rewrite on Multiply (BUG-362)

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -347,9 +347,19 @@ pub(crate) fn evaluate_compiled_score(
         }
       }
       let mut effective_base = base_score;
-      if effective_base.abs() <= f32::EPSILON && !function_values.is_empty() {
-        // Preserve function contributions even when the base query scored 0.0,
-        // so multiplicative boost modes do not erase function-only scoring.
+      if effective_base.abs() <= f32::EPSILON
+        && !function_values.is_empty()
+        && *boost_mode == FunctionBoostMode::Multiply
+      {
+        // Preserve function contributions when the base query scored 0.0 and
+        // the boost_mode is Multiply — otherwise `0 * func = 0` would erase
+        // the function-only scoring. All other boost modes (Sum, Max, Min,
+        // Replace) already preserve the function contribution without a
+        // rewrite, so leaving `effective_base` at 0.0 gives the correct
+        // result: Sum -> `0 + func = func`, Max -> `max(0, func)`, Min ->
+        // `min(0, func)`, Replace ignores the base. Gating the rewrite on
+        // Multiply prevents an artificial +1.0 bias in Sum, a 1.0 clamp in
+        // Max when `func < 1.0`, and a 1.0 floor in Min when `func >= 1.0`.
         effective_base = 1.0;
       }
       let mut combined =

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1368,3 +1368,159 @@ fn script_score_large_but_finite_literal_is_accepted() {
     );
   }
 }
+
+// BUG-362: `evaluate_compiled_score` unconditionally rewrote a near-zero
+// base query score to `1.0` whenever function values were present, but the
+// rewrite is only correct for `boost_mode: multiply` (where `0 * func = 0`
+// would erase the function contribution). For Sum, Max, and Min boost
+// modes, rewriting the base from `0.0` to `1.0` adds an artificial bias:
+// Sum becomes `1 + func` instead of `0 + func`, Max clamps at `1.0` when
+// `func < 1.0`, and Min produces a `1.0` floor when `func >= 1.0`. The fix
+// gates the rewrite on `FunctionBoostMode::Multiply`, leaving other modes
+// to preserve the base naturally.
+
+fn zero_base_function_score(func_weight: f32, boost_mode: FunctionBoostMode) -> QueryNode {
+  QueryNode::FunctionScore {
+    query: Box::new(QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(0.0),
+    }),
+    functions: vec![FunctionSpec::Weight {
+      weight: func_weight,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(boost_mode),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  }
+}
+
+#[test]
+fn function_score_sum_boost_mode_preserves_zero_base() {
+  // Sum: `0 + 5 = 5`. The pre-fix implementation rewrote the base to 1.0,
+  // producing `1 + 5 = 6` — a +1.0 bias on every doc whose base query
+  // legitimately scored zero.
+  let reader = setup_reader();
+  let req = base_request(zero_base_function_score(5.0, FunctionBoostMode::Sum));
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 5.0).abs() < 1e-6,
+      "expected 5.0 (0.0 + 5.0), got {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn function_score_max_boost_mode_preserves_zero_base() {
+  // Max: `max(0, 0.5) = 0.5`. The pre-fix implementation rewrote the base
+  // to 1.0, producing `max(1, 0.5) = 1.0` — clamping the function value
+  // whenever it was below 1.0.
+  let reader = setup_reader();
+  let req = base_request(zero_base_function_score(0.5, FunctionBoostMode::Max));
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 0.5).abs() < 1e-6,
+      "expected 0.5 (max(0.0, 0.5)), got {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn function_score_min_boost_mode_preserves_zero_base() {
+  // Min: `min(0, 5) = 0`. The pre-fix implementation rewrote the base to
+  // 1.0, producing `min(1, 5) = 1.0` — a 1.0 floor whenever the function
+  // value was ≥ 1.0.
+  let reader = setup_reader();
+  let req = base_request(zero_base_function_score(5.0, FunctionBoostMode::Min));
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.abs() < 1e-6,
+      "expected 0.0 (min(0.0, 5.0)), got {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn function_score_multiply_boost_mode_still_rewrites_zero_base() {
+  // Regression lock: Multiply still needs the `0 -> 1` rewrite because
+  // `0 * func = 0` would erase the function contribution entirely. After
+  // the fix, Multiply must continue to produce `1 * 5 = 5`.
+  let reader = setup_reader();
+  let req = base_request(zero_base_function_score(5.0, FunctionBoostMode::Multiply));
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 5.0).abs() < 1e-6,
+      "expected 5.0 (rewritten 1.0 * 5.0), got {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn function_score_replace_boost_mode_preserves_function_value_over_zero_base() {
+  // Replace: ignores the base entirely. Behaviour is identical before and
+  // after the fix; included as a regression lock so the base rewrite gate
+  // cannot accidentally alter Replace semantics.
+  let reader = setup_reader();
+  let req = base_request(zero_base_function_score(5.0, FunctionBoostMode::Replace));
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 5.0).abs() < 1e-6,
+      "expected 5.0 (Replace drops base), got {}",
+      hit.score
+    );
+  }
+}
+
+#[test]
+fn function_score_sum_boost_mode_with_nonzero_base_unchanged() {
+  // Regression lock: when the base is not near zero, the rewrite gate does
+  // not fire regardless of boost_mode, and Sum still combines the real
+  // base score with the function value.
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(2.0),
+    }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 5.0,
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Sum),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      (hit.score - 7.0).abs() < 1e-6,
+      "expected 7.0 (2.0 + 5.0), got {}",
+      hit.score
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #362.

`evaluate_compiled_score` unconditionally rewrote `effective_base` from a near-zero base query score to `1.0` whenever function values were present. The rewrite is only correct for `boost_mode: multiply` — where `0 * func` would erase the function contribution — but it was applied to every boost mode, adding an artificial +1.0 bias to Sum, clamping Max at 1.0 when `func < 1.0`, and producing a 1.0 floor in Min when `func >= 1.0`.

The rewrite is now gated on `FunctionBoostMode::Multiply`. The other boost modes preserve the function contribution naturally without a rewrite:

- **Sum** — `0 + func = func`
- **Max** — `max(0, func) = func` when `func >= 0`
- **Min** — `min(0, func) = 0` (the true minimum)
- **Replace** — ignores the base entirely

| boost_mode | func | expected | before | after |
|-----------|-----:|---------:|------:|-----:|
| Sum       | 5.0  | 5.0      | 6.0   | 5.0  |
| Max       | 0.5  | 0.5      | 1.0   | 0.5  |
| Min       | 5.0  | 0.0      | 1.0   | 0.0  |
| Multiply  | 5.0  | 5.0      | 5.0   | 5.0  |
| Replace   | 5.0  | 5.0      | 5.0   | 5.0  |

Trigger paths include `constant_score` with `boost: 0.0` as the base query, and BM25 on an extremely high-DF term producing a near-zero base score. The regression tests exercise the `constant_score` path which directly lands a `0.0` base into `FunctionScore` evaluation.

## Changes

- `searchlite-core/src/api/scoring.rs` — gate the zero-base rewrite on `*boost_mode == FunctionBoostMode::Multiply`. The comment is updated to explain why each non-Multiply mode is left with the natural zero base.

- `searchlite-core/tests/function_score.rs` — six new regression tests:
  - `function_score_sum_boost_mode_preserves_zero_base` — Sum should produce `0 + 5 = 5`, not `1 + 5 = 6`.
  - `function_score_max_boost_mode_preserves_zero_base` — Max should produce `max(0, 0.5) = 0.5`, not `max(1, 0.5) = 1.0`.
  - `function_score_min_boost_mode_preserves_zero_base` — Min should produce `min(0, 5) = 0`, not `min(1, 5) = 1.0`.
  - `function_score_multiply_boost_mode_still_rewrites_zero_base` — lock in that Multiply still needs the rewrite to avoid `0 * func = 0`.
  - `function_score_replace_boost_mode_preserves_function_value_over_zero_base` — Replace ignores the base; behaviour unchanged.
  - `function_score_sum_boost_mode_with_nonzero_base_unchanged` — lock in that the rewrite gate does not fire for non-zero bases.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --lib --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core` — all suites green, including 44/44 in `function_score` (6 new regression tests).

## Test plan

- [x] New regression tests in `searchlite-core/tests/function_score.rs` pass
- [x] Existing function_score suite unaffected (38 prior tests still green)
- [x] Full `searchlite-core` test suite green
- [x] Clippy clean on both default and `vectors` feature sets