### PR TITLE
fix(vectors): saturate l2_distance overflow to f32::MAX (BUG-388)

### DIFF
--- a/searchlite-core/src/vectors/mod.rs
+++ b/searchlite-core/src/vectors/mod.rs
@@ -107,7 +107,25 @@ pub fn l2_distance(a: &[f32], b: &[f32]) -> f32 {
     let d = x - y;
     sum += d * d;
   }
-  sum.sqrt()
+  let dist = sum.sqrt();
+  // BUG-388: saturate to `f32::MAX` when the accumulated sum overflows.
+  // BUG-384 / BUG-386 bound every indexed and queried vector to
+  // `sum(v_i^2) <= f32::MAX`, which constrains `|v_i| <= sqrt(f32::MAX) ≈
+  // 1.84e19` per component. Pairwise `|a_i - b_i|` can still reach
+  // `3.68e19`, so `(a_i - b_i)^2` can exceed `f32::MAX` in a single
+  // dimension (e.g. `a = [1.5e19, 0]`, `b = [-1.5e19, 0]` gives `(3e19)^2
+  // = 9e38 > f32::MAX`). Without a guard here, `sum` saturates to `+inf`,
+  // `sqrt(+inf) = +inf`, `metric_similarity(L2) = -inf`, and the BUG-328
+  // hybrid-score guard silently drops the doc from results. Returning a
+  // finite sentinel keeps the ordering well-defined (the doc ranks at the
+  // bottom, consistent with `missing_vector_score(L2) = f32::MIN`) and
+  // prevents non-finite scores from leaking into HNSW graph construction,
+  // `compute_hybrid_score`, or the explanation payload.
+  if dist.is_finite() {
+    dist
+  } else {
+    f32::MAX
+  }
 }
 
 pub fn metric_similarity(metric: &VectorMetric, a: &[f32], b: &[f32]) -> f32 {
@@ -173,5 +191,81 @@ mod tests {
     let mut v = vec![0.0_f32, 0.0_f32];
     normalize_in_place(&mut v);
     assert_eq!(v, vec![0.0, 0.0]);
+  }
+
+  // BUG-388: even with the BUG-384 / BUG-386 sum-of-squares guard at the
+  // validation boundary (every indexed and queried vector has
+  // `sum(v_i^2) <= f32::MAX`, so `|v_i| <= sqrt(f32::MAX) ≈ 1.84e19`),
+  // pairwise `|a_i - b_i|` can still reach `3.68e19`, so the per-dimension
+  // squared difference `(a_i - b_i)^2` can exceed `f32::MAX` in a single
+  // dimension. Before the guard, `sum` saturated to `+inf`, `sqrt(+inf) =
+  // +inf`, and `metric_similarity(L2) = -inf` flowed into
+  // `compute_hybrid_score`, which silently dropped the candidate via the
+  // BUG-328 non-finite guard. After the guard, `l2_distance` returns a
+  // finite sentinel so the doc ranks at the bottom instead of silently
+  // disappearing from the result set.
+  #[test]
+  fn l2_distance_saturates_to_f32_max_when_squared_diff_overflows() {
+    // Both vectors pass the BUG-386 sum-of-squares guard: `(1.5e19)^2 =
+    // 2.25e38 < f32::MAX ≈ 3.4e38`. But `(a[0] - b[0])^2 = (3e19)^2 =
+    // 9e38 > f32::MAX`, which overflows the accumulator in a single step.
+    let a = [1.5e19_f32, 0.0_f32];
+    let b = [-1.5e19_f32, 0.0_f32];
+    let sum_a: f32 = a.iter().map(|v| v * v).sum();
+    let sum_b: f32 = b.iter().map(|v| v * v).sum();
+    assert!(
+      sum_a.is_finite() && sum_b.is_finite(),
+      "precondition: both vectors must pass BUG-386 sum-of-squares guard (sum_a={sum_a}, sum_b={sum_b})",
+    );
+    let dist = l2_distance(&a, &b);
+    assert!(dist.is_finite(), "expected finite distance, got {dist}");
+    assert_eq!(
+      dist,
+      f32::MAX,
+      "overflow must saturate to `f32::MAX`, not `+inf` or `0`",
+    );
+  }
+
+  // BUG-388: the downstream `metric_similarity(L2)` contract is that its
+  // output is always finite when inputs pass validation — the BUG-328
+  // hybrid guard uses the finitude of the blended score to decide whether
+  // to drop a candidate, so a non-finite return here is observationally
+  // identical to "the doc doesn't exist" from the caller's perspective.
+  #[test]
+  fn metric_similarity_l2_stays_finite_when_l2_distance_overflows() {
+    use crate::api::types::VectorMetric;
+    let a = [1.5e19_f32, 0.0_f32];
+    let b = [-1.5e19_f32, 0.0_f32];
+    let sim = metric_similarity(&VectorMetric::L2, &a, &b);
+    assert!(
+      sim.is_finite(),
+      "metric_similarity(L2) must be finite when l2_distance overflows, got {sim}",
+    );
+  }
+
+  // Boundary: an in-range pairwise squared diff must not be truncated by
+  // the saturation guard. `(1e9 - (-1e9))^2 = (2e9)^2 = 4e18`, well below
+  // `f32::MAX`; the accurate distance `sqrt(4e18) = 2e9` must be returned
+  // as-is so the guard doesn't over-clamp legitimate distances.
+  #[test]
+  fn l2_distance_preserves_finite_result_within_range() {
+    let a = [1.0e9_f32, 0.0_f32];
+    let b = [-1.0e9_f32, 0.0_f32];
+    let dist = l2_distance(&a, &b);
+    assert!(dist.is_finite(), "in-range distance must remain finite");
+    let expected = 2.0e9_f32;
+    let tolerance = expected * 1e-5;
+    assert!(
+      (dist - expected).abs() < tolerance,
+      "expected ~{expected}, got {dist}",
+    );
+  }
+
+  // Sanity: the ordinary 3-4-5 triangle still round-trips exactly.
+  #[test]
+  fn l2_distance_returns_exact_value_for_small_vectors() {
+    let a = [0.0_f32, 0.0_f32];
+    let b = [3.0_f32, 4.0_f32];
+    assert_eq!(l2_distance(&a, &b), 5.0);
   }
 }

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -1068,3 +1068,87 @@ fn cosine_vector_with_finite_sum_of_squares_round_trips() {
   assert!(!hits.is_empty(), "expected the single doc to match");
   assert_eq!(hits[0].doc_id.as_str(), "finite-norm");
 }
