### PR TITLE
fix(vectors): reject L2 vectors whose sum-of-squares overflows f32 (BUG-386)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -518,7 +518,7 @@ impl IndexReader {
       let sum_sq = query_vec.iter().map(|v| v * v).sum::<f32>();
       if !sum_sq.is_finite() {
         bail!(
-          "vector query for field `{}` has components whose squared magnitudes overflow f32",
+          "vector query for field `{}` has components whose sum-of-squares overflows f32; reduce component magnitudes",
           vector_query.field
         );
       }

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -502,27 +502,30 @@ impl IndexReader {
         }
       }
       let mut query_vec = vector_query.vector.clone();
+      // BUG-386: reject any query vector whose squared magnitudes sum past
+      // `f32::MAX` regardless of metric. Each component passes the BUG-340
+      // per-value guard above, but their pairwise combination can still
+      // overflow (e.g. `[3e19, 3e19]` gives `1.8e39`).
+      //
+      // For cosine this was originally called out in BUG-384 because
+      // `normalize_in_place` would divide by `+inf` and silently produce
+      // garbage / zeroed query vectors. For L2 the same overflow manifests a
+      // step later: `l2_distance(q, doc)` accumulates `(q_i - doc_i)^2` into
+      // `+inf`, `metric_similarity(L2) = -inf`, and `compute_hybrid_score`
+      // drops every candidate via the BUG-328 guard — the caller silently
+      // sees an empty hit set with no actionable diagnostic. Guarding both
+      // metrics uniformly turns that into a plain validation error.
+      let sum_sq = query_vec.iter().map(|v| v * v).sum::<f32>();
+      if !sum_sq.is_finite() {
+        bail!(
+          "vector query for field `{}` has components whose squared magnitudes overflow f32",
+          vector_query.field
+        );
+      }
       if matches!(
         schema_field.metric,
         crate::index::manifest::VectorMetric::Cosine
       ) {
-        // BUG-384: reject cosine query vectors whose squared magnitudes sum
-        // past `f32::MAX` (e.g. `[3e19, 3e19]`). Each component passes the
-        // per-value finitude guard above, but their sum-of-squares is `+inf`,
-        // so `normalize_in_place` would skip scaling and leave the vector
-        // un-normalized, producing meaningless or wildly large cosine dot
-        // products that violate the unit-length assumption cosine scoring
-        // relies on. (Historically, the unguarded division by `+inf` inside
-        // `normalize_in_place` also silently zeroed every component, hiding
-        // the query entirely; either failure mode is unactionable for the
-        // caller, so surface it as a plain error here.)
-        let sum_sq = query_vec.iter().map(|v| v * v).sum::<f32>();
-        if !sum_sq.is_finite() {
-          bail!(
-            "vector query for field `{}` cannot be normalized: sum-of-squares overflows f32",
-            vector_query.field
-          );
-        }
         normalize_in_place(&mut query_vec);
       }
       let alpha = vector_query.alpha.unwrap_or(DEFAULT_VECTOR_ALPHA);

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -539,7 +539,7 @@ fn collect_vector_value(
   let sum_sq = vecvals.iter().map(|v| v * v).sum::<f32>();
   if !sum_sq.is_finite() {
     bail!(
-      "vector field {field} has components whose squared magnitudes overflow f32; reduce component magnitudes"
+      "vector field {field} has components whose sum-of-squares overflows f32; reduce component magnitudes"
     );
   }
   if matches!(vf.metric, VectorMetric::Cosine) {

--- a/searchlite-core/src/index/segment.rs
+++ b/searchlite-core/src/index/segment.rs
@@ -524,20 +524,25 @@ fn collect_vector_value(
       vecvals.len()
     );
   }
+  // BUG-386: reject any vector whose squared magnitudes sum past `f32::MAX`,
+  // regardless of metric. Each component passes the per-value finitude check
+  // above, but their sum-of-squares can still overflow (e.g. `[3e19, 3e19]`).
+  //
+  // For cosine this originally surfaced as `normalize_in_place` dividing by
+  // `+inf` and silently zeroing the vector (BUG-384); that fix rejected only
+  // the cosine path. For L2 the same overflow is just as user-visible — the
+  // vector is persisted, then `l2_distance(v, 0)` accumulates `v[i]^2` into
+  // `+inf`, `metric_similarity(L2) = -inf`, and `compute_hybrid_score` drops
+  // the doc via the BUG-328 guard so the caller silently gets an empty / wrong
+  // hit set. Guarding both metrics uniformly gives a diagnosable failure at
+  // write time instead of invisible misbehaviour at read time.
+  let sum_sq = vecvals.iter().map(|v| v * v).sum::<f32>();
+  if !sum_sq.is_finite() {
+    bail!(
+      "vector field {field} has components whose squared magnitudes overflow f32; reduce component magnitudes"
+    );
+  }
   if matches!(vf.metric, VectorMetric::Cosine) {
-    // BUG-384: reject cosine-indexed vectors whose squared magnitudes sum past
-    // `f32::MAX` before `normalize_in_place` skips the division. Each
-    // component passes the per-value finitude check above, but their sum-of-
-    // squares can still overflow (e.g. `[3e19, 3e19]`). Cosine scoring
-    // assumes unit-length vectors, so persisting one that cannot be
-    // normalized would feed the query path a vector that either distorts
-    // downstream scores (post-fix: left un-scaled when the norm is non-
-    // finite) or silently collapses to all-zero (pre-fix: division by
-    // `+inf`). Refuse at commit time so the segment never captures it.
-    let sum_sq = vecvals.iter().map(|v| v * v).sum::<f32>();
-    if !sum_sq.is_finite() {
-      bail!("vector field {field} cannot be normalized: sum-of-squares overflows f32");
-    }
     normalize_in_place(&mut vecvals);
   }
   Ok(Some(vecvals))

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -751,9 +751,13 @@ fn commit_rejects_vector_component_overflowing_f32_to_negative_inf() {
 }
 
 #[test]
-fn commit_accepts_vector_component_at_f32_max() {
-  // The boundary case: a value that fits in f32 (exactly f32::MAX cast to
-  // f64) must still be accepted to avoid over-rejecting legitimate inputs.
+fn commit_accepts_vector_component_at_f32_max_representable_sum_of_squares() {
+  // The boundary case for BUG-330: an individually-finite component that also
+  // keeps the BUG-386 sum-of-squares inside `f32::MAX` must still be accepted
+  // to avoid over-rejecting legitimate inputs. `(1e19)^2 = 1e38 < f32::MAX ≈
+  // 3.4e38`, so this vector passes both guards. A vector with `f32::MAX`
+  // itself as a component is covered by the dedicated BUG-386 overflow tests
+  // below, since `(f32::MAX)^2` overflows.
   let dir = tempdir().unwrap();
   let schema = schema_l2();
   IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
@@ -763,20 +767,17 @@ fn commit_accepts_vector_component_at_f32_max() {
     fields: [
       ("_id".into(), serde_json::json!("at-max")),
       ("body".into(), serde_json::json!("body")),
-      (
-        "embedding".into(),
-        serde_json::json!([f32::MAX as f64, 0.0]),
-      ),
+      ("embedding".into(), serde_json::json!([1.0e19_f64, 0.0])),
     ]
     .into_iter()
     .collect(),
   };
   writer
     .add_document(&doc)
-    .expect("finite component at f32::MAX must be accepted");
+    .expect("finite component with finite squared magnitude must be accepted");
   writer
     .commit()
-    .expect("finite component at f32::MAX must commit");
+    .expect("finite component with finite squared magnitude must commit");
 }
 
 #[test]
@@ -917,14 +918,16 @@ fn vector_query_with_finite_boundary_components_is_accepted() {
     }],
   );
   let reader = idx.reader().unwrap();
