### PR TITLE
test(score): cover BUG-381 score_adjust salvage path

### DIFF
--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -1649,6 +1649,137 @@ mod tests {
     );
   }
 
+  /// BUG-381 salvage path: the finitude guard runs *after* `score_adjust` at
+  /// every push-into-heap site, so a custom scorer (notably `FunctionScore`
+  /// with `boost_mode=Replace`) that turns a non-finite raw BM25 into a
+  /// finite final score keeps the doc in the top-k. Pinning this with a
+  /// regression test prevents a future "drop early to skip work" refactor
+  /// from silently losing salvageable hits — matches the post-output-only
+  /// rejection policy used by `evaluate_compiled_score` (BUG-315) and the
+  /// rescore combine path (BUG-326).
+  #[test]
+  fn wand_score_adjust_can_salvage_non_finite_raw_score() {
+    let anchor = term_from_entries(&[PostingEntry {
+      doc_id: 1,
+      term_freq: 1,
+      positions: smallvec![],
+    }]);
+    let overflow = overflow_scored_term(&[5]);
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let mut adjust: Box<ScoreAdjustFn<'_>> =
+      Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
+    let results = execute_top_k_with_stats_and_mode_internal::<
+      _,
+      crate::query::collector::MatchCountingCollector,
+    >(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Wand,
+      None,
+      None,
+      &mut accept,
+      None,
+      None,
+      ScoreMode::Score,
+      Some(&mut adjust),
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "wand salvage path leaked non-finite score {}",
+        r.score,
+      );
+    }
+    let salvaged = results
+      .iter()
+      .find(|r| r.doc_id == 5)
+      .expect("wand dropped overflow doc 5 even though score_adjust returned a finite value");
+    assert_eq!(
+      salvaged.score, 42.0,
+      "wand kept overflow doc 5 but did not take the adjusted score: {salvaged:?}",
+    );
+  }
+
+  /// BUG-381 salvage path, BMW strategy.
+  #[test]
+  fn bmw_score_adjust_can_salvage_non_finite_raw_score() {
+    let anchor = term_from_entries(&[PostingEntry {
+      doc_id: 1,
+      term_freq: 1,
+      positions: smallvec![],
+    }]);
+    let overflow = overflow_scored_term(&[5]);
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let mut adjust: Box<ScoreAdjustFn<'_>> =
+      Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
+    let results = execute_top_k_with_stats_and_mode_internal::<
+      _,
+      crate::query::collector::MatchCountingCollector,
+    >(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Bmw,
+      None,
+      None,
+      &mut accept,
+      None,
+      None,
+      ScoreMode::Score,
+      Some(&mut adjust),
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "bmw salvage path leaked non-finite score {}",
+        r.score,
+      );
+    }
+    assert!(
+      results.iter().any(|r| r.doc_id == 5),
+      "bmw dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}",
+    );
+  }
+
+  /// BUG-381 salvage path, brute-force plain-BM25 branch (no ScorePlan).
+  #[test]
+  fn brute_force_score_adjust_can_salvage_non_finite_raw_score() {
+    let anchor = term_from_entries(&[PostingEntry {
+      doc_id: 1,
+      term_freq: 1,
+      positions: smallvec![],
+    }]);
+    let overflow = overflow_scored_term(&[5]);
+    let mut accept = |_doc: DocId, _score: f32| true;
+    let mut adjust: Box<ScoreAdjustFn<'_>> =
+      Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
+    let results = execute_top_k_with_stats_and_mode_internal::<
+      _,
+      crate::query::collector::MatchCountingCollector,
+    >(
+      vec![anchor, overflow],
+      10,
+      ExecutionStrategy::Bm25,
+      None,
+      None,
+      &mut accept,
+      None,
+      None,
+      ScoreMode::Score,
+      Some(&mut adjust),
+    );
+    for r in results.iter() {
+      assert!(
+        r.score.is_finite(),
+        "brute_force salvage path leaked non-finite score {}",
+        r.score,
+      );
+    }
+    assert!(
+      results.iter().any(|r| r.doc_id == 5),
+      "brute_force dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}",
+    );
+  }
+
   #[test]
   fn skip_blocks_below_bound_noop_when_threshold_zero() {
     let block_size = 2;

--- a/searchlite-core/src/query/wand.rs
+++ b/searchlite-core/src/query/wand.rs
@@ -1522,6 +1522,32 @@ mod tests {
     }
   }
 
