### PR TITLE
fix(vectors): reject cosine vectors whose sum-of-squares overflows f32 (BUG-384)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -509,9 +509,13 @@ impl IndexReader {
         // BUG-384: reject cosine query vectors whose squared magnitudes sum
         // past `f32::MAX` (e.g. `[3e19, 3e19]`). Each component passes the
         // per-value finitude guard above, but their sum-of-squares is `+inf`,
-        // and `normalize_in_place` would otherwise leave the vector un-scaled
-        // or silently zero it — returning uniformly zero cosine scores for
-        // every hit.
+        // so `normalize_in_place` would skip scaling and leave the vector
+        // un-normalized, producing meaningless or wildly large cosine dot
+        // products that violate the unit-length assumption cosine scoring
+        // relies on. (Historically, the unguarded division by `+inf` inside
+        // `normalize_in_place` also silently zeroed every component, hiding
+        // the query entirely; either failure mode is unactionable for the
+        // caller, so surface it as a plain error here.)
         let sum_sq = query_vec.iter().map(|v| v * v).sum::<f32>();
         if !sum_sq.is_finite() {
           bail!(

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -506,6 +506,19 @@ impl IndexReader {
         schema_field.metric,
         crate::index::manifest::VectorMetric::Cosine
       ) {
+        // BUG-384: reject cosine query vectors whose squared magnitudes sum
+        // past `f32::MAX` (e.g. `[3e19, 3e19]`). Each component passes the
+        // per-value finitude guard above, but their sum-of-squares is `+inf`,
+        // and `normalize_in_place` would otherwise leave the vector un-scaled
+        // or silently zero it — returning uniformly zero cosine scores for
+        // every hit.
+        let sum_sq = query_vec.iter().map(|v| v * v).sum::<f32>();
+        if !sum_sq.is_finite() {
+          bail!(
+            "vector query for field `{}` cannot be normalized: sum-of-squares overflows f32",
+            vector_query.field
+          );
+        }
         normalize_in_place(&mut query_vec);
       }
       let alpha = vector_query.alpha.unwrap_or(DEFAULT_VECTOR_ALPHA);

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -526,11 +526,14 @@ fn collect_vector_value(
   }
   if matches!(vf.metric, VectorMetric::Cosine) {
     // BUG-384: reject cosine-indexed vectors whose squared magnitudes sum past
-    // `f32::MAX` before `normalize_in_place` silently skips the division.
-    // Each component passes the per-value finitude check above, but their
-    // sum-of-squares can still overflow (e.g. `[3e19, 3e19]`), and an
-    // un-normalized (or silently zeroed) cosine vector is invisible to every
-    // subsequent query for the lifetime of the segment.
+    // `f32::MAX` before `normalize_in_place` skips the division. Each
+    // component passes the per-value finitude check above, but their sum-of-
+    // squares can still overflow (e.g. `[3e19, 3e19]`). Cosine scoring
+    // assumes unit-length vectors, so persisting one that cannot be
+    // normalized would feed the query path a vector that either distorts
+    // downstream scores (post-fix: left un-scaled when the norm is non-
+    // finite) or silently collapses to all-zero (pre-fix: division by
+    // `+inf`). Refuse at commit time so the segment never captures it.
     let sum_sq = vecvals.iter().map(|v| v * v).sum::<f32>();
     if !sum_sq.is_finite() {
       bail!("vector field {field} cannot be normalized: sum-of-squares overflows f32");

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -525,6 +525,16 @@ fn collect_vector_value(
     );
   }
   if matches!(vf.metric, VectorMetric::Cosine) {
+    // BUG-384: reject cosine-indexed vectors whose squared magnitudes sum past
+    // `f32::MAX` before `normalize_in_place` silently skips the division.
+    // Each component passes the per-value finitude check above, but their
+    // sum-of-squares can still overflow (e.g. `[3e19, 3e19]`), and an
+    // un-normalized (or silently zeroed) cosine vector is invisible to every
+    // subsequent query for the lifetime of the segment.
+    let sum_sq = vecvals.iter().map(|v| v * v).sum::<f32>();
+    if !sum_sq.is_finite() {
+      bail!("vector field {field} cannot be normalized: sum-of-squares overflows f32");
+    }
     normalize_in_place(&mut vecvals);
   }
   Ok(Some(vecvals))

--- a/searchlite-core/src/vectors/mod.rs
+++ b/searchlite-core/src/vectors/mod.rs
@@ -73,7 +73,13 @@ impl VectorStore {
 
 pub fn normalize_in_place(vec: &mut [f32]) {
   let norm = vec.iter().map(|v| v * v).sum::<f32>().sqrt();
-  if norm > 0.0 {
+  // BUG-384: the sum-of-squares of individually-finite components can still
+  // overflow `f32::MAX` to `+inf` (e.g. `[3e19, 3e19]`). Under `norm = +inf`,
+  // `v / norm` silently collapses every component to `0.0`, poisoning any
+  // downstream cosine similarity. Leave the vector un-normalized in that case
+  // so the caller's overflow guard surfaces an actionable error rather than a
+  // segment with all-zero cosine vectors that are invisible to every query.
+  if norm > 0.0 && norm.is_finite() {
     for v in vec.iter_mut() {
       *v /= norm;
     }
@@ -126,4 +132,46 @@ pub fn blend_scores(bm25: f32, vector_score: f32, alpha: f32, higher_is_better: 
     -vector_score
   };
   alpha * bm25 + (1.0 - alpha) * vec_component
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn normalize_in_place_scales_finite_vector_to_unit_length() {
+    let mut v = vec![3.0_f32, 4.0_f32];
+    normalize_in_place(&mut v);
+    assert!((v[0] - 0.6).abs() < 1e-6, "expected 0.6, got {}", v[0]);
+    assert!((v[1] - 0.8).abs() < 1e-6, "expected 0.8, got {}", v[1]);
+    let norm_sq: f32 = v.iter().map(|x| x * x).sum();
+    assert!((norm_sq - 1.0).abs() < 1e-6);
+  }
+
+  // BUG-384: `[3e19, 3e19]` has finite components but `(3e19)^2 = 9e38` alone
+  // already exceeds `f32::MAX`, so the sum-of-squares saturates to `+inf`. The
+  // pre-fix code computed `norm = sqrt(inf) = inf`, passed the `norm > 0.0`
+  // check, and then divided every component by `inf` — silently zeroing the
+  // vector and poisoning every downstream cosine score to exactly `0`.
+  #[test]
+  fn normalize_in_place_leaves_vector_untouched_when_sum_of_squares_overflows() {
+    let input: Vec<f32> = vec![3.0e19_f32, 3.0e19_f32];
+    let mut v = input.clone();
+    normalize_in_place(&mut v);
+    assert_eq!(
+      v, input,
+      "non-finite norm must leave the vector un-normalized, not zero it"
+    );
+    assert!(
+      v.iter().all(|x| *x == 3.0e19_f32),
+      "no component should be silently collapsed to zero"
+    );
+  }
+
+  #[test]
+  fn normalize_in_place_leaves_zero_vector_untouched() {
+    let mut v = vec![0.0_f32, 0.0_f32];
+    normalize_in_place(&mut v);
+    assert_eq!(v, vec![0.0, 0.0]);
+  }
 }

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -937,3 +937,132 @@ fn vector_query_with_finite_boundary_components_is_accepted() {
   };
   let _ = reader.search(&req).expect("boundary f32 values are finite");
 }
+
+// BUG-384: cosine cosine-cast query vectors with individually-finite components
+// whose squared magnitudes sum past `f32::MAX` used to reach
+// `normalize_in_place`, which silently turned them into an all-zero vector.
+// Downstream cosine dot products against any document vector then returned 0
+// for every hit, so the query silently matched nothing even though the caller
+// supplied a well-formed vector. Reject it at the same layer as BUG-340 so
+// callers get an actionable error.
+#[test]
+fn cosine_query_vector_with_overflowing_sum_of_squares_is_rejected() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("rust search")),
+        ("embedding".into(), serde_json::json!([1.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  // Each component is finite (`3e19 < f32::MAX ≈ 3.4e38`) and passes the
+  // BUG-340 per-component guard, but `(3e19)^2 + (3e19)^2 = 1.8e39` overflows
+  // `f32::MAX` to `+inf`.
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![3.0e19_f32, 3.0e19_f32],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("cannot be normalized")
+      && err.contains("sum-of-squares")
+      && err.contains("embedding"),
+    "expected sum-of-squares overflow error, got {err}"
+  );
+}
+
+// BUG-384: cosine-indexed documents whose squared magnitudes sum past
+// `f32::MAX` used to be silently written as an all-zero normalized vector.
+// Commit must refuse the document so the segment does not capture a corrupt
+// vector that is invisible to every subsequent query.
+#[test]
+fn commit_rejects_cosine_vector_with_overflowing_sum_of_squares() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  let mut writer = idx.writer().expect("writer");
+  // Each component is finite but their squared magnitudes sum to `+inf`.
+  let doc = Document {
+    fields: [
+      ("_id".into(), serde_json::json!("overflow-norm")),
+      ("body".into(), serde_json::json!("body")),
+      (
+        "embedding".into(),
+        serde_json::json!([3.0e19_f64, 3.0e19_f64]),
+      ),
+    ]
+    .into_iter()
+    .collect(),
+  };
+  writer.add_document(&doc).expect("staging accepts the doc");
+  let err = writer.commit().unwrap_err().to_string();
+  assert!(
+    err.contains("cannot be normalized") && err.contains("sum-of-squares"),
+    "expected sum-of-squares overflow error, got {err}"
+  );
+}
+
+// Companion: a cosine-indexed document and query where the sum-of-squares is
+// finite but close to the boundary still round-trip successfully — the new
+// guard must not reject legitimate inputs.
+#[test]
+fn cosine_vector_with_finite_sum_of_squares_round_trips() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  // `(1e19)^2 = 1e38 < f32::MAX ≈ 3.4e38`, so the sum-of-squares stays finite.
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("finite-norm")),
+        ("body".into(), serde_json::json!("rust search")),
+        ("embedding".into(), serde_json::json!([1.0e19_f64, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![1.0e19_f32, 0.0],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let hits = reader
+    .search(&req)
+    .expect("finite sum-of-squares must be accepted")
+    .hits;
+  assert!(!hits.is_empty(), "expected the single doc to match");
+  assert_eq!(hits[0].doc_id.as_str(), "finite-norm");
+}

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -938,13 +938,15 @@ fn vector_query_with_finite_boundary_components_is_accepted() {
   let _ = reader.search(&req).expect("boundary f32 values are finite");
 }
 
-// BUG-384: cosine cosine-cast query vectors with individually-finite components
-// whose squared magnitudes sum past `f32::MAX` used to reach
-// `normalize_in_place`, which silently turned them into an all-zero vector.
-// Downstream cosine dot products against any document vector then returned 0
-// for every hit, so the query silently matched nothing even though the caller
-// supplied a well-formed vector. Reject it at the same layer as BUG-340 so
-// callers get an actionable error.
+// BUG-384: cosine query vectors with individually-finite components whose
+// squared magnitudes sum past `f32::MAX` used to reach `normalize_in_place`,
+// where division by `+inf` silently turned them into an all-zero vector — so
+// downstream cosine dot products returned 0 for every hit and the query
+// matched nothing even though the caller supplied a well-formed vector. The
+// defensive `is_finite()` guard now skips normalization instead of zeroing
+// it, but an un-normalized cosine vector still violates the unit-length
+// assumption and produces garbage scores. Reject the input at the same layer
+// as BUG-340 so callers get an actionable error either way.
 #[test]
 fn cosine_query_vector_with_overflowing_sum_of_squares_is_rejected() {
   let dir = tempdir().unwrap();


### PR DESCRIPTION
## Summary

Fixes BUG-384 (#384). `normalize_in_place` computed `norm = sqrt(sum_of_squares)` and only guarded with `norm > 0.0` — a check that passes for `+inf`. Each vector component can be individually finite (and thus pass the existing BUG-330 / BUG-340 per-component finitude guards) yet their sum-of-squares overflows `f32::MAX` during normalization (e.g. `(3e19)^2 + (3e19)^2 = 1.8e39`). Dividing by `+inf` silently collapses every component to `0.0`, so the resulting cosine vector scores `0` against every query or document for the lifetime of the segment — the doc / query becomes invisible with no error surfaced to the caller.

Same class of bug as BUG-370 / BUG-381 (boost-product overflow): each input is individually within range, but the arithmetic combination overflows and poisons downstream scoring.

## Changes

- `searchlite-core/src/vectors/mod.rs`
  - `normalize_in_place`: guard with `norm.is_finite()` so a non-finite norm leaves the vector un-normalized instead of silently zeroing it. Mirrors the defensive pattern used by every other non-finite-score guard in the repo.
  - New `vectors::tests` unit module: `normalize_in_place_scales_finite_vector_to_unit_length`, `normalize_in_place_leaves_vector_untouched_when_sum_of_squares_overflows`, `normalize_in_place_leaves_zero_vector_untouched`.
- `searchlite-core/src/api/reader.rs` (cosine query vector path, after BUG-340 per-component guard)
  - Compute sum-of-squares; bail with `"vector query for field '{}' cannot be normalized: sum-of-squares overflows f32"` if non-finite so callers get an actionable error instead of a silent-miss response.
- `searchlite-core/src/index/segment.rs::collect_vector_value` (cosine-indexed documents, after BUG-330 per-component guard)
  - Same sum-of-squares guard; commit refuses the doc before it would be persisted as an all-zero cosine vector.
- `searchlite-core/tests/vector_search.rs`
  - `cosine_query_vector_with_overflowing_sum_of_squares_is_rejected` — cosine query with `[3e19, 3e19]` must surface the overflow error.
  - `commit_rejects_cosine_vector_with_overflowing_sum_of_squares` — same input on the writer path must fail at commit.
  - `cosine_vector_with_finite_sum_of_squares_round_trips` — boundary-safe `[1e19, 0.0]` (sum-of-squares `1e38 < f32::MAX`) must still index and search successfully; the new guard must not over-reject legitimate inputs.

## Test plan

- [x] `cargo fmt --all --check` — clean.
- [x] `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean.
- [x] `cargo test -p searchlite-core --features vectors` — 520 lib tests + all integration suites green (including the 3 new unit tests in `vectors::tests` and the 3 new integration regressions in `tests/vector_search.rs`).
- [x] Reverted only the `searchlite-core/src/**` changes locally and confirmed both integration regressions (`cosine_query_vector_with_overflowing_sum_of_squares_is_rejected`, `commit_rejects_cosine_vector_with_overflowing_sum_of_squares`) genuinely fail — they exercise the bug rather than tautologically passing.

Closes #384