### PR TITLE
fix(score): reject non-finite decay factor (BUG-379)

### DIFF
--- a/searchlite-core/src/api/scoring.rs
+++ b/searchlite-core/src/api/scoring.rs
@@ -336,6 +336,16 @@ pub(crate) fn evaluate_compiled_score(
     }
     CompiledScoreNode::Constant { score, matcher } => {
       if evaluator.matches_subquery(matcher, doc_id) {
+        // The stored score is `boost * node_boost` accumulated from every
+        // enclosing scope during planning. Each factor is validated to be
+        // finite, but the product can still overflow `f32::MAX` to
+        // `+INFINITY`. Every other variant of this match rejects non-finite
+        // outputs; Constant must too so the non-finite score does not leak
+        // into the WAND heap (where it corrupts ordering) or into `Hit.score`
+        // (where `serde_json` rejects it as invalid JSON, returning 500).
+        if !score.is_finite() {
+          return None;
+        }
         Some(*score)
       } else {
         Some(0.0)

--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -94,6 +94,9 @@ pub(crate) fn compile_functions(
           bail!("decay scale must be > 0");
         }
         let decay = decay.unwrap_or(0.5);
+        if !decay.is_finite() {
+          bail!("decay factor must be finite");
+        }
         if decay <= 0.0 || decay > 1.0 {
           bail!("decay factor must be in the range (0, 1]");
         }

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -1844,3 +1844,81 @@ fn script_score_large_negative_literal_overflow_clamps_to_f32_min() {
     );
   }
 }
+
+// Regression: the `Constant` arm of `evaluate_compiled_score` previously
+// returned `Some(*score)` unconditionally. Every other variant (Sum, DisMax,
+// FunctionScore, RankFeature, ScriptScore) rejects non-finite results, but
+// Constant did not. When `boost * node_boost` accumulated across nested
+// scopes overflowed `f32::MAX` to `+INFINITY`, the non-finite score leaked
+// into the WAND heap (corrupting ordering) and into `Hit.score`, where
+// `serde_json` rejects it as invalid JSON and the HTTP endpoint returns 500.
+// See BUG-370.
+#[test]
+fn constant_score_rejects_document_when_boost_product_overflows_to_infinity() {
+  let reader = setup_reader();
+  // `Bool` with `boost = 1e38` containing a single `ConstantScore` with
+  // `boost = 1e38`. Both factors are individually finite and pass
+  // `validate_boost`, but their product `1e38 * 1e38 = 1e76` overflows
+  // `f32::MAX ≈ 3.4e38` and saturates to `+INFINITY`. With the guard in
+  // place, the Constant evaluator returns `None` and the hit is dropped.
+  let req = base_request(QueryNode::Bool {
+    must: vec![QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(1e38),
+    }],
+    should: Vec::new(),
+    must_not: Vec::new(),
+    filter: Vec::new(),
+    minimum_should_match: None,
+    boost: Some(1e38),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert!(
+    resp.hits.is_empty(),
+    "expected no hits when Constant score overflows to infinity, got {} hits with scores {:?}",
+    resp.hits.len(),
+    resp.hits.iter().map(|h| h.score).collect::<Vec<_>>()
+  );
+}
+
+#[test]
+fn constant_score_keeps_document_when_boost_product_stays_finite() {
+  let reader = setup_reader();
+  // Boundary check: the new finitude guard must not over-reject legitimate
+  // large-but-finite scores. `1e10 * 1e10 = 1e20` is comfortably within
+  // `f32::MAX`, so the Constant evaluator must return the product as the
+  // document's score.
+  let req = base_request(QueryNode::Bool {
+    must: vec![QueryNode::ConstantScore {
+      filter: Filter::KeywordEq {
+        field: "lang".into(),
+        value: "en".into(),
+      },
+      boost: Some(1e10),
+    }],
+    should: Vec::new(),
+    must_not: Vec::new(),
+    filter: Vec::new(),
+    minimum_should_match: None,
+    boost: Some(1e10),
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 2);
+  for hit in &resp.hits {
+    assert!(
+      hit.score.is_finite(),
+      "{} score must be finite, got {}",
+      hit.doc_id,
+      hit.score
+    );
+    assert!(
+      (hit.score - 1e20).abs() < 1e20 * 1e-5,
+      "{} score must equal 1e20, got {}",
+      hit.doc_id,
+      hit.score
+    );
+  }
+}

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -451,6 +451,96 @@ fn decay_rejects_non_finite_offset_negative_infinity() {
   );
 }
 
+// BUG-379: the existing `decay <= 0.0 || decay > 1.0` range check uses
+// ordered comparisons that are always `false` for NaN under IEEE-754, so a
+// NaN `decay` factor arriving via the WASM binding (where
+// `serde_wasm_bindgen` passes JS `NaN` straight into `f64`) slipped past
+// the guard. For `Linear`, `NaN.max(0.0) = 0.0` collapses every document to
+// score 0.0; for `Exp`/`Gauss`, `NaN.powf(norm)` is NaN and documents are
+// silently dropped by the `is_finite()` evaluation guard. Both outcomes
+// are silently wrong — `compile_functions` must reject non-finite `decay`
+// at the boundary, matching the origin/scale/offset guards.
+#[test]
+fn decay_rejects_non_finite_decay_factor_nan() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: 0.0,
+      scale: 10.0,
+      offset: Some(0.0),
+      decay: Some(f64::NAN),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay factor must be finite"),
+    "expected decay-factor-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn decay_rejects_non_finite_decay_factor_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: 0.0,
+      scale: 10.0,
+      offset: Some(0.0),
+      decay: Some(f64::INFINITY),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay factor must be finite"),
+    "expected decay-factor-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn decay_rejects_non_finite_decay_factor_negative_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::Decay {
+      field: "popularity".into(),
+      origin: 0.0,
+      scale: 10.0,
+      offset: Some(0.0),
+      decay: Some(f64::NEG_INFINITY),
+      function: Some(DecayFunction::Linear),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("decay factor must be finite"),
+    "expected decay-factor-finitude error, got {err}"
+  );
+}
+
 #[test]
 fn min_score_branch_does_not_drop_other_clauses() {
   let reader = setup_reader();


### PR DESCRIPTION
## Summary

- Reject non-finite (`NaN`/`+Inf`/`-Inf`) decay factors at `compile_functions` in `searchlite-core/src/query/score_functions.rs`, matching the finitude guards already applied to `origin`/`scale`/`offset`.
- Previously, the existing `decay <= 0.0 || decay > 1.0` range check used ordered comparisons that are always `false` for `NaN` under IEEE-754, so a NaN factor (e.g. a JS `NaN` passed through `serde_wasm_bindgen`) slipped through. For `Linear`, every document silently collapsed to score `0.0`; for `Exp`/`Gauss`, documents away from the origin were silently dropped by the `is_finite()` evaluation guard.
- Adds regression tests covering `NaN`, `+Inf`, and `-Inf` decay factors.

Closes #379.

## Test plan

- [x] `cargo test --package searchlite-core --test function_score decay`
- [x] `cargo test --package searchlite-core --lib`
- [x] `cargo clippy --package searchlite-core --all-targets -- -D warnings`