+  /// Precondition probe for the BUG-381 salvage tests: assert that a freshly
+  /// constructed overflow term still produces a non-finite per-doc BM25 score
+  /// at `doc_id`. Without this, a future bm25 / `score_tf` math change that
+  /// kept `bm25 * weight` finite would leave the salvage tests passing while
+  /// no longer exercising the post-`score_adjust` ordering they're meant to
+  /// pin — they'd silently degrade into "the heap accepts a finite raw score"
+  /// tautologies. Mirrors the inline probe in
+  /// `wand_drops_doc_with_non_finite_bm25_score` so all BUG-381 fixtures
+  /// share the same fail-loud guarantee.
+  fn assert_overflow_term_score_non_finite_at(term: &ScoredTerm, doc_id: DocId) {
+    let probe_score = score_tf(
+      1.0,
+      term.postings.len() as f32,
+      term.doc_len(doc_id),
+      term.avgdl,
+      term.docs,
+      term.k1,
+      term.b,
+      term.weight,
+    );
+    assert!(
+      !probe_score.is_finite(),
+      "fixture precondition: overflow term's per-doc score at doc {doc_id} must be non-finite to exercise BUG-381 salvage; got {probe_score}",
+    );
+  }
+
   /// BUG-381: a document whose BM25 score overflows to `+inf` must not reach
   /// the top-k heap on the WAND path. Before the fix, `score_sum` flowed
   /// straight from `score_tf` to `push_top_k` whenever no custom scoring
@@ -1665,6 +1691,7 @@ mod tests {
       positions: smallvec![],
     }]);
     let overflow = overflow_scored_term(&[5]);
+    assert_overflow_term_score_non_finite_at(&overflow, 5);
     let mut accept = |_doc: DocId, _score: f32| true;
     let mut adjust: Box<ScoreAdjustFn<'_>> =
       Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
@@ -1690,10 +1717,11 @@ mod tests {
         r.score,
       );
     }
-    let salvaged = results
-      .iter()
-      .find(|r| r.doc_id == 5)
-      .expect("wand dropped overflow doc 5 even though score_adjust returned a finite value");
+    let salvaged = results.iter().find(|r| r.doc_id == 5).unwrap_or_else(|| {
+      panic!(
+        "wand dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}"
+      )
+    });
     assert_eq!(
       salvaged.score, 42.0,
       "wand kept overflow doc 5 but did not take the adjusted score: {salvaged:?}",
@@ -1709,6 +1737,7 @@ mod tests {
       positions: smallvec![],
     }]);
     let overflow = overflow_scored_term(&[5]);
+    assert_overflow_term_score_non_finite_at(&overflow, 5);
     let mut accept = |_doc: DocId, _score: f32| true;
     let mut adjust: Box<ScoreAdjustFn<'_>> =
       Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
@@ -1734,9 +1763,18 @@ mod tests {
         r.score,
       );
     }
-    assert!(
-      results.iter().any(|r| r.doc_id == 5),
-      "bmw dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}",
+    let salvaged = results.iter().find(|r| r.doc_id == 5).unwrap_or_else(|| {
+      panic!(
+        "bmw dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}"
+      )
+    });
+    // Pin that the heap took the *adjusted* score (42.0), not some other
+    // finite fallback like a clamp of the raw +inf — the salvage contract is
+    // about the adjuster's output landing in the heap, not just any finite
+    // value taking its place.
+    assert_eq!(
+      salvaged.score, 42.0,
+      "bmw kept overflow doc 5 but did not take the adjusted score: {salvaged:?}",
     );
   }
 
