### PR TITLE
fix(score): reject non-finite decay origin and offset (BUG-373)

### DIFF
--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -78,8 +78,16 @@ pub(crate) fn compile_functions(
         function,
         filter,
       } => {
+        if !origin.is_finite() {
+          bail!("decay origin must be finite");
+        }
         if !scale.is_finite() {
           bail!("decay scale must be finite");
+        }
+        if let Some(off) = offset {
+          if !off.is_finite() {
+            bail!("decay offset must be finite");
+          }
         }
         ensure_numeric_fast(schema, field, "function_score")?;
         if *scale <= 0.0 {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -371,6 +371,60 @@ fn decay_rejects_non_finite_offset_nan() {
 }
 
 #[test]
+fn decay_rejects_non_finite_origin_negative_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: f64::NEG_INFINITY,
+      scale: 10.0,
+      offset: Some(0.0),
+      decay: Some(0.5),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay origin must be finite"),
+    "expected origin-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn decay_rejects_non_finite_offset_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: 0.0,
+      scale: 10.0,
+      offset: Some(f64::INFINITY),
+      decay: Some(0.5),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay offset must be finite"),
+    "expected offset-finitude error, got {err}"
+  );
+}
+
+#[test]
 fn decay_rejects_non_finite_offset_negative_infinity() {
   let reader = setup_reader();
   let req = base_request(QueryNode::FunctionScore {

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -282,6 +282,121 @@ fn decay_function_orders_by_distance() {
   assert!(resp.hits[1].score > resp.hits[2].score);
 }
 
+// BUG-373: `serde_wasm_bindgen` (unlike `serde_json`) passes JS `NaN`/`Infinity`
+// straight into `f64`, so a decay `origin`/`offset` arriving via the WASM
+// binding could poison the scoring formula. `(value - NaN).abs() = NaN`,
+// then `NaN.max(0.0) = 0.0` (IEEE-754 maxNum picks the non-NaN), which
+// collapses every document to `decay^0 = 1.0` — a silently wrong result.
+// `compile_functions` must reject non-finite `origin` and `offset` at the
+// boundary, matching the existing `scale` guard.
+#[test]
+fn decay_rejects_non_finite_origin_nan() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: f64::NAN,
+      scale: 10.0,
+      offset: Some(0.0),
+      decay: Some(0.5),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay origin must be finite"),
+    "expected origin-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn decay_rejects_non_finite_origin_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: f64::INFINITY,
+      scale: 10.0,
+      offset: Some(0.0),
+      decay: Some(0.5),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay origin must be finite"),
+    "expected origin-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn decay_rejects_non_finite_offset_nan() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: 0.0,
+      scale: 10.0,
+      offset: Some(f64::NAN),
+      decay: Some(0.5),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay offset must be finite"),
+    "expected offset-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn decay_rejects_non_finite_offset_negative_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: 0.0,
+      scale: 10.0,
+      offset: Some(f64::NEG_INFINITY),
+      decay: Some(0.5),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay offset must be finite"),
+    "expected offset-finitude error, got {err}"
+  );
+}
+
 #[test]
 fn min_score_branch_does_not_drop_other_clauses() {
   let reader = setup_reader();


### PR DESCRIPTION
## Summary

- `compile_functions` validates `scale` for finiteness but skips `origin` and `offset`. Via the WASM binding (`serde_wasm_bindgen`), JavaScript `NaN`/`Infinity` pass straight into `f64`, so a caller can supply `origin: NaN` and every document collapses to `decay^0 = 1.0` (or `decay^∞ = 0.0`), producing silently wrong scores that still pass the downstream `is_finite()` guard.
- Add boundary validation for `origin` and `offset` in the `FunctionSpec::Decay` branch, mirroring the existing `scale` check. The JSON path (`serde_json`) already rejects non-finite numbers during parsing, so only WASM callers were affected — but the guard is cheap defense-in-depth for any future non-JSON path.
- Regression tests cover NaN and ±Infinity for both fields.

Fixes #373

## Test plan

- [x] `cargo test --package searchlite-core --test function_score` — 56 tests pass, including 4 new `decay_rejects_non_finite_*` cases
- [x] `cargo clippy --package searchlite-core --all-targets --no-deps` clean
- [x] Existing `decay_function_orders_by_distance` still passes (no regression on the happy path)