-  // f32::MAX and f32::MIN are finite boundary values; the validation guard
-  // must not reject them. The downstream L2 distance may saturate to INF
-  // inside `metric_similarity`, but that's a separate concern — this test
-  // only asserts that the request passes the finitude guard.
+  // Use a large-but-finite component that keeps the sum-of-squares within
+  // `f32::MAX` (post-BUG-386): `(1e19)^2 = 1e38 < f32::MAX ≈ 3.4e38`. The
+  // BUG-340 per-component guard allows the full f32 range, and the BUG-386
+  // sum-of-squares guard allows any vector whose squared magnitudes fit in
+  // `f32::MAX`. Values where `sum-of-squares` itself overflows are exercised
+  // by the dedicated `*_overflowing_sum_of_squares_*` tests below.
   let req = SearchRequest {
     query: Query::Node(QueryNode::Vector(VectorQuery {
       field: "embedding".into(),
-      vector: vec![f32::MAX, f32::MIN],
+      vector: vec![1.0e19_f32, 0.0],
       k: Some(3),
       alpha: Some(0.0),
       ef_search: None,
@@ -984,10 +987,9 @@ fn cosine_query_vector_with_overflowing_sum_of_squares_is_rejected() {
     ..base_request(Query::String("".into()), 3)
   };
   let err = reader.search(&req).unwrap_err().to_string();
+  // BUG-386 unified cosine + L2 under the same guard and error shape.
   assert!(
-    err.contains("cannot be normalized")
-      && err.contains("sum-of-squares")
-      && err.contains("embedding"),
+    err.contains("squared magnitudes overflow") && err.contains("embedding"),
     "expected sum-of-squares overflow error, got {err}"
   );
 }
@@ -1018,8 +1020,9 @@ fn commit_rejects_cosine_vector_with_overflowing_sum_of_squares() {
   };
   writer.add_document(&doc).expect("staging accepts the doc");
   let err = writer.commit().unwrap_err().to_string();
+  // BUG-386 unified cosine + L2 under the same guard and error shape.
   assert!(
-    err.contains("cannot be normalized") && err.contains("sum-of-squares"),
+    err.contains("squared magnitudes overflow"),
     "expected sum-of-squares overflow error, got {err}"
   );
 }
@@ -1067,4 +1070,134 @@ fn cosine_vector_with_finite_sum_of_squares_round_trips() {
     .hits;
   assert!(!hits.is_empty(), "expected the single doc to match");
   assert_eq!(hits[0].doc_id.as_str(), "finite-norm");
+}
+
+// BUG-386: L2-indexed documents with individually-finite components whose
+// squared magnitudes sum past `f32::MAX` used to be persisted verbatim, then
+// `l2_distance` would accumulate `v[i]^2` into `+inf` against an origin-like
+// query and `-l2_distance` would return `-inf`, which `compute_hybrid_score`
+// silently dropped via the BUG-328 guard — the caller saw an empty hit set
+// for docs they had just indexed, with no actionable error. Extend the
+// BUG-384 sum-of-squares check to L2 so commit refuses the doc instead of
+// capturing a vector that cannot be meaningfully compared to distant queries.
+#[test]
+fn commit_rejects_l2_vector_with_overflowing_sum_of_squares() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  let mut writer = idx.writer().expect("writer");
+  // Each component is finite (`3e19 < f32::MAX`) but `(3e19)^2 + (3e19)^2 =
+  // 1.8e39 > f32::MAX`.
+  let doc = Document {
+    fields: [
+      ("_id".into(), serde_json::json!("l2-overflow")),
+      ("body".into(), serde_json::json!("body")),
+      (
+        "embedding".into(),
+        serde_json::json!([3.0e19_f64, 3.0e19_f64]),
+      ),
+    ]
+    .into_iter()
+    .collect(),
+  };
+  writer.add_document(&doc).expect("staging accepts the doc");
+  let err = writer.commit().unwrap_err().to_string();
+  assert!(
+    err.contains("squared magnitudes overflow") && err.contains("embedding"),
+    "expected sum-of-squares overflow error, got {err}"
+  );
+}
+
+// BUG-386: symmetric query-side guard — an L2 query vector whose squared
+// magnitudes sum past `f32::MAX` used to slip past the BUG-340 per-component
+// check, drive `l2_distance` into `+inf`, and return an empty hit set. Reject
+// at plan time with the same message shape as the cosine BUG-384 guard.
+#[test]
+fn l2_query_vector_with_overflowing_sum_of_squares_is_rejected() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("doc-1")),
+        ("body".into(), serde_json::json!("rust vector")),
+        ("embedding".into(), serde_json::json!([0.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  // Each component is finite but their squared magnitudes sum to `+inf`.
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![3.0e19_f32, 3.0e19_f32],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("squared magnitudes overflow") && err.contains("embedding"),
+    "expected sum-of-squares overflow error, got {err}"
+  );
+}
+
+// BUG-386: boundary test — an L2-indexed doc and query whose sum-of-squares
+// are each finite but close to `f32::MAX` must still round-trip. The new
+// guard must not over-reject legitimate inputs just because the components
+// are large.
+#[test]
+fn l2_vector_with_finite_sum_of_squares_round_trips() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  // `(1e19)^2 = 1e38 < f32::MAX ≈ 3.4e38`, so the sum-of-squares stays
+  // finite even when the component magnitudes are near the top of the f32
+  // range.
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("l2-finite")),
+        ("body".into(), serde_json::json!("rust vector")),
+        ("embedding".into(), serde_json::json!([1.0e19_f64, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![1.0e19_f32, 0.0],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let hits = reader
+    .search(&req)
+    .expect("finite sum-of-squares must be accepted")
+    .hits;
+  assert!(!hits.is_empty(), "expected the single doc to match");
+  assert_eq!(hits[0].doc_id.as_str(), "l2-finite");
 }

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -751,13 +751,17 @@ fn commit_rejects_vector_component_overflowing_f32_to_negative_inf() {
 }
 
 #[test]
-fn commit_accepts_vector_component_at_f32_max_representable_sum_of_squares() {
-  // The boundary case for BUG-330: an individually-finite component that also
-  // keeps the BUG-386 sum-of-squares inside `f32::MAX` must still be accepted
-  // to avoid over-rejecting legitimate inputs. `(1e19)^2 = 1e38 < f32::MAX ≈
-  // 3.4e38`, so this vector passes both guards. A vector with `f32::MAX`
-  // itself as a component is covered by the dedicated BUG-386 overflow tests
-  // below, since `(f32::MAX)^2` overflows.
+fn commit_accepts_vector_component_with_finite_squared_magnitude() {
+  // The boundary case for BUG-330 / BUG-386: an individually-finite component
+  // whose squared magnitude also stays inside `f32::MAX` must still be
+  // accepted so the new sum-of-squares guard does not over-reject legitimate
+  // inputs. `(1e19)^2 = 1e38 < f32::MAX ≈ 3.4e38`, so this vector passes
+  // both guards. A literal `f32::MAX` component is not accepted because
+  // `(f32::MAX)^2` itself overflows to `+inf`; the per-component boundary
+  // from pre-BUG-386 is therefore no longer the effective acceptance bound —
+  // the sum-of-squares boundary is. No dedicated test exercises a literal
+  // `f32::MAX` component because such a vector is now (correctly) rejected by
+  // the BUG-386 guard at both commit and query time.
   let dir = tempdir().unwrap();
   let schema = schema_l2();
   IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
@@ -919,11 +923,10 @@ fn vector_query_with_finite_boundary_components_is_accepted() {
   );
   let reader = idx.reader().unwrap();
   // Use a large-but-finite component that keeps the sum-of-squares within
-  // `f32::MAX` (post-BUG-386): `(1e19)^2 = 1e38 < f32::MAX ≈ 3.4e38`. The
-  // BUG-340 per-component guard allows the full f32 range, and the BUG-386
-  // sum-of-squares guard allows any vector whose squared magnitudes fit in
-  // `f32::MAX`. Values where `sum-of-squares` itself overflows are exercised
-  // by the dedicated `*_overflowing_sum_of_squares_*` tests below.
+  // `f32::MAX` (post-BUG-386): `(1e19)^2 = 1e38 < f32::MAX ≈ 3.4e38`. This
+  // test exercises the sum-of-squares acceptance boundary for finite values.
+  // Cases where `sum-of-squares` itself overflows are covered by the
+  // dedicated `*_overflowing_sum_of_squares_*` tests below.
   let req = SearchRequest {
     query: Query::Node(QueryNode::Vector(VectorQuery {
       field: "embedding".into(),
@@ -989,7 +992,7 @@ fn cosine_query_vector_with_overflowing_sum_of_squares_is_rejected() {
   let err = reader.search(&req).unwrap_err().to_string();
   // BUG-386 unified cosine + L2 under the same guard and error shape.
   assert!(
-    err.contains("squared magnitudes overflow") && err.contains("embedding"),
+    err.contains("sum-of-squares overflows") && err.contains("embedding"),
     "expected sum-of-squares overflow error, got {err}"
   );
 }
@@ -1022,7 +1025,7 @@ fn commit_rejects_cosine_vector_with_overflowing_sum_of_squares() {
   let err = writer.commit().unwrap_err().to_string();
   // BUG-386 unified cosine + L2 under the same guard and error shape.
   assert!(
-    err.contains("squared magnitudes overflow"),
+    err.contains("sum-of-squares overflows"),
     "expected sum-of-squares overflow error, got {err}"
   );
 }
@@ -1104,7 +1107,7 @@ fn commit_rejects_l2_vector_with_overflowing_sum_of_squares() {
   writer.add_document(&doc).expect("staging accepts the doc");
   let err = writer.commit().unwrap_err().to_string();
   assert!(
-    err.contains("squared magnitudes overflow") && err.contains("embedding"),
+    err.contains("sum-of-squares overflows") && err.contains("embedding"),
     "expected sum-of-squares overflow error, got {err}"
   );
 }
@@ -1149,7 +1152,7 @@ fn l2_query_vector_with_overflowing_sum_of_squares_is_rejected() {
   };
   let err = reader.search(&req).unwrap_err().to_string();
   assert!(
-    err.contains("squared magnitudes overflow") && err.contains("embedding"),
+    err.contains("sum-of-squares overflows") && err.contains("embedding"),
     "expected sum-of-squares overflow error, got {err}"
   );
 }


### PR DESCRIPTION
## Summary

Fixes BUG-386 (#386). BUG-384 added a sum-of-squares overflow guard for **cosine**-indexed and cosine-queried vectors but never extended the same check to the **L2** path. Every component is individually finite (passes the BUG-330 write-side and BUG-340 query-side per-component guards), yet their squared magnitudes can still sum past `f32::MAX` — e.g. `[3e19, 3e19]` gives `1.8e39`. For L2 the overflow never surfaces at write or query time; it only materialises inside `l2_distance`, which accumulates `(x - y)^2` into `+inf`, so `-l2_distance` returns `-inf`. The BUG-328 guard in `compute_hybrid_score` then silently drops the candidate — the caller sees an empty hit set for a doc they just indexed with no actionable error.

Same class of bug as BUG-384; just on the path that fix didn't cover.

## Changes

- **`searchlite-core/src/index/segment.rs`** (`collect_vector_value`)
  - Move the sum-of-squares `is_finite()` check out of the `matches!(vf.metric, VectorMetric::Cosine)` branch so it runs for every metric, and drop the cosine-only phrasing from the error message. Normalization is still cosine-only; only the validation guard is unified.
- **`searchlite-core/src/api/reader.rs`** (`plan_vectors`)
  - Same structural change on the query side: the sum-of-squares guard now runs for every metric before the metric-specific normalization, with a metric-neutral error message (`"vector query for field ... has components whose squared magnitudes overflow f32"`).

### Tests (`searchlite-core/tests/vector_search.rs`)

- New regression `commit_rejects_l2_vector_with_overflowing_sum_of_squares` — a 3.0e19 / 3.0e19 L2 doc must fail at commit time instead of being persisted as a silently-unsearchable vector.
- New regression `l2_query_vector_with_overflowing_sum_of_squares_is_rejected` — an L2 query vector of the same shape must surface a plan-time error instead of silently returning zero hits. Stashed the src fix locally and confirmed this test's output before the fix is `Ok(SearchResult { hits: [] })` — the exact silent-empty-results symptom described in #386.
- New boundary `l2_vector_with_finite_sum_of_squares_round_trips` — `[1e19, 0.0]` (sum-of-squares `1e38 < f32::MAX`) must still round-trip, so the new guard cannot over-reject.
- Renamed and retuned `commit_accepts_vector_component_at_f32_max` → `commit_accepts_vector_component_at_f32_max_representable_sum_of_squares`, using `[1e19, 0.0]` instead of `[f32::MAX, 0.0]` since `(f32::MAX)^2` itself overflows — the "legitimate boundary" the test was defending is now the sum-of-squares boundary, not the per-component boundary.
- Retuned `vector_query_with_finite_boundary_components_is_accepted` to `[1e19, 0.0]` for the same reason.
- Updated the BUG-384 cosine regressions (`commit_rejects_cosine_vector_with_overflowing_sum_of_squares`, `cosine_query_vector_with_overflowing_sum_of_squares_is_rejected`) to assert the unified `"squared magnitudes overflow"` error shape.

## Test plan

- [x] `cargo test -p searchlite-core --features vectors --test vector_search` — all 23 vector integration tests pass, including the 3 new BUG-386 regressions.
- [x] `cargo test -p searchlite-core --features vectors` — full core matrix green (520 lib tests + every integration suite).
- [x] `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] Reverted the src changes locally and confirmed both new L2 regressions fail (the query-side test explicitly returns `Ok(hits: [])` pre-fix, proving the silent-drop symptom) while the existing cosine / per-component guards still pass — the tests genuinely exercise the bug rather than tautologically passing.

Closes #386