### PR TITLE
fix(query): reject non-finite tie_breaker at plan time (BUG-399)

### DIFF
--- a/searchlite-core/src/query/planner.rs
+++ b/searchlite-core/src/query/planner.rs
@@ -995,6 +995,19 @@ fn clamp_expansions(
 
 fn validate_tie_breaker(tie: &Option<f32>) -> Result<f32> {
   let value = tie.unwrap_or(0.0);
+  // Every ordered comparison with `NaN` returns `false` under IEEE-754, so the
+  // `< 0.0` and `> 1.0` range checks below do not fire for `NaN`. Without this
+  // guard a caller supplying `tie_breaker: NaN` (reachable via the WASM
+  // binding, same as BUG-373 / BUG-379) plants `NaN` into
+  // `ScoreNode::DisMax.tie_breaker` and `ScoreExpr::DisMax.tie_breaker`. At
+  // runtime `max + NaN * (sum - max)` evaluates to `NaN`, which either
+  // silently drops every candidate via the `is_finite()` guard in
+  // `evaluate_compiled_score` or clamps their DisMax contribution to `0.0`
+  // via the matching guard on the BM25 fast path. Reject non-finite
+  // `tie_breaker` at the plan boundary instead, mirroring `validate_boost`.
+  if !value.is_finite() {
+    bail!("tie_breaker must be finite");
+  }
   if value < 0.0 {
     bail!("tie_breaker must be non-negative");
   }
@@ -1661,5 +1674,101 @@ mod tests {
     let plan = build_query_plan(&query, &["body".to_string()])
       .expect("finite nested boost product must plan cleanly");
     assert!(plan.scorer.is_some());
+  }
+
+  // Regression tests for BUG-399. `validate_tie_breaker` previously range-checked
+  // `< 0.0` / `> 1.0` only; both comparisons evaluate to `false` for `NaN` under
+  // IEEE-754, so a `tie_breaker: NaN` planted via the WASM binding flowed into
+  // `ScoreNode::DisMax` / `ScoreExpr::DisMax` and silently dropped or zero-scored
+  // matching candidates at runtime. The guard must reject `NaN` (and `±Infinity`,
+  // for symmetry with `validate_boost`) at plan time.
+
+  #[test]
+  fn validate_tie_breaker_rejects_nan() {
+    let err = validate_tie_breaker(&Some(f32::NAN)).unwrap_err();
+    assert!(
+      err.to_string().contains("must be finite"),
+      "expected finitude error, got: {err}",
+    );
+  }
+
+  #[test]
+  fn validate_tie_breaker_rejects_positive_infinity() {
+    let err = validate_tie_breaker(&Some(f32::INFINITY)).unwrap_err();
+    assert!(
+      err.to_string().contains("must be finite"),
+      "expected finitude error, got: {err}",
+    );
+  }
+
+  #[test]
+  fn validate_tie_breaker_rejects_negative_infinity() {
+    let err = validate_tie_breaker(&Some(f32::NEG_INFINITY)).unwrap_err();
+    assert!(
+      err.to_string().contains("must be finite"),
+      "expected finitude error, got: {err}",
+    );
+  }
+
+  #[test]
+  fn validate_tie_breaker_accepts_finite_in_range() {
+    assert_eq!(validate_tie_breaker(&None).unwrap(), 0.0);
+    assert_eq!(validate_tie_breaker(&Some(0.0)).unwrap(), 0.0);
+    assert_eq!(validate_tie_breaker(&Some(0.5)).unwrap(), 0.5);
+    assert_eq!(validate_tie_breaker(&Some(1.0)).unwrap(), 1.0);
+  }
+
+  #[test]
+  fn validate_tie_breaker_still_rejects_out_of_range() {
+    let err = validate_tie_breaker(&Some(-0.1)).unwrap_err();
+    assert!(
+      err.to_string().contains("non-negative"),
+      "expected non-negative error, got: {err}",
+    );
+    let err = validate_tie_breaker(&Some(1.1)).unwrap_err();
+    assert!(
+      err.to_string().contains("<= 1.0"),
+      "expected upper-bound error, got: {err}",
+    );
+  }
+
+  #[test]
+  fn build_query_plan_rejects_dis_max_tie_breaker_nan() {
+    let query = Query::Node(QueryNode::DisMax {
+      queries: vec![QueryNode::Term {
+        field: "body".into(),
+        value: "rust".into(),
+        boost: None,
+      }],
+      tie_breaker: Some(f32::NAN),
+      boost: None,
+    });
+    let err = build_query_plan(&query, &["body".to_string()]).unwrap_err();
+    assert!(
+      err.to_string().contains("tie_breaker must be finite"),
+      "expected tie_breaker finitude error, got: {err}",
+    );
+  }
+
+  #[test]
+  fn build_query_plan_rejects_multi_match_tie_breaker_nan() {
+    let query = Query::Node(QueryNode::MultiMatch {
+      query: "rust".into(),
+      fields: vec![FieldSpec {
+        field: "body".into(),
+        boost: None,
+      }],
+      match_type: MultiMatchType::BestFields,
+      fuzziness: None,
+      tie_breaker: Some(f32::NAN),
+      operator: None,
+      minimum_should_match: None,
+      boost: None,
+    });
+    let err = build_query_plan(&query, &["body".to_string()]).unwrap_err();
+    assert!(
+      err.to_string().contains("tie_breaker must be finite"),
+      "expected tie_breaker finitude error, got: {err}",
+    );
   }
 }


### PR DESCRIPTION
## Summary

Fixes BUG-399 (#399). `validate_tie_breaker` (`searchlite-core/src/query/planner.rs:996-1005`) range-checks `tie_breaker` against `< 0.0` and `> 1.0`, but neither comparison fires for `NaN` under IEEE-754 (every ordered comparison with NaN returns `false`). A NaN `tie_breaker` is therefore accepted at plan time and baked into both `ScoreNode::DisMax.tie_breaker` (regular scoring path in `searchlite-core/src/api/scoring.rs:288-336`) and `ScoreExpr::DisMax.tie_breaker` (BM25 fast-path in `searchlite-core/src/query/planner.rs:172-209`).

At runtime `max + NaN * (sum - max) = NaN`. The downstream finitude guard in `evaluate_compiled_score` (BUG-364) at `scoring.rs:329-331` then returns `None` and the candidate is silently excluded from the top-k heap; the parallel guard on the BM25 fast path (`planner.rs:205-209`) instead clamps to `0.0`, keeping the doc but giving its DisMax contribution a wrong score. Both `MultiMatch` and `DisMax` callers reach the same scoring code via the shared validator and exhibit the same two failure modes.

Same class of bug as BUG-373 / BUG-379: a numeric validator uses ordered comparisons against bounds without an `is_finite()` precondition, so NaN slips through and corrupts downstream scoring. The sibling validator one function up — `validate_boost` (`planner.rs:935-941`) — already encodes the right pattern (`!value.is_finite() || value.is_sign_negative()`); `validate_tie_breaker` is now symmetric.

The JSON path naturally rejects `NaN`/`Infinity` during deserialisation, but `serde_wasm_bindgen` (`searchlite-wasm/src/wasm.rs:952`) accepts JS `NaN` directly — the same path that surfaced BUG-373 and BUG-379.

## Changes

- **`searchlite-core/src/query/planner.rs`** (`validate_tie_breaker`)
  - Add an `is_finite()` precondition before the existing range checks, with a metric-neutral `tie_breaker must be finite` error and a doc-comment explaining the IEEE-754 ordered-comparison gap and the WASM trigger. The single guard covers `NaN`, `+Infinity`, and `-Infinity` (the existing `> 1.0` would also catch `+Infinity` and `< 0.0` would catch `-Infinity`, but stating it explicitly is symmetric with `validate_boost` and unambiguously rejects `NaN`). Both `MultiMatch` and `DisMax` callers benefit because they share the validator.

### Tests (`searchlite-core/src/query/planner.rs::tests`)

- **New** `validate_tie_breaker_rejects_nan` — `validate_tie_breaker(Some(NaN))` must surface the finitude error instead of returning `Ok(NaN)`.
- **New** `validate_tie_breaker_rejects_positive_infinity` / `validate_tie_breaker_rejects_negative_infinity` — symmetric to `validate_boost`'s finitude treatment; the error message must be the unified `tie_breaker must be finite` regardless of which infinity sign was supplied.
- **New** `validate_tie_breaker_accepts_finite_in_range` — `None` (default `0.0`), `0.0`, `0.5`, and `1.0` must still round-trip, so the new guard cannot over-reject legitimate inputs.
- **New** `validate_tie_breaker_still_rejects_out_of_range` — `-0.1` and `1.1` must still produce the existing `non-negative` / `<= 1.0` errors, so the new guard does not displace the existing range checks.
- **New** `build_query_plan_rejects_dis_max_tie_breaker_nan` — `QueryNode::DisMax { tie_breaker: NaN }` must surface a plan-time error instead of silently dropping every matching candidate at runtime via the BUG-364 guard in `evaluate_compiled_score`.
- **New** `build_query_plan_rejects_multi_match_tie_breaker_nan` — `QueryNode::MultiMatch { tie_breaker: NaN }` must surface the same plan-time error; `MultiMatch` reaches the same scoring code via the same validator.

## Test plan

- [x] `cargo test -p searchlite-core --lib query::planner` — all 27 planner tests pass, including the 7 new BUG-399 regressions.
- [x] `cargo test -p searchlite-core --lib` — full lib matrix green (508 tests).
- [x] `cargo test -p searchlite-core` — full core matrix green (508 lib tests + every integration suite).
- [x] `cargo clippy -p searchlite-core --all-targets -- -D warnings` — clean.
- [x] `cargo clippy -p searchlite-core --features vectors --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Reverted the `validate_tie_breaker` change locally and confirmed all 5 `rejects_*` regressions fail (NaN slips through with no error; ±Infinity is caught by the existing range checks but produces the wrong error text) while the `accepts_finite_in_range` and `still_rejects_out_of_range` controls still pass — the regressions genuinely exercise the bug rather than tautologically passing.

Closes #399