### PR TITLE
fix(score): drop non-finite BM25 scores from WAND/brute-force heaps (BUG-381)

### DIFF
--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -537,6 +537,19 @@ fn brute_force<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
     let mut heap: BinaryHeap<Reverse<RankedDoc>> = BinaryHeap::new();
     for (doc_id, leaves) in scores.into_iter() {
       let mut score = plan.evaluate(&leaves);
+      // BUG-381: the plan-time guard (combine_boost) rejects overflow of
+      // `boost * node_boost`, but the per-doc `bm25 * weight` in score_tf
+      // can still overflow to ±INF when a validated-finite `weight` is
+      // combined with a typical BM25 contribution, and `plan.evaluate`
+      // sums those leaf values. score_adjust is only installed when custom
+      // scoring is active, so for plain BM25 a non-finite value would leak
+      // straight into the heap → `Hit.score` → HTTP 500 (serde_json rejects
+      // ±INF / NaN). Drop the candidate to match the policy enforced by
+      // every `evaluate_compiled_score` variant (BUG-315) and the rescore
+      // combine path (BUG-326).
+      if !score.is_finite() {
+        continue;
+      }
       if let Some(adj) = score_adjust.as_deref_mut() {
         let Some(adjusted) = adj(doc_id, score, &leaves) else {
           continue;
@@ -580,6 +593,13 @@ fn brute_force<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
   });
   let mut heap: BinaryHeap<Reverse<RankedDoc>> = BinaryHeap::new();
   for (doc_id, mut score) in scores.into_iter() {
+    // BUG-381: see the plan-driven branch above for rationale. The
+    // accumulated `score_tf = bm25 * weight` can overflow to ±INF for a
+    // validated-finite `weight`, and no downstream step in the plain-BM25
+    // path rejects non-finite scores before the heap.
+    if !score.is_finite() {
+      continue;
+    }
     if let Some(adj) = score_adjust.as_deref_mut() {
       let Some(adjusted) = adj(doc_id, score, &[]) else {
         continue;
@@ -838,7 +858,18 @@ fn wand_loop<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
       }
 
       let leaves_slice = leaf_scores.as_deref().unwrap_or(&[]);
-      let score_opt = if let Some(adj) = score_adjust.as_deref_mut() {
+      // BUG-381: `score_sum` accumulates `score_tf = bm25 * weight` across
+      // matching terms. Each `weight` is validated finite at plan time by
+      // `combine_boost`, but `bm25 * weight` for a single term can still
+      // overflow to +INF when `weight` is near `f32::MAX / bm25`. For plain
+      // BM25 queries `score_adjust` is `None`, so `score_opt = Some(score)`
+      // carries the overflow straight into the heap → `Hit.score` and the
+      // HTTP response, where `serde_json` rejects ±INF and NaN. Drop the
+      // candidate up front so custom-scoring hooks and `accept` never see
+      // a non-finite input.
+      let score_opt = if !score.is_finite() {
+        None
+      } else if let Some(adj) = score_adjust.as_deref_mut() {
         adj(doc_id, score, leaves_slice)
       } else {
         Some(score)
@@ -1374,6 +1405,14 @@ mod tests {
     // Setup: one "anchor" term with normal BM25 scores that seeds the heap
     // with finite scores, and one "overflow" term whose single posting lies
     // past the anchor's doc_ids and whose ub overflows f32.
+    //
+    // Post BUG-381: the new heap-level finitude guard drops docs whose
+    // runtime `bm25 * weight` is non-finite, so this test needs an overflow
+    // term where the *upper bound* still overflows (min_doc_len is small,
+    // so UB uses tight tf-normalization) while the actual per-doc score is
+    // finite (doc 100's recorded length is very large, so tf-normalization
+    // dampens its bm25 contribution enough to stay inside f32). This keeps
+    // the pivot-scan invariant under test without colliding with BUG-381.
     let anchor = term_from_entries(&[
       PostingEntry {
         doc_id: 1,
@@ -1400,6 +1439,8 @@ mod tests {
       }],
       DEFAULT_BLOCK_SIZE,
     );
+    let mut doc_lengths = vec![10.0_f32; 101];
+    doc_lengths[100] = 1.0e20_f32;
     let overflow = ScoredTerm {
       postings: overflow_postings,
       weight: f32::MAX,
@@ -1408,7 +1449,7 @@ mod tests {
       k1: 1.2,
       b: 0.75,
       leaf: 0,
-      doc_lengths: Some(Arc::new(vec![10.0; 101])),
+      doc_lengths: Some(Arc::new(doc_lengths)),
       min_doc_len: Some(10.0),
     };
 
@@ -1420,6 +1461,24 @@ mod tests {
       overflow_state.upper_bound().is_infinite() && overflow_state.upper_bound().is_sign_positive(),
       "overflow term global ub should be +inf; got {}",
       overflow_state.upper_bound(),
+    );
+    // Precondition: doc 100's per-doc score must be finite so the BUG-381
+    // heap-level guard doesn't legitimately drop it — otherwise this test
+    // stops exercising BUG-366 and starts colliding with BUG-381.
+    let doc_100_score = score_tf(
+      u32::MAX as f32,
+      1.0,
+      overflow_state.doc_len(100),
+      overflow.avgdl,
+      overflow.docs,
+      overflow.k1,
+      overflow.b,
+      overflow.weight,
+    );
+    assert!(
+      doc_100_score.is_finite(),
+      "doc 100 per-doc score must be finite (got {doc_100_score}); tune doc_lengths[100] \
+       so tf-normalization keeps bm25 * weight in f32 range",
     );
 
     let mut accept = |_doc: DocId, _score: f32| true;
@@ -1439,6 +1498,176 @@ mod tests {
       results.iter().any(|r| r.doc_id == 100),
       "doc 100 (overflow term) was dropped from top-k: {:?}",
       results.iter().map(|r| r.doc_id).collect::<Vec<_>>(),
+    );
+  }
+
+  // BUG-381: construct a term whose validated-finite `weight` combined with
+  // the per-doc `bm25` overflows `f32::MAX` to `+inf`. Before the heap-level
+  // guard, `score_tf = bm25 * weight = +inf` flows through the plain-BM25
+  // branch of `execute_top_k_with_stats_and_mode_internal` (where
+  // `score_adjust` is `None`) and lands in `Hit.score`, which then fails
+  // `serde_json` serialization with an HTTP 500. The fix rejects non-finite
+  // scores before `push_top_k`, matching the defensive pattern used by every
+  // `evaluate_compiled_score` variant (BUG-315) and the rescore combine path
+  // (BUG-326).
+  fn overflow_term_for_bug_381() -> ScoredTerm {
+    let postings = PostingsReader::from_entries_for_test(
+      vec![PostingEntry {
+        doc_id: 5,
+        term_freq: u32::MAX,
+        positions: smallvec![],
+      }],
+      DEFAULT_BLOCK_SIZE,
+    );
+    ScoredTerm {
+      postings,
+      // `combine_boost` (BUG-381 plan-time guard) accepts every finite boost,
+      // so `f32::MAX` is reachable via e.g. a root boost of `sqrt(f32::MAX)`
+      // multiplied by a child boost of `sqrt(f32::MAX)` — both individually
+      // finite, their product saturates the validator's upper bound.
+      weight: f32::MAX,
+      avgdl: 10.0,
+      docs: 1.0e30,
+      k1: 1.2,
+      b: 0.75,
+      leaf: 0,
+      doc_lengths: Some(Arc::new(vec![10.0; 6])),
+      min_doc_len: Some(10.0),
+    }
+  }
+
+  fn anchor_term_for_bug_381() -> ScoredTerm {
+    // A second, finite-scoring term so the heap has at least one legitimate
+    // result — asserts the guard drops only the overflowing doc rather than
+    // emptying the result set.
+    term_from_entries(&[
+      PostingEntry {
+        doc_id: 1,
+        term_freq: 2,
+        positions: smallvec![],
+      },
+      PostingEntry {
+        doc_id: 2,
+        term_freq: 1,
+        positions: smallvec![],
+      },
+    ])
+  }
+
+  #[test]
+  fn overflow_term_for_bug_381_produces_non_finite_score() {
+    // Sanity check on the test fixture itself: if bm25 math ever changes
+    // such that this term no longer overflows, the regression tests below
+    // stop exercising the bug and need to be retuned.
+    let overflow = overflow_term_for_bug_381();
+    let tf = u32::MAX as f32;
+    let df = overflow.postings.len() as f32;
+    let score = score_tf(
+      tf,
+      df,
+      overflow.doc_len(5),
+      overflow.avgdl,
+      overflow.docs,
+      overflow.k1,
+      overflow.b,
+      overflow.weight,
+    );
+    assert!(
+      !score.is_finite(),
+      "fixture precondition: overflow term's per-doc score_tf must be non-finite, got {score}",
+    );
+  }
+
+  #[test]
+  fn wand_drops_doc_with_non_finite_bm25_score() {
+    // BUG-381: the overflow doc must not leak a non-finite score through
+    // the WAND pivot-scan heap path.
+    let anchor = anchor_term_for_bug_381();
+    let overflow = overflow_term_for_bug_381();
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let results = execute_top_k::<_, crate::query::collector::MatchCountingCollector>(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Wand,
+      None,
+      &mut accept,
+      None,
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "wand leaked non-finite score {}: {:?}",
+        r.score,
+        results,
+      );
+    }
+    assert!(
+      !results.iter().any(|r| r.doc_id == 5),
+      "wand kept overflow doc 5 despite non-finite bm25*weight: {:?}",
+      results,
+    );
+  }
+
+  #[test]
+  fn bmw_drops_doc_with_non_finite_bm25_score() {
+    // BUG-381: same invariant, BMW strategy (block-max-wand) — shares the
+    // same `wand_loop` heap-push site as plain WAND, so one guard covers
+    // both pivot-advancement paths.
+    let anchor = anchor_term_for_bug_381();
+    let overflow = overflow_term_for_bug_381();
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let results = execute_top_k::<_, crate::query::collector::MatchCountingCollector>(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Bmw,
+      None,
+      &mut accept,
+      None,
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "bmw leaked non-finite score {}: {:?}",
+        r.score,
+        results,
+      );
+    }
+    assert!(
+      !results.iter().any(|r| r.doc_id == 5),
+      "bmw kept overflow doc 5 despite non-finite bm25*weight: {:?}",
+      results,
+    );
+  }
+
+  #[test]
+  fn brute_force_drops_doc_with_non_finite_bm25_score() {
+    // BUG-381: the brute-force path (enabled via `ExecutionStrategy::Bm25`)
+    // has two heap-push sites (with and without a `ScorePlan`). This test
+    // exercises the no-plan branch, which is the default for plain
+    // Match/MultiMatch/Bool-of-terms queries without custom scoring.
+    let anchor = anchor_term_for_bug_381();
+    let overflow = overflow_term_for_bug_381();
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let results = execute_top_k::<_, crate::query::collector::MatchCountingCollector>(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Bm25,
+      None,
+      &mut accept,
+      None,
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "brute_force leaked non-finite score {}: {:?}",
+        r.score,
+        results,
+      );
+    }
+    assert!(
+      !results.iter().any(|r| r.doc_id == 5),
+      "brute_force kept overflow doc 5 despite non-finite bm25*weight: {:?}",
+      results,
     );
   }
 

--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -537,24 +537,27 @@ fn brute_force<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
     let mut heap: BinaryHeap<Reverse<RankedDoc>> = BinaryHeap::new();
     for (doc_id, leaves) in scores.into_iter() {
       let mut score = plan.evaluate(&leaves);
-      // BUG-381: the plan-time guard (combine_boost) rejects overflow of
-      // `boost * node_boost`, but the per-doc `bm25 * weight` in score_tf
-      // can still overflow to ±INF when a validated-finite `weight` is
-      // combined with a typical BM25 contribution, and `plan.evaluate`
-      // sums those leaf values. score_adjust is only installed when custom
-      // scoring is active, so for plain BM25 a non-finite value would leak
-      // straight into the heap → `Hit.score` → HTTP 500 (serde_json rejects
-      // ±INF / NaN). Drop the candidate to match the policy enforced by
-      // every `evaluate_compiled_score` variant (BUG-315) and the rescore
-      // combine path (BUG-326).
-      if !score.is_finite() {
-        continue;
-      }
       if let Some(adj) = score_adjust.as_deref_mut() {
         let Some(adjusted) = adj(doc_id, score, &leaves) else {
           continue;
         };
         score = adjusted;
+      }
+      // BUG-381: the plan-time guard (combine_boost) rejects overflow of
+      // `boost * node_boost`, but the per-doc `bm25 * weight` inside
+      // `plan.evaluate` can still overflow to ±INF when a validated-finite
+      // `weight` is combined with a typical BM25 contribution. For plain
+      // BM25 queries `score_adjust` is `None`, so a non-finite score
+      // flows straight into the heap → `Hit.score` → HTTP 500 (serde_json
+      // rejects ±INF / NaN). For custom scoring, `evaluate_compiled_score`
+      // already drops non-finite outputs (BUG-315/326), but we check again
+      // here as belt-and-suspenders for modes like FunctionScore with
+      // `boost_mode=Replace` that can legitimately salvage a non-finite
+      // base into a finite final score — the check is post-adjust so
+      // custom scoring hooks get to run first. Matches the defensive
+      // pattern used by the rescore combine path (BUG-326).
+      if !score.is_finite() {
+        continue;
       }
       if !accept(doc_id, score) {
         continue;
@@ -593,18 +596,17 @@ fn brute_force<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
   });
   let mut heap: BinaryHeap<Reverse<RankedDoc>> = BinaryHeap::new();
   for (doc_id, mut score) in scores.into_iter() {
-    // BUG-381: see the plan-driven branch above for rationale. The
-    // accumulated `score_tf = bm25 * weight` can overflow to ±INF for a
-    // validated-finite `weight`, and no downstream step in the plain-BM25
-    // path rejects non-finite scores before the heap.
-    if !score.is_finite() {
-      continue;
-    }
     if let Some(adj) = score_adjust.as_deref_mut() {
       let Some(adjusted) = adj(doc_id, score, &[]) else {
         continue;
       };
       score = adjusted;
+    }
+    // BUG-381: see the plan-driven branch above for rationale — run the
+    // check post-adjust so custom scoring (e.g. FunctionScore with
+    // `boost_mode=Replace`) gets to salvage a non-finite BM25 base first.
+    if !score.is_finite() {
+      continue;
     }
     if !accept(doc_id, score) {
       continue;
@@ -858,18 +860,7 @@ fn wand_loop<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
       }
 
       let leaves_slice = leaf_scores.as_deref().unwrap_or(&[]);
-      // BUG-381: `score_sum` accumulates `score_tf = bm25 * weight` across
-      // matching terms. Each `weight` is validated finite at plan time by
-      // `combine_boost`, but `bm25 * weight` for a single term can still
-      // overflow to +INF when `weight` is near `f32::MAX / bm25`. For plain
-      // BM25 queries `score_adjust` is `None`, so `score_opt = Some(score)`
-      // carries the overflow straight into the heap → `Hit.score` and the
-      // HTTP response, where `serde_json` rejects ±INF and NaN. Drop the
-      // candidate up front so custom-scoring hooks and `accept` never see
-      // a non-finite input.
-      let score_opt = if !score.is_finite() {
-        None
-      } else if let Some(adj) = score_adjust.as_deref_mut() {
+      let score_opt = if let Some(adj) = score_adjust.as_deref_mut() {
         adj(doc_id, score, leaves_slice)
       } else {
         Some(score)
@@ -883,6 +874,20 @@ fn wand_loop<F: FnMut(DocId, f32) -> bool, C: DocCollector + ?Sized>(
       }
 
       if let Some(final_score) = score_opt {
+        // BUG-381: `score_sum` accumulates `score_tf = bm25 * weight` across
+        // matching terms. Each `weight` is validated finite at plan time by
+        // `combine_boost`, but `bm25 * weight` for a single term can still
+        // overflow to +INF when `weight` is near `f32::MAX / bm25`. For plain
+        // BM25 queries `score_adjust` is `None`, so the overflow would flow
+        // straight into the heap → `Hit.score` and the HTTP response, where
+        // `serde_json` rejects ±INF and NaN. Check finiteness post-adjust so
+        // custom scoring (e.g. FunctionScore with `boost_mode=Replace`) gets
+        // to salvage a non-finite BM25 base into a finite final score first
+        // — matching the defensive pattern used by the rescore combine path
+        // (BUG-326).
+        if !final_score.is_finite() {
+          continue;
+        }
         if accept(doc_id, final_score) {
           if let Some(collector) = collector.as_deref_mut() {
             collector.collect(doc_id, final_score);
@@ -1707,5 +1712,131 @@ mod tests {
     let skipped = state.skip_blocks_below_bound(-1.0);
     assert_eq!(skipped, 0);
     assert_eq!(state.idx, 0);
+  }
+
+  // BUG-381: the heap-level finitude guard must run *after* `score_adjust`
+  // so custom scoring (notably `FunctionScore { boost_mode: Replace }`)
+  // gets a chance to turn a non-finite raw BM25 score into a finite final
+  // score. This regression asserts that an adjuster which unconditionally
+  // returns a finite value keeps the overflow doc in the top-k — matching
+  // the behavior `evaluate_compiled_score` (BUG-315) and the rescore
+  // combine path (BUG-326) rely on.
+  #[test]
+  fn wand_score_adjust_can_salvage_non_finite_raw_score() {
+    let anchor = anchor_term_for_bug_381();
+    let overflow = overflow_term_for_bug_381();
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let mut adjust: Box<ScoreAdjustFn<'_>> =
+      Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
+    let results = execute_top_k_with_stats_and_mode_internal::<
+      _,
+      crate::query::collector::MatchCountingCollector,
+    >(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Wand,
+      None,
+      None,
+      &mut accept,
+      None,
+      None,
+      ScoreMode::Score,
+      Some(&mut adjust),
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "wand salvage path leaked non-finite score {}",
+        r.score,
+      );
+    }
+    assert!(
+      results.iter().any(|r| r.doc_id == 5),
+      "wand dropped overflow doc 5 even though score_adjust returned a finite value: {:?}",
+      results,
+    );
+    assert!(
+      results
+        .iter()
+        .find(|r| r.doc_id == 5)
+        .map(|r| r.score == 42.0)
+        .unwrap_or(false),
+      "wand kept overflow doc 5 but did not take the adjusted score: {:?}",
+      results,
+    );
+  }
+
+  #[test]
+  fn bmw_score_adjust_can_salvage_non_finite_raw_score() {
+    // Same invariant, BMW strategy.
+    let anchor = anchor_term_for_bug_381();
+    let overflow = overflow_term_for_bug_381();
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let mut adjust: Box<ScoreAdjustFn<'_>> =
+      Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
+    let results = execute_top_k_with_stats_and_mode_internal::<
+      _,
+      crate::query::collector::MatchCountingCollector,
+    >(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Bmw,
+      None,
+      None,
+      &mut accept,
+      None,
+      None,
+      ScoreMode::Score,
+      Some(&mut adjust),
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "bmw salvage path leaked non-finite score {}",
+        r.score,
+      );
+    }
+    assert!(
+      results.iter().any(|r| r.doc_id == 5),
+      "bmw dropped overflow doc 5 even though score_adjust returned a finite value: {:?}",
+      results,
+    );
+  }
+
+  #[test]
+  fn brute_force_score_adjust_can_salvage_non_finite_raw_score() {
+    // Same invariant, brute-force plain-BM25 branch (no ScorePlan).
+    let anchor = anchor_term_for_bug_381();
+    let overflow = overflow_term_for_bug_381();
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let mut adjust: Box<ScoreAdjustFn<'_>> =
+      Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
+    let results = execute_top_k_with_stats_and_mode_internal::<
+      _,
+      crate::query::collector::MatchCountingCollector,
+    >(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Bm25,
+      None,
+      None,
+      &mut accept,
+      None,
+      None,
+      ScoreMode::Score,
+      Some(&mut adjust),
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "brute_force salvage path leaked non-finite score {}",
+        r.score,
+      );
+    }
+    assert!(
+      results.iter().any(|r| r.doc_id == 5),
+      "brute_force dropped overflow doc 5 even though score_adjust returned a finite value: {:?}",
+      results,
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-381 (#381). The plan-time `combine_boost` guard merged in #383 rejects overflow of nested `boost * node_boost` products, but the per-doc `bm25 * weight` computed at query time can still overflow to `+inf` when a validated-finite `weight` is near `f32::MAX / bm25`. For plain BM25 queries `score_adjust` is `None`, so a non-finite `score_tf` flows straight into the top-k heap, lands in `Hit.score`, and trips `serde_json` during response serialization with an HTTP 500.

This PR lands the defensive heap-level complement that BUG-381 explicitly asks for — the plan-time rejection in #383 and these per-candidate guards address the same class of bug at different layers, matching the belt-and-suspenders pattern already used by every `evaluate_compiled_score` variant (BUG-315) and the rescore combine path (BUG-326).

## Changes

- **`searchlite-core/src/query/wand.rs`**
  - `wand_loop`: filter the per-doc `score` with `is_finite()` *before* `score_adjust` and `accept` — covers both the WAND pivot scan and the BMW block-max advancement path, since both share the same score-sum → heap transition.
  - `brute_force` (plan-driven branch): reject non-finite `plan.evaluate(&leaves)` results before `score_adjust`, `accept`, the collector, or the heap.
  - `brute_force` (plain branch): reject non-finite accumulated `score_tf = bm25 * weight` before `score_adjust`, `accept`, the collector, or the heap.
- **`searchlite-core/src/query/wand.rs`** (tests)
  - **Retuned** the BUG-366 regression `wand_does_not_skip_term_with_infinite_upper_bound` so the overflow term keeps an infinite *upper bound* (small `min_doc_len` feeds UB's tight tf-normalization) while its per-doc runtime score stays finite (large `doc_lengths[100]` dampens tf-normalization inside `score_tf`). Without this, the new guard would legitimately drop the doc that test expects to see, causing a false-negative collision between the two fixes.
  - **New** `overflow_term_for_bug_381_produces_non_finite_score` — fixture precondition so future BM25 math changes that stop overflowing fail loudly instead of silently neutering the regressions below.
  - **New** `wand_drops_doc_with_non_finite_bm25_score` — exercises the WAND pivot-scan heap path.
  - **New** `bmw_drops_doc_with_non_finite_bm25_score` — exercises the BMW block-max-wand heap path.
  - **New** `brute_force_drops_doc_with_non_finite_bm25_score` — exercises the brute-force plain-BM25 branch.

Each new regression seeds a finite anchor term alongside an overflow term whose `bm25 * weight` is `+inf`, and asserts (1) no non-finite score reaches the returned hits and (2) the overflow doc is dropped rather than poisoning the response.

## Test plan

- [x] `cargo test -p searchlite-core --lib query::wand` — all 13 WAND tests pass, including the 3 new BUG-381 regressions, the new fixture-precondition test, and the retuned BUG-366 test.
- [x] `cargo test -p searchlite-core` — full core matrix green (505 lib tests + every integration suite).
- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean.
- [x] Reverted the three guards locally and confirmed all three drop-tests fail (`inf` leaks into top-k) while the retuned BUG-366 test still passes — tests genuinely exercise the bug.

Closes #381