@@ -1749,6 +1787,7 @@ mod tests {
       positions: smallvec![],
     }]);
     let overflow = overflow_scored_term(&[5]);
+    assert_overflow_term_score_non_finite_at(&overflow, 5);
     let mut accept = |_doc: DocId, _score: f32| true;
     let mut adjust: Box<ScoreAdjustFn<'_>> =
       Box::new(|_doc: DocId, _raw: f32, _leaves: &[f32]| Some(42.0_f32));
@@ -1774,9 +1813,14 @@ mod tests {
         r.score,
       );
     }
-    assert!(
-      results.iter().any(|r| r.doc_id == 5),
-      "brute_force dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}",
+    let salvaged = results.iter().find(|r| r.doc_id == 5).unwrap_or_else(|| {
+      panic!("brute_force dropped overflow doc 5 even though score_adjust returned a finite value: {results:?}")
+    });
+    // Same adjusted-score pin as the BMW variant — keeps the brute-force
+    // heap insertion site honest about which value reaches `Hit.score`.
+    assert_eq!(
+      salvaged.score, 42.0,
+      "brute_force kept overflow doc 5 but did not take the adjusted score: {salvaged:?}",
     );
   }
 


### PR DESCRIPTION
## Summary

Adds the regression tests from #391's salvage commit (`612d2b5`) on top of the merged BUG-381 fix (#382). The salvage **behavior** already exists on main — both #382 and #391 converged on running the heap-level finitude guard *after* `score_adjust` at all three sites, just via different code shapes. What's missing is regression coverage for the salvage path itself: the existing `*_drops_doc_with_non_finite_bm25_score` tests on main run with `score_adjust = None`, so they only exercise the rejection side. If a future refactor moved the finitude check pre-adjust to skip work, salvageable hits from `FunctionScore { boost_mode: Replace }` (and any other adjuster that ignores its raw input) would silently disappear with no test failure.

> Splits out just the test additions from #391 since the source-side changes in that PR are a no-op against current main. #391 closed in favor of this.

## Changes

- **`searchlite-core/src/query/wand.rs`** (tests only — no production code change)
  - **New** `wand_score_adjust_can_salvage_non_finite_raw_score` — pivot-scan heap path. Also asserts the kept score equals the adjuster's return value (`42.0`), pinning the order: drop the doc only if the *final* score is non-finite, never the raw input.
  - **New** `bmw_score_adjust_can_salvage_non_finite_raw_score` — block-max-wand path.
  - **New** `brute_force_score_adjust_can_salvage_non_finite_raw_score` — plain-BM25 brute-force branch.

Each new test reuses the existing `overflow_scored_term(&[5])` and `term_from_entries` helpers introduced by #382, drives \`execute_top_k_with_stats_and_mode_internal\` directly with a \`Some(&mut adjust)\` callback that unconditionally returns \`Some(42.0)\`, and asserts (1) every kept score is finite and (2) the overflow doc was kept rather than dropped.

## Test plan

- [x] \`cargo test -p searchlite-core --lib salvage_non_finite_raw_score\` — 3/3 pass.
- [x] \`cargo test -p searchlite-core --lib query::wand::\` — 15/15 WAND tests pass (12 existing + 3 new).
- [x] \`cargo test -p searchlite-core\` — full core matrix green (507 lib tests + every integration suite).
- [x] \`cargo clippy -p searchlite-core --all-targets -- -D warnings\` — clean.
- [x] \`cargo fmt --all --check\` — clean.
- [x] **Negative verification**: temporarily reverted the \`wand_loop\` filter from \`.filter(|s| s.is_finite())\` (post-adjust) to \`if !score.is_finite() { None } else if let Some(adj) = ... { adj(...) } else { Some(score) }\` (pre-adjust). The \`wand\` and \`bmw\` salvage tests both fail with the expected \"dropped overflow doc 5 even though score_adjust returned a finite value\" panic; brute_force still passes (its site wasn't touched). Reverted again — all green. The tests genuinely exercise the post-adjust ordering, not a tautology.

Refs #381, supersedes #391.