### PR TITLE
fix(score): reject non-finite field_value_factor `missing` at plan time (BUG-392)

### DIFF
--- a/searchlite-core/src/query/score_functions.rs
+++ b/searchlite-core/src/query/score_functions.rs
@@ -60,6 +60,11 @@ pub(crate) fn compile_functions(
         if !factor.is_finite() {
           bail!("field_value_factor `factor` must be finite");
         }
+        if let Some(m) = missing {
+          if !m.is_finite() {
+            bail!("field_value_factor `missing` must be finite");
+          }
+        }
         ensure_numeric_fast(schema, field, "function_score")?;
         compiled.push(CompiledFunction::FieldValueFactor {
           field: field.clone(),

--- a/searchlite-core/tests/function_score.rs
+++ b/searchlite-core/tests/function_score.rs
@@ -541,6 +541,110 @@ fn decay_rejects_non_finite_decay_factor_negative_infinity() {
   );
 }
 
+// BUG-392: `compile_functions` validates `FieldValueFactor.factor` for
+// finiteness but not `FieldValueFactor.missing`. A non-finite `missing`
+// (NaN, ±Infinity) propagates through `raw * factor` for docs that omit the
+// numeric field; the downstream `scaled.is_finite()` guard then silently
+// drops the doc's function contribution. Mirrors the symmetric guard on
+// `rank_feature.missing` and the `decay` parameter guards: reject
+// non-finite `missing` at the plan boundary with an actionable error.
+#[test]
+fn field_value_factor_rejects_non_finite_missing_nan() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::None),
+      missing: Some(f64::NAN),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("field_value_factor `missing` must be finite"),
+    "expected missing-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn field_value_factor_rejects_non_finite_missing_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::None),
+      missing: Some(f64::INFINITY),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("field_value_factor `missing` must be finite"),
+    "expected missing-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn field_value_factor_rejects_non_finite_missing_negative_infinity() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::None),
+      missing: Some(f64::NEG_INFINITY),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let err = reader.search(&req).unwrap_err().to_string();
+  assert!(
+    err.contains("field_value_factor `missing` must be finite"),
+    "expected missing-finitude error, got {err}"
+  );
+}
+
+#[test]
+fn field_value_factor_accepts_finite_missing() {
+  let reader = setup_reader();
+  let req = base_request(QueryNode::FunctionScore {
+    query: Box::new(QueryNode::MatchAll { boost: None }),
+    functions: vec![FunctionSpec::FieldValueFactor {
+      field: "popularity".into(),
+      factor: 1.0,
+      modifier: Some(FieldValueModifier::None),
+      missing: Some(0.0),
+      filter: None,
+    }],
+    score_mode: Some(FunctionScoreMode::Sum),
+    boost_mode: Some(FunctionBoostMode::Replace),
+    max_boost: None,
+    min_score: None,
+    boost: None,
+  });
+  let resp = reader.search(&req).unwrap();
+  assert_eq!(resp.hits.len(), 3);
+}
+
 #[test]
 fn min_score_branch_does_not_drop_other_clauses() {
   let reader = setup_reader();


### PR DESCRIPTION
## Summary

Fixes BUG-392 (#392). `compile_functions` in `searchlite-core/src/query/score_functions.rs` already validates `FieldValueFactor.factor` for finiteness but applies **no** symmetric guard to `FieldValueFactor.missing`. The parallel `RankFeature.missing` path was hardened in BUG-330 with a plan-time `is_finite()` check; the same guard was never extended to `field_value_factor`.

For docs that omit a nullable numeric field, a non-finite `missing` (NaN, ±Infinity) propagates through `raw * factor`, the downstream `scaled.is_finite()` guard catches the non-finite product, and the function's contribution to that doc is silently dropped. The caller sees a wrong ranking with no actionable diagnostic.

Same class of bug as BUG-330 (rank_feature.missing), BUG-373 (decay origin/offset), and BUG-379 (decay factor): unguarded float input at the validation boundary produces silent document drops instead of a plan-time error.

## Changes

- **`searchlite-core/src/query/score_functions.rs`** (`compile_functions`)
  - `FunctionSpec::FieldValueFactor` arm: reject non-finite `Some(missing)` at the plan boundary with `field_value_factor \`missing\` must be finite`, mirroring the existing `factor` guard shape and the `rank_feature.missing` guard in `api/scoring.rs:175-177`. `None` still defaults to `0.0` unchanged.

### Tests (`searchlite-core/tests/function_score.rs`)

- **New** `field_value_factor_rejects_non_finite_missing_nan` — rejects `Some(f64::NAN)` at plan time with the expected error.
- **New** `field_value_factor_rejects_non_finite_missing_infinity` — rejects `Some(f64::INFINITY)` at plan time.
- **New** `field_value_factor_rejects_non_finite_missing_negative_infinity` — rejects `Some(f64::NEG_INFINITY)` at plan time.
- **New** `field_value_factor_accepts_finite_missing` — `Some(0.0)` still round-trips so the new guard cannot over-reject legitimate inputs.

All four new tests mirror the shape of the existing `decay_rejects_non_finite_*` regressions and the existing `field_value_factor_orders_by_field` happy-path test.

## Test plan

- [x] `cargo test -p searchlite-core --test function_score` — all 66 function_score tests pass, including the 4 new BUG-392 regressions.
- [x] `cargo test -p searchlite-core` — full core matrix green (501 lib tests + every integration suite).
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Reverted the src change locally and confirmed all three `rejects_*` tests fail (search succeeds with an `Ok(SearchResult)` instead of the expected plan-time error) while the happy-path test still passes — tests genuinely exercise the bug rather than tautologically passing.

Closes #392