### PR TITLE
fix(score): reject non-finite Constant score from boost-product overflow (BUG-370)

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -336,6 +336,16 @@ pub(crate) fn evaluate_compiled_score(
     }
     CompiledScoreNode::Constant { score, matcher } => {
       if evaluator.matches_subquery(matcher, doc_id) {
+        // The stored score is `boost * node_boost` accumulated from every
+        // enclosing scope during planning. Each factor is validated to be
+        // finite, but the product can still overflow `f32::MAX` to
+        // `+INFINITY`. Every other variant of this match rejects non-finite
+        // outputs; Constant must too so the non-finite score does not leak
+        // into the WAND heap (where it corrupts ordering) or into `Hit.score`
+        // (where `serde_json` rejects it as invalid JSON, returning 500).
+        if !score.is_finite() {
+          return None;
+        }
         Some(*score)
       } else {
         Some(0.0)

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1844,3 +1844,81 @@ fn script_score_large_negative_literal_overflow_clamps_to_f32_min() {
     );
   }
 }
+
+// Regression: the `Constant` arm of `evaluate_compiled_score` previously
+// returned `Some(*score)` unconditionally. Every other variant (Sum, DisMax,
+// FunctionScore, RankFeature, ScriptScore) rejects non-finite results, but
+// Constant did not. When `boost * node_boost` accumulated across nested
+// scopes overflowed `f32::MAX` to `+INFINITY`, the non-finite score leaked
+// into the WAND heap (corrupting ordering) and into `Hit.score`, where
+// `serde_json` rejects it as invalid JSON and the HTTP endpoint returns 500.
+// See BUG-370.
+#[test]
+fn constant_score_rejects_document_when_boost_product_overflows_to_infinity() {
+  let reader = setup_reader();
+  // `Bool` with `boost = 1e38` containing a single `ConstantScore` with
+  // `boost = 1e38`. Both factors are individually finite and pass
+  // `validate_boost`, but their product `1e38 * 1e38 = 1e76` overflows
+  // `f32::MAX ≈ 3.4e38` and saturates to `+INFINITY`. With the guard in
+  // place, the Constant evaluator returns `None` and the hit is dropped.
+  let req = base_request(QueryNode::Bool {
+    must: vec![QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(1e38),
+    }],
+    should: Vec::new(),
+    must_not: Vec::new(),
+    filter: Vec::new(),
+    minimum_should_match: None,
+    boost: Some(1e38),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when Constant score overflows to infinity, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn constant_score_keeps_document_when_boost_product_stays_finite() {
+  let reader = setup_reader();
+  // Boundary check: the new finitude guard must not over-reject legitimate
+  // large-but-finite scores. `1e10 * 1e10 = 1e20` is comfortably within
+  // `f32::MAX`, so the Constant evaluator must return the product as the
+  // document's score.
+  let req = base_request(QueryNode::Bool {
+    must: vec![QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(1e10),
+    }],
+    should: Vec::new(),
+    must_not: Vec::new(),
+    filter: Vec::new(),
+    minimum_should_match: None,
+    boost: Some(1e10),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "{} score must be finite, got {}",
+      hit.doc_id,
+      hit.score
+    );
+    assert!(
+      (hit.score - 1e20).abs() < 1e20 * 1e-5,
+      "{} score must equal 1e20, got {}",
+      hit.doc_id,
+      hit.score
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #370.

The `Constant` arm of `evaluate_compiled_score` in `searchlite-core/src/api/scoring.rs` returned `Some(*score)` unconditionally. Every other scoring variant — `Sum`, `DisMax`, `FunctionScore`, `RankFeature`, `ScriptScore` — already guards its output with `is_finite()`, but `Constant` did not. When `boost * node_boost` accumulated across nested scopes overflowed `f32::MAX` to `+INFINITY`, the non-finite score leaked into the WAND sort-key heap (silently corrupting ordering) and into `Hit.score`, where `serde_json` rejects it as invalid JSON and the HTTP endpoint returns a 500.

Each factor in the boost product is already validated to be finite and non-negative by `validate_boost` in the planner, but the **product** can still saturate: e.g. a `Bool` with `boost: 1e38` wrapping a `ConstantScore` with `boost: 1e38` yields `1e76`, which exceeds `f32::MAX ≈ 3.4e38`. The Bool's single-`must` shortcut lifts the `ScoreNode::Constant` directly into the score tree without wrapping it in a `Sum`, so the existing `Sum` / `DisMax` finitude guards never see the non-finite value.

## Changes

- `searchlite-core/src/api/scoring.rs` — add an `is_finite()` guard to the `CompiledScoreNode::Constant` arm of `evaluate_compiled_score`, returning `None` (skip document) when the stored score is non-finite. Mirrors the policy already used by every other arm of this match.

- `searchlite-core/tests/function_score.rs` — two new regression tests:
  - `constant_score_rejects_document_when_boost_product_overflows_to_infinity` — a `Bool { boost: 1e38, must: [ConstantScore { boost: 1e38, ... }] }` whose product overflows to `+INFINITY`. With the fix, the hit is dropped; confirmed to fail on `main` with `got 2 hits with scores [inf, inf]`.
  - `constant_score_keeps_document_when_boost_product_stays_finite` — boundary check that `1e10 * 1e10 = 1e20` (comfortably within `f32::MAX`) is still accepted and scored correctly, guarding against over-rejection.

## Validation

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean
- `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean
- `cargo test -p searchlite-core` — all 18 suites green, including 52/52 in `function_score` (2 new regression tests)
- `cargo test -p searchlite-core --features vectors --test function_score` — 52/52 green

## Test plan

- [x] Regression test reproduces the bug on `main` and passes with the fix
- [x] Boundary test confirms finite-but-large scores are preserved
- [x] Existing `function_score` suite unaffected (50 prior tests still green)
- [x] Full `searchlite-core` suite green with and without the `vectors` feature
- [x] Clippy clean on both default and `vectors` feature sets