### PR TITLE
fix(vectors): saturate vscore * boost overflow to f32 range (BUG-394)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -32,6 +32,8 @@ use crate::query::collector::{AggregationSegmentCollector, DocCollector};
 use crate::query::filters::passes_filter;
 use crate::query::planner::{build_query_plan, QueryMatcher, ScorePlan};
 use crate::query::sort::{SortKey, SortPlan};
+#[cfg(feature = "vectors")]
+use crate::query::util::f64_to_finite_f32;
 use crate::query::wand::{
   execute_top_k_with_stats_and_mode_internal, score_tf, QueryStats, ScoreAdjustFn, ScoreMode,
   ScoredTerm,
@@ -952,7 +954,22 @@ impl IndexReader {
               continue;
             }
           }
-          vscore *= clause.boost;
+          // BUG-394: saturate the per-candidate `vscore * boost` product to
+          // the f32 range. Both factors are already validated finite at plan
+          // time (per-component vector guards and `boost.is_finite()`), but
+          // the raw `f32 *= f32` can still overflow to `±INF` for L2, where
+          // BUG-388 saturates `l2_distance` to `f32::MAX` so that
+          // `metric_similarity(L2)` returns the finite sentinel `f32::MIN` at
+          // the worst pair. Any user-supplied `boost > 1.0` would then flip
+          // that sentinel straight back to `-INF`, and the BUG-328 hybrid
+          // score guard silently drops the candidate — undoing BUG-388's
+          // contract that far docs rank last rather than disappear entirely.
+          // Promoting to f64 (which cannot overflow for any finite f32 × f32)
+          // and clamping back to the f32 range via `f64_to_finite_f32` keeps
+          // every legitimate in-range product exact while preventing the
+          // non-finite leak. Mirrors the clamp policy already used by
+          // BUG-336 / BUG-342 on the scoring-side f64→f32 cast.
+          vscore = f64_to_finite_f32((vscore as f64) * (clause.boost as f64));
           let cand = VectorCandidate {
             segment_ord: segment_ord as u32,
             doc_id,

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -1237,14 +1237,15 @@ fn l2_search_with_boost_gt_one_returns_far_doc_when_pairwise_squared_diff_overfl
       hit.doc_id,
       hit.score,
     );
-    if let Some(vs) = hit.vector_score {
-      assert!(
-        vs.is_finite(),
-        "vector_score must be finite after saturating boost multiplication; doc {} had vector_score {}",
-        hit.doc_id,
-        vs,
-      );
-    }
+    let vs = hit
+      .vector_score
+      .expect("vector-only query hits must include vector_score");
+    assert!(
+      vs.is_finite(),
+      "vector_score must be finite after saturating boost multiplication; doc {} had vector_score {}",
+      hit.doc_id,
+      vs,
+    );
   }
 }
 
@@ -1300,4 +1301,12 @@ fn vector_boost_preserves_finite_vscore_product_within_f32_range() {
     "expected vscore ≈ 3.0 (cosine 1.0 * boost 3.0), got {vs}"
   );
   assert!(hits[0].score.is_finite());
+  // Vector-only hybrid query (`alpha = 0.0`) with a single clause must
+  // collapse to `hit.score == hit.vector_score`. Asserting the relationship
+  // catches any future divergence between the two fields end-to-end.
+  assert!(
+    (hits[0].score - vs).abs() < 1e-5,
+    "expected score ≈ vector_score for a vector-only query, got score={} vector_score={vs}",
+    hits[0].score
+  );
 }

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -1152,3 +1152,152 @@ fn l2_search_returns_far_doc_when_pairwise_squared_diff_overflows() {
     );
   }
 }