+
+// BUG-388: the BUG-384 / BUG-386 sum-of-squares guards bound every indexed
+// and queried vector to `sum(v_i^2) <= f32::MAX`, which constrains
+// `|v_i| <= sqrt(f32::MAX) ≈ 1.84e19` per component. But pairwise
+// `|a_i - b_i|` can still reach `3.68e19`, so a single dimension's squared
+// difference can overflow `f32::MAX`. Before the `l2_distance` saturation
+// guard, `sum` saturated to `+inf`, `metric_similarity(L2) = -inf`, and the
+// BUG-328 hybrid-score guard silently dropped the far doc from the result
+// set with no error. After the guard, `l2_distance` returns a finite
+// sentinel (`f32::MAX`) so the doc is returned (ranked last) instead of
+// silently disappearing.
+#[test]
+fn l2_search_returns_far_doc_when_pairwise_squared_diff_overflows() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  // Both vectors pass the per-vector sum-of-squares bound: `(1.5e19)^2 =
+  // 2.25e38 < f32::MAX ≈ 3.4e38`. But their pairwise `d[0] = 3.0e19` and
+  // `d[0]^2 = 9e38 > f32::MAX` overflows the `l2_distance` accumulator in a
+  // single step.
+  add_docs(
+    &idx,
+    &[
+      Document {
+        fields: [
+          ("_id".into(), serde_json::json!("near")),
+          ("body".into(), serde_json::json!("rust vector")),
+          ("embedding".into(), serde_json::json!([1.5e19_f64, 0.0_f64])),
+        ]
+        .into_iter()
+        .collect(),
+      },
+      Document {
+        fields: [
+          ("_id".into(), serde_json::json!("far")),
+          ("body".into(), serde_json::json!("rust search")),
+          (
+            "embedding".into(),
+            serde_json::json!([-1.5e19_f64, 0.0_f64]),
+          ),
+        ]
+        .into_iter()
+        .collect(),
+      },
+    ],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![1.5e19_f32, 0.0_f32],
+      k: Some(10),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(10),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 10)
+  };
+  let hits = reader
+    .search(&req)
+    .expect("pairwise-overflow distance must not fail the query")
+    .hits;
+  let ids: Vec<_> = hits.iter().map(|h| h.doc_id.as_str().to_string()).collect();
+  assert!(
+    ids.contains(&"far".to_string()),
+    "`far` doc with overflowing pairwise distance must be returned, not silently dropped; got ids={ids:?}",
+  );
+  assert!(
+    ids.contains(&"near".to_string()),
+    "`near` doc must remain in results alongside `far`; got ids={ids:?}",
+  );
+  for hit in hits.iter() {
+    assert!(
+      hit.score.is_finite(),
+      "every hit score must be finite; doc {} had score {}",
+      hit.doc_id,
+      hit.score,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Fixes BUG-388 (#388). BUG-384 / BUG-386 bound every indexed and queried L2 vector to `sum(v_i^2) <= f32::MAX`, which constrains `|v_i| <= sqrt(f32::MAX) ≈ 1.84e19` per component. But pairwise `|a_i - b_i|` can still reach `3.68e19`, so a single dimension's squared difference `(a_i - b_i)^2` can exceed `f32::MAX` in the `l2_distance` accumulator — even when both vectors pass every validation at the boundary.

Before this fix: `sum` saturated to `+inf`, `sqrt(+inf) = +inf`, `metric_similarity(L2) = -inf` flowed into `compute_hybrid_score`, and the BUG-328 non-finite guard silently dropped the candidate. The caller saw a missing doc from a legitimately-indexed document with no error or diagnostic — the same silent-drop symptom BUG-386 was meant to prevent, on the orthogonal input shape BUG-386's own "Suggested fix" section explicitly flagged as a needed follow-up:

> *"Add a lightweight overflow guard inside `l2_distance` itself as belt-and-braces for any code path that bypasses validation (explanations, HNSW construction-time similarity, future callers)."*

PR #387 addresses the sum-of-squares validation at the write/query boundary but does not touch `vectors/mod.rs`; this PR is orthogonal.

## Reproduction (numerically verified)

```text
a = [1.5e19, 0]      sum(a_i^2) = 2.25e38 < f32::MAX (3.4e38)  — passes BUG-386
b = [-1.5e19, 0]     sum(b_i^2) = 2.25e38 < f32::MAX            — passes BUG-386
(a[0] - b[0])^2      = (3e19)^2 = 9e38 > f32::MAX               — OVERFLOWS to +inf
l2_distance(a, b)    = +inf
metric_similarity(L2) = -inf                                    — silently dropped
```

## Changes

- **`searchlite-core/src/vectors/mod.rs`** (`l2_distance`)
  - Check `dist.is_finite()` after `sum.sqrt()`. Non-finite result → saturate to `f32::MAX` so downstream callers (HNSW construction/search, `compute_hybrid_score`, explanation payload) always observe a finite distance and the doc ranks at the bottom of the L2 order rather than silently disappearing. The saturation value is consistent with the existing `missing_vector_score(L2) = f32::MIN` sentinel.

### Tests

- **`searchlite-core/src/vectors/mod.rs`** (unit)
  - `l2_distance_saturates_to_f32_max_when_squared_diff_overflows` — the exact pairwise-overflow pair from the reproduction above: both vectors pass BUG-386 but produce an overflowing distance. Asserts the distance is finite **and** equal to `f32::MAX`.
  - `metric_similarity_l2_stays_finite_when_l2_distance_overflows` — end-to-end contract: `metric_similarity(L2)` must never return non-finite when its inputs pass validation.
  - `l2_distance_preserves_finite_result_within_range` — boundary test: `sqrt(4e18) = 2e9` must round-trip through the new guard without being truncated, so we don't over-clamp legitimate distances.
  - `l2_distance_returns_exact_value_for_small_vectors` — sanity: the 3-4-5 triangle is unchanged.

- **`searchlite-core/tests/vector_search.rs`** (integration)
  - `l2_search_returns_far_doc_when_pairwise_squared_diff_overflows` — indexes both `near = [1.5e19, 0]` and `far = [-1.5e19, 0]`, queries with `[1.5e19, 0]`, and asserts both are returned with finite scores. Before the fix, `far` was silently dropped by the `compute_hybrid_score` BUG-328 guard.

## Test plan

- [x] `cargo test -p searchlite-core --features vectors --lib vectors::` — 9 tests pass (includes 4 new BUG-388 unit regressions).
- [x] `cargo test -p searchlite-core --features vectors --test vector_search` — 21 tests pass (includes the new BUG-388 integration regression).
- [x] `cargo test -p searchlite-core --features vectors` — full core matrix green: 524 lib tests + all integration suites.
- [x] `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] Reverted the `l2_distance` guard locally and confirmed both new unit regressions (`l2_distance_saturates_to_f32_max_…`, `metric_similarity_l2_stays_finite_…`) **and** the integration regression (`l2_search_returns_far_doc_…`) fail before the fix — the tests genuinely exercise the bug rather than tautologically passing.

Closes #388
