### PR TITLE
fix(score): reject term_weights accumulation overflow (BUG-401)

### DIFF
--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1272,6 +1272,16 @@ impl IndexReader {
         term.group_fields.clone(),
       ));
       entry.1 += term.weight;
+      // BUG-401: individual boosts are validated finite by combine_boost, but the
+      // sum of N finite f32 values can still overflow to +Inf when the same
+      // field:term key appears across multiple query clauses. Reject at the
+      // accumulation point so Inf never reaches ScoredTerm / score_tf.
+      if !entry.1.is_finite() {
+        bail!(
+          "accumulated boost for term `{}` overflows f32; reduce per-clause boost values",
+          term.key
+        );
+      }
       if entry.3.is_none() && term.group_fields.is_some() {
         entry.3 = term.group_fields.clone();
       }
@@ -2105,6 +2115,14 @@ impl IndexReader {
             .entry(term.key.clone())
             .or_insert((term.field.clone(), 0.0, term.leaf));
         entry.1 += term.weight;
+        // BUG-401: guard against finite-but-additive overflow into +Inf when
+        // multiple rescore clauses share the same field:term key.
+        if !entry.1.is_finite() {
+          bail!(
+            "accumulated boost for term `{}` overflows f32; reduce per-clause boost values",
+            term.key
+          );
+        }
       }
       // BM25 N must use total doc_count (including deleted documents) so it matches
       // the df basis (postings.len() includes deleted documents). See BUG-360.

--- a/searchlite-core/tests/multi_field.rs
+++ b/searchlite-core/tests/multi_field.rs
@@ -754,3 +754,92 @@ fn multi_match_ignores_overflow_boost_on_numeric_field_kind() {
     );
   }
 }
+
+#[test]
+fn bool_rejects_accumulated_term_weight_overflow() {
+  // BUG-401: `term_weights` in `IndexReader::search` sums per-term weights
+  // with `entry.1 += term.weight` when multiple query clauses resolve to the
+  // same `field:term` key. Each individual boost is validated finite by
+  // `combine_boost` at plan/expansion time (BUG-381 / BUG-396), but the sum
+  // of N finite f32 values can still overflow `f32::MAX` (~3.4e38) to `+Inf`.
+  // Before the guard, that `Inf` propagated into `ScoredTerm.weight` and
+  // through BM25 `score_tf` into the WAND/brute-force heap, corrupting
+  // ranking (WAND+Sum silently clamped to 0.0 per BUG-364) or producing an
+  // `Inf` in the serialised response (HTTP 500 on `serde_json::to_vec`).
+  // The guard must fire at accumulation time and mirror the
+  // `combine_boost` error shape.
+  let (_tmp, reader) = setup_reader();
+  // Two `should` clauses, each matching `body:rust` with a boost that is
+  // individually finite (f32::MAX ≈ 3.4e38). Their accumulated sum
+  // (3.6e38) exceeds f32::MAX and overflows to +Inf.
+  let query = QueryNode::Bool {
+    must: Vec::new(),
+    should: vec![
+      QueryNode::Term {
+        field: "body".into(),
+        value: "rust".into(),
+        boost: Some(1.8e38),
+      },
+      QueryNode::Term {
+        field: "body".into(),
+        value: "rust".into(),
+        boost: Some(1.8e38),
+      },
+    ],
+    must_not: Vec::new(),
+    filter: Vec::new(),
+    minimum_should_match: None,
+    boost: None,
+  };
+  let err = reader.search(&request(query)).unwrap_err();
+  let msg = err.to_string();
+  assert!(
+    msg.contains("overflows"),
+    "expected overflow error from the term_weights accumulation guard, got: {msg}",
+  );
+  assert!(
+    msg.contains("body:rust"),
+    "error should name the field:term key that overflowed, got: {msg}",
+  );
+}
+
+#[test]
+fn bool_accepts_accumulated_term_weight_within_range() {
+  // Control case for BUG-401: two clauses sharing a key whose summed weight
+  // stays finite must continue to search cleanly. Guards against a guard
+  // that rejects every legitimate multi-clause query.
+  let (_tmp, reader) = setup_reader();
+  let query = QueryNode::Bool {
+    must: Vec::new(),
+    should: vec![
+      QueryNode::Term {
+        field: "body".into(),
+        value: "rust".into(),
+        boost: Some(2.0),
+      },
+      QueryNode::Term {
+        field: "body".into(),
+        value: "rust".into(),
+        boost: Some(3.0),
+      },
+    ],
+    must_not: Vec::new(),
+    filter: Vec::new(),
+    minimum_should_match: None,
+    boost: None,
+  };
+  let result = reader
+    .search(&request(query))
+    .expect("finite summed weight must search cleanly");
+  assert!(
+    !result.hits.is_empty(),
+    "BUG-401 control case: legitimate in-range boosts must still return hits",
+  );
+  for hit in result.hits.iter() {
+    assert!(
+      hit.score.is_finite(),
+      "BUG-401 control case: legitimate summed weights must yield finite scores (got {})",
+      hit.score,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- Individual term boosts are validated finite by `combine_boost` at plan and expansion time (BUG-381 / BUG-396), but when multiple query clauses resolve to the same `field:term` key the per-term weights are summed into a single `ScoredTerm.weight`. The sum of N finite f32 values can still overflow `f32::MAX` (~3.4e38) to `+Inf`, which then propagates through `score_tf` into the WAND / brute-force scoring pipeline — silently clamped to `0.0` under BUG-364's `Sum` guard or leaked as an `Inf` score that trips `serde_json::to_vec` (HTTP 500).
- Add a finitude check at both production accumulation sites (`IndexReader::search` and `IndexReader::rescore_hits`) mirroring the `combine_boost` error shape. The guard rejects the query at the earliest point the non-finite total is produced, before it can reach `ScoredTerm` or the scoring heap.

## Reproduction

Before the guard, a `bool.should` with two clauses carrying `1.8e38` boosts on the same `field:term` key accumulates to `3.6e38 → +Inf` and silently corrupts ranking or breaks serialisation. After the guard, the query is rejected at plan/expansion boundary with `accumulated boost for term \`body:rust\` overflows f32; reduce per-clause boost values`.

## Test plan

- [x] `cargo test --package searchlite-core --test multi_field` — 14 tests pass, including two new tests (`bool_rejects_accumulated_term_weight_overflow`, `bool_accepts_accumulated_term_weight_within_range`).
- [x] `cargo test --package searchlite-core` — full core test suite passes (770+ tests).
- [x] `cargo fmt --package searchlite-core --check` — clean.

Closes #401