+
+// BUG-394: BUG-388 saturates `l2_distance` to `f32::MAX` so that
+// `metric_similarity(L2)` returns the finite sentinel `f32::MIN` at the worst
+// pair — avoiding the `-INF` that the BUG-328 hybrid-score guard would
+// otherwise drop. That saturation is local to `l2_distance`, though. The very
+// next step in `collect_vector_maps` is `vscore *= clause.boost`, and any
+// user-supplied `boost > 1.0` turns the `f32::MIN` sentinel straight back
+// into `-INF` via f32 multiplication overflow. The non-finite `vscore` then
+// flows into `vector_scores`, `compute_hybrid_score` rejects it, and the
+// `far` doc is silently dropped again — undoing BUG-388's fix for any query
+// with a non-default boost. This regression is identical in shape to
+// `l2_search_returns_far_doc_when_pairwise_squared_diff_overflows` except for
+// `boost: Some(2.0)`; pre-fix, that single change causes `far` to disappear
+// from the result set, matching exactly the failure mode BUG-388 was written
+// to eliminate.
+#[test]
+fn l2_search_with_boost_gt_one_returns_far_doc_when_pairwise_squared_diff_overflows() {
+  let dir = tempdir().unwrap();
+  let schema = schema_l2();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[
+      Document {
+        fields: [
+          ("_id".into(), serde_json::json!("near")),
+          ("body".into(), serde_json::json!("rust vector")),
+          ("embedding".into(), serde_json::json!([1.5e19_f64, 0.0_f64])),
+        ]
+        .into_iter()
+        .collect(),
+      },
+      Document {
+        fields: [
+          ("_id".into(), serde_json::json!("far")),
+          ("body".into(), serde_json::json!("rust search")),
+          (
+            "embedding".into(),
+            serde_json::json!([-1.5e19_f64, 0.0_f64]),
+          ),
+        ]
+        .into_iter()
+        .collect(),
+      },
+    ],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![1.5e19_f32, 0.0_f32],
+      k: Some(10),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(10),
+      // `boost > 1.0` is the only delta vs the BUG-388 regression: pre-fix,
+      // `f32::MIN * 2.0` overflows to `-INF` and the far doc silently
+      // disappears even though every pre-BUG-394 guard passes.
+      boost: Some(2.0),
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 10)
+  };
+  let hits = reader
+    .search(&req)
+    .expect("pairwise-overflow distance with boost must not fail the query")
+    .hits;
+  let ids: Vec<_> = hits.iter().map(|h| h.doc_id.as_str().to_string()).collect();
+  assert!(
+    ids.contains(&"far".to_string()),
+    "`far` doc must be returned even with boost > 1.0; got ids={ids:?}",
+  );
+  assert!(
+    ids.contains(&"near".to_string()),
+    "`near` doc must remain in results alongside `far`; got ids={ids:?}",
+  );
+  for hit in hits.iter() {
+    assert!(
+      hit.score.is_finite(),
+      "every hit score must be finite; doc {} had score {}",
+      hit.doc_id,
+      hit.score,
+    );
+    if let Some(vs) = hit.vector_score {
+      assert!(
+        vs.is_finite(),
+        "vector_score must be finite after saturating boost multiplication; doc {} had vector_score {}",
+        hit.doc_id,
+        vs,
+      );
+    }
+  }
+}
+
+// BUG-394: boundary test. The f64-then-clamp saturation must not silently
+// perturb legitimate in-range products. A cosine query with `boost = 3.0`
+// against a unit vector produces `vscore = 1.0 * 3.0 = 3.0`, which stays
+// well inside the f32 range. The clamp must preserve the exact product.
+#[test]
+fn vector_boost_preserves_finite_vscore_product_within_f32_range() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[Document {
+      fields: [
+        ("_id".into(), serde_json::json!("only-doc")),
+        ("body".into(), serde_json::json!("rust search")),
+        ("embedding".into(), serde_json::json!([1.0, 0.0])),
+      ]
+      .into_iter()
+      .collect(),
+    }],
+  );
+  let reader = idx.reader().unwrap();
+  let req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![1.0, 0.0],
+      k: Some(3),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(3),
+      boost: Some(3.0),
+    })),
+    vector_query: None,
+    vector_filter: None,
+    ..base_request(Query::String("".into()), 3)
+  };
+  let hits = reader
+    .search(&req)
+    .expect("finite product must be preserved")
+    .hits;
+  assert_eq!(hits.len(), 1);
+  let vs = hits[0]
+    .vector_score
+    .expect("cosine match must carry a vector_score");
+  // Cosine similarity of identical unit vectors is 1.0; times boost=3.0 the
+  // vscore is exactly 3.0. The f64 clamp must not perturb in-range products.
+  assert!(
+    (vs - 3.0).abs() < 1e-5,
+    "expected vscore ≈ 3.0 (cosine 1.0 * boost 3.0), got {vs}"
+  );
+  assert!(hits[0].score.is_finite());
+}


