### PR TITLE
fix(query): disable WAND pruning when score hook can amplify scores (BUG-376)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1269,10 +1269,12 @@ impl IndexReader {
         let mut agg_ref = agg_collector
           .as_mut()
           .map(|collector| collector as &mut dyn DocCollector);
-        // When a score hook (function_score/script_score/rank_feature) is
-        // active, WAND's per-term BM25 upper bounds no longer bound the
-        // candidate score; pass a collector so pivot_threshold drops to
-        // NEG_INFINITY and pruning is disabled. See BUG-376.
+        // When any custom scoring node is active — constant_score,
+        // function_score, script_score, or rank_feature (see
+        // `has_custom_scoring`) — WAND's per-term BM25 upper bounds no
+        // longer bound the candidate score. Pass a collector so
+        // `pivot_threshold` drops to NEG_INFINITY and pruning is disabled.
+        // See BUG-376.
         if agg_ref.is_none()
           && (page_limit == 0
             || !req.return_hits

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1269,8 +1269,15 @@ impl IndexReader {
         let mut agg_ref = agg_collector
           .as_mut()
           .map(|collector| collector as &mut dyn DocCollector);
+        // When a score hook (function_score/script_score/rank_feature) is
+        // active, WAND's per-term BM25 upper bounds no longer bound the
+        // candidate score; pass a collector so pivot_threshold drops to
+        // NEG_INFINITY and pruning is disabled. See BUG-376.
         if agg_ref.is_none()
-          && (page_limit == 0 || !req.return_hits || (!score_fast_path && page_limit > 0))
+          && (page_limit == 0
+            || !req.return_hits
+            || (!score_fast_path && page_limit > 0)
+            || needs_score_hook)
         {
           agg_ref = Some(&mut noop_collector);
         }

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -2053,6 +2053,135 @@ fn constant_score_rejects_document_when_boost_product_overflows_to_infinity() {
   );
 }
 
+// Regression test for BUG-376: when `score_fast_path` is active (sort by
+// `_score` desc, no `track_total_hits`, no aggs) and a score hook
+// (function_score/script_score/rank_feature) amplifies scores above BM25
+// upper bounds, WAND's dynamic threshold pruning terminates early because
+// the heap threshold — now an adjusted-score minimum — exceeds the sum of
+// remaining BM25 term upper bounds. Documents that would have ranked in the
+// top-k after adjustment are silently dropped.
+#[test]
+fn wand_does_not_prune_against_amplified_scores_on_fast_path() {
+  let path = tempfile::tempdir().unwrap().path().join("idx");
+  let mut schema = Schema::default_text_body();
+  schema.keyword_fields.push(KeywordField {
+    name: "boosted".into(),
+    stored: true,
+    indexed: true,
+    fast: true,
+    nullable: false,
+  });
+  let opts = IndexOptions {
+    path: path.clone(),
+    create_if_missing: true,
+    enable_positions: true,
+    bm25_k1: 0.9,
+    bm25_b: 0.4,
+    storage: StorageType::Filesystem,
+    #[cfg(feature = "vectors")]
+    vector_defaults: None,
+  };
+  let idx = Index::create(&path, schema, opts).unwrap();
+  let mut writer = idx.writer().unwrap();
+  // All documents match the boost filter (boosted = "yes") and contain
+  // "common". Term frequency increases with doc_id so doc-2 has the highest
+  // BM25, indexed last. With weight=100 multiplicative boost, the early
+  // docs' adjusted scores fill the heap with a threshold far above any
+  // term's BM25 upper bound. The buggy WAND terminates before reaching the
+  // latest doc (doc-2), returning doc-1 instead of doc-2 as the top hit.
+  for d in [
+    Document {
+      fields: [
+        ("_id".to_string(), serde_json::json!("doc-0")),
+        ("body".to_string(), serde_json::json!("common")),
+        ("boosted".to_string(), serde_json::json!("yes")),
+      ]
+      .into_iter()
+      .collect(),
+    },
+    Document {
+      fields: [
+        ("_id".to_string(), serde_json::json!("doc-1")),
+        ("body".to_string(), serde_json::json!("common common")),
+        ("boosted".to_string(), serde_json::json!("yes")),
+      ]
+      .into_iter()
+      .collect(),
+    },
+    Document {
+      fields: [
+        ("_id".to_string(), serde_json::json!("doc-2")),
+        (
+          "body".to_string(),
+          serde_json::json!("common common common common"),
+        ),
+        ("boosted".to_string(), serde_json::json!("yes")),
+      ]
+      .into_iter()
+      .collect(),
+    },
+  ] {
+    writer.add_document(&d).unwrap();
+  }
+  writer.commit().unwrap();
+  let reader = idx.reader().unwrap();
+
+  let mut req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::Term {
+      field: "body".into(),
+      value: "common".into(),
+      boost: None,
+    }),
+    functions: vec![FunctionSpec::Weight {
+      weight: 100.0,
+      filter: Some(Filter::KeywordEq {
+        field: "boosted".into(),
+        value: "yes".into(),
+      }),
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Multiply),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  // size=1 (top_k=2 internally) is the minimal setting that forces the
+  // heap to fill before the last document is examined. Once the heap
+  // holds two adjusted-score hits, the heap threshold climbs well above
+  // any BM25 upper bound. `track_total_hits = false` (the default) is
+  // what activates `score_fast_path` — the code path with the bug.
+  req.limit = 1;
+
+  let resp = reader.search(&req).unwrap();
+  let ids: Vec<String> = resp.hits.iter().map(|h| h.doc_id.clone()).collect();
+
+  assert_eq!(
+    ids,
+    vec!["doc-2".to_string()],
+    "top-1 must be doc-2 (highest BM25 * 100); got {:?}",
+    ids
+  );
+  let top = &resp.hits[0];
+  assert!(
+    top.score.is_finite(),
+    "score must be finite, got {}",
+    top.score
+  );
+
+  // Compare against the `track_total_hits = true` path, which disables
+  // `score_fast_path` entirely and therefore has never been affected by
+  // the WAND pruning bug. The two paths must agree on the top hit.
+  let mut req_total = req.clone();
+  req_total.track_total_hits = Some(true);
+  let resp_total = reader.search(&req_total).unwrap();
+  let ids_total: Vec<String> = resp_total.hits.iter().map(|h| h.doc_id.clone()).collect();
+  assert_eq!(
+    ids, ids_total,
+    "fast-path top-k must match the track_total_hits=true path (which doesn't trigger WAND pruning); fast={:?} full={:?}",
+    ids, ids_total
+  );
+}
+
 #[test]
 fn constant_score_keeps_document_when_boost_product_stays_finite() {
   let reader = setup_reader();

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -2062,7 +2062,11 @@ fn constant_score_rejects_document_when_boost_product_overflows_to_infinity() {
 // top-k after adjustment are silently dropped.
 #[test]
 fn wand_does_not_prune_against_amplified_scores_on_fast_path() {
-  let path = tempfile::tempdir().unwrap().path().join("idx");
+  // Bind `TempDir` to a local so the directory survives the whole test and
+  // is cleaned up on drop; calling `.path()` on a temporary would delete the
+  // directory before the index could be created.
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().join("idx");
   let mut schema = Schema::default_text_body();
   schema.keyword_fields.push(KeywordField {
     name: "boosted".into(),


### PR DESCRIPTION
## Summary

Fixes BUG-376: when `score_fast_path` was active (sort by `_score` desc, no `track_total_hits`, no aggregations) and a score hook — `function_score`, `script_score`, or `rank_feature` — amplified scores above BM25 upper bounds, WAND's dynamic threshold pruning terminated early. The heap threshold, now populated with adjusted-score minima, could exceed the sum of remaining BM25 term upper bounds, so the pivot scan failed and documents that would have ranked in the top-k after score adjustment were silently dropped.

## Fix

WAND's pruning is disabled when `wand_loop` receives a collector (it forces `pivot_threshold = NEG_INFINITY`). The non-fast-path code already uses a `NoopCollector` for that reason. Extend the same gate on the fast path so the collector is installed whenever `needs_score_hook` is true. With pruning disabled, every matching document flows through the full pipeline (BM25 + score_adjust) and the top-k heap ranks them correctly.

Alternatives considered:
- Flipping `score_fast_path` to `false` when a score hook is active would also fix the bug, but it changes the on-wire cursor format (from `PaginationCursor` to `SortCursorState`), which could invalidate existing cursors across deployments.
- Handling this inside `wand_loop` by inspecting `score_adjust` would couple the WAND code to higher-level concerns and require threading a new signal through the execution layer.

The gate flip is the narrowest correctness fix and matches what the non-fast-path already does.

## Test plan

- [x] New regression test `wand_does_not_prune_against_amplified_scores_on_fast_path` in `searchlite-core/tests/function_score.rs`. Without the fix the top-1 is `doc-1` (the buggy result); with the fix it's `doc-2` (the doc with the highest BM25, which is indexed last and is the document WAND skips when it terminates early). The test also cross-checks against `track_total_hits = true`, which takes the non-fast-path and has never had the bug.
- [x] `cargo test -p searchlite-core` — all 737 tests pass.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy -p searchlite-core --all-features -- -D warnings` — clean.