### PR DESCRIPTION
## Summary

Fixes BUG-394 (#394). BUG-388 saturates `l2_distance` to `f32::MAX` so `metric_similarity(L2)` can return the finite sentinel `f32::MIN` at the worst pair — avoiding the `-INF` that the BUG-328 hybrid-score guard would otherwise drop. The saturation is local to `l2_distance`, though: the very next step in `collect_vector_maps` is `vscore *= clause.boost`, and any user-supplied `boost > 1.0` turns the `f32::MIN` sentinel straight back into `-INF` via f32 multiplication overflow. The non-finite `vscore` then flows into `vector_scores`, `compute_hybrid_score` rejects it, and the `far` doc is silently dropped again — undoing BUG-388's contract for any vector query with a non-default boost.

Same class of bug as BUG-370 / BUG-381: a plan-time finitude guard covers each input (per-component vector guards and `boost.is_finite()`), but the arithmetic combination at runtime can still overflow and is not guarded.

## Changes

- **`searchlite-core/src/api/reader.rs`** (`collect_vector_maps`)
  - Replace raw `vscore *= clause.boost;` with `vscore = f64_to_finite_f32((vscore as f64) * (clause.boost as f64));`. Every finite `f32 × f32` product fits in f64 without overflow; `f64_to_finite_f32` then clamps to `[f32::MIN, f32::MAX]` so overflowing products saturate rather than producing `±INF`. Mirrors the `f64_to_finite_f32` clamping policy already used by BUG-336 / BUG-342 on the scoring-side cast.

### Tests (`searchlite-core/tests/vector_search.rs`)

- **New** `l2_search_with_boost_gt_one_returns_far_doc_when_pairwise_squared_diff_overflows` — mirrors BUG-388's `l2_search_returns_far_doc_when_pairwise_squared_diff_overflows` regression except for `boost: Some(2.0)`. Verified pre-fix by stashing the `reader.rs` change: the test fails with `ids=["near"]` (the `far` doc disappears). Post-fix: both `near` and `far` are returned with finite scores and vector_scores, matching BUG-388's contract under any `boost > 1.0`.
- **New** `vector_boost_preserves_finite_vscore_product_within_f32_range` — boundary test asserting a cosine match with `boost=3.0` produces `vscore ≈ 3.0`, so the f64 clamp cannot silently perturb legitimate in-range products.

## Test plan

- [x] `cargo test -p searchlite-core --features vectors --test vector_search` — all 23 vector integration tests pass, including the two new BUG-394 regressions.
- [x] `cargo test -p searchlite-core --features vectors` — full core matrix green (524 lib tests + every integration suite).
- [x] `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean (no-vectors build path).
- [x] `cargo fmt --all -- --check` — clean.
- [x] Stashed only the `reader.rs` change and confirmed `l2_search_with_boost_gt_one_returns_far_doc_when_pairwise_squared_diff_overflows` fails (the `far` doc is silently dropped, matching the BUG-394 reproduction) while every pre-existing test still passes — the regression genuinely exercises the bug rather than tautologically passing.

Closes #394