### PR TITLE
fix(http): classify write-key errors via typed downcast (BUG-406)

### DIFF
--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -23,8 +23,8 @@ use searchlite_core::api::builder::IndexBuilder;
 use searchlite_core::api::types::{
   Document, IndexOptions, MgetRequest, MgetResponse, MultiSearchRequest, SearchRequest, StorageType,
 };
-use searchlite_core::api::PatchError;
 use searchlite_core::api::{IndexReader, MultiSearchResponse, SearchResult};
+use searchlite_core::api::{PatchError, WriteKeyError};
 use searchlite_core::util::doc_id::validate_doc_id;
 use searchlite_core::{Index, Manifest, Schema};
 use thiserror::Error;
@@ -963,6 +963,28 @@ impl HttpError {
   }
 }
 
+/// Classify an error from `Index::writer_with_key` / `Index::commit_with_key`
+/// / `Index::compact_with_key` into the HTTP status code the caller should
+/// receive. Uses `anyhow::Error::downcast_ref::<WriteKeyError>()` so the
+/// classification stays correct if the error's `Display` text changes or a
+/// non-auth error coincidentally mentions "write key" — the substring match
+/// this replaces flipped classifications whenever either shifted. Mirrors the
+/// FFI-side `classify_writer_err` (see BUG-020).
+///
+/// `write_key_provided` selects 401 (no key supplied) vs 403 (wrong key) on
+/// auth failures, matching the pre-existing behaviour.
+fn classify_writer_error(err: &anyhow::Error, write_key_provided: bool) -> StatusCode {
+  if err.downcast_ref::<WriteKeyError>().is_some() {
+    if write_key_provided {
+      StatusCode::FORBIDDEN
+    } else {
+      StatusCode::UNAUTHORIZED
+    }
+  } else {
+    StatusCode::INTERNAL_SERVER_ERROR
+  }
+}
+
 impl IntoResponse for HttpError {
   fn into_response(self) -> Response {
     let body = Json(ErrorResponse {
@@ -1188,16 +1210,7 @@ async fn add_ndjson(
         let mut writer = index_ref
           .writer_with_key(write_key.as_deref())
           .map_err(|e| {
-            let msg = e.to_string().to_lowercase();
-            let status = if msg.contains("write key") || msg.contains("unauthorized") {
-              if write_key.is_some() {
-                StatusCode::FORBIDDEN
-              } else {
-                StatusCode::UNAUTHORIZED
-              }
-            } else {
-              StatusCode::INTERNAL_SERVER_ERROR
-            };
+            let status = classify_writer_error(&e, write_key.is_some());
             HttpError::from_anyhow("writer_open", status, e)
           })?;
         let mut total = 0usize;
@@ -1392,16 +1405,7 @@ async fn bulk_ingest(
   tokio::task::spawn_blocking(move || {
     let _writer_guard = writer_lock.blocking_lock();
     let mut writer = index.writer_with_key(write_key.as_deref()).map_err(|e| {
-      let msg = e.to_string().to_lowercase();
-      let status = if msg.contains("write key") || msg.contains("unauthorized") {
-        if write_key.is_some() {
-          StatusCode::FORBIDDEN
-        } else {
-          StatusCode::UNAUTHORIZED
-        }
-      } else {
-        StatusCode::INTERNAL_SERVER_ERROR
-      };
+      let status = classify_writer_error(&e, write_key.is_some());
       HttpError::from_anyhow("writer_open", status, e)
     })?;
     for doc in docs.iter() {
@@ -1454,16 +1458,7 @@ async fn delete_documents(
   }
   let _writer_guard = managed.writer_lock.lock().await;
   let mut writer = index.writer_with_key(write_key.as_deref()).map_err(|e| {
-    let msg = e.to_string().to_lowercase();
-    let status = if msg.contains("write key") || msg.contains("unauthorized") {
-      if write_key.is_some() {
-        StatusCode::FORBIDDEN
-      } else {
-        StatusCode::UNAUTHORIZED
-      }
-    } else {
-      StatusCode::INTERNAL_SERVER_ERROR
-    };
+    let status = classify_writer_error(&e, write_key.is_some());
     HttpError::from_anyhow("writer_open", status, e)
   })?;
   writer
@@ -1509,16 +1504,7 @@ async fn update_document(
   tokio::task::spawn_blocking(move || {
     let _writer_guard = writer_lock.blocking_lock();
     let mut writer = index.writer_with_key(write_key.as_deref()).map_err(|e| {
-      let msg = e.to_string().to_lowercase();
-      let status = if msg.contains("write key") || msg.contains("unauthorized") {
-        if write_key.is_some() {
-          StatusCode::FORBIDDEN
-        } else {
-          StatusCode::UNAUTHORIZED
-        }
-      } else {
-        StatusCode::INTERNAL_SERVER_ERROR
-      };
+      let status = classify_writer_error(&e, write_key.is_some());
       HttpError::from_anyhow("writer_open", status, e)
     })?;
     if let Err(err) = writer.apply_patch(&body.id, &body.set, &body.unset) {
@@ -1613,16 +1599,7 @@ async fn bulk_update(
         let mut writer = index_ref
           .writer_with_key(write_key.as_deref())
           .map_err(|e| {
-            let msg = e.to_string().to_lowercase();
-            let status = if msg.contains("write key") || msg.contains("unauthorized") {
-              if write_key.is_some() {
-                StatusCode::FORBIDDEN
-              } else {
-                StatusCode::UNAUTHORIZED
-              }
-            } else {
-              StatusCode::INTERNAL_SERVER_ERROR
-            };
+            let status = classify_writer_error(&e, write_key.is_some());
             HttpError::from_anyhow("writer_open", status, e)
           })?;
         let checkpoint = writer.checkpoint().map_err(|e| {
@@ -1919,16 +1896,7 @@ async fn commit(
     )
   })?
   .map_err(|err| {
-    let msg = err.to_string();
-    let status = if msg.to_lowercase().contains("write key") {
-      if write_key.is_some() {
-        StatusCode::FORBIDDEN
-      } else {
-        StatusCode::UNAUTHORIZED
-      }
-    } else {
-      StatusCode::INTERNAL_SERVER_ERROR
-    };
+    let status = classify_writer_error(&err, write_key.is_some());
     HttpError::from_anyhow("commit_failed", status, err)
   })?;
   Ok(Json(CommitResponse { committed: true }))
@@ -1986,16 +1954,7 @@ async fn compact(
     )
   })?
   .map_err(|err| {
-    let msg = err.to_string();
-    let status = if msg.to_lowercase().contains("write key") {
-      if write_key.is_some() {
-        StatusCode::FORBIDDEN
-      } else {
-        StatusCode::UNAUTHORIZED
-      }
-    } else {
-      StatusCode::INTERNAL_SERVER_ERROR
-    };
+    let status = classify_writer_error(&err, write_key.is_some());
     HttpError::from_anyhow("compact_failed", status, err)
   })?;
   Ok(Json(CompactResponse { compacted: true }))
@@ -2935,6 +2894,78 @@ mod tests {
       "2026-03-03T00:00:01Z"
     ));
     assert!(should_refresh(None, "2026-03-03T00:00:00Z"));
+  }
+
+  #[test]
+  fn classify_writer_error_routes_write_key_variants_to_auth_status() {
+    // Every `WriteKeyError` variant must map to an auth status regardless of
+    // its `Display` text, which is what the previous substring match got
+    // wrong (BUG-406, mirrors the FFI-side BUG-020).
+    for err in [
+      WriteKeyError::Required,
+      WriteKeyError::Mismatch("segment binding; index may be tampered"),
+      WriteKeyError::MetadataTampered,
+      WriteKeyError::Empty,
+      WriteKeyError::FeatureDisabled,
+    ] {
+      let anyhow_err: anyhow::Error = err.into();
+      assert_eq!(
+        classify_writer_error(&anyhow_err, false),
+        StatusCode::UNAUTHORIZED,
+        "no client key → 401"
+      );
+
+      let anyhow_err: anyhow::Error = WriteKeyError::Required.into();
+      assert_eq!(
+        classify_writer_error(&anyhow_err, true),
+        StatusCode::FORBIDDEN,
+        "client sent a key → 403"
+      );
+    }
+  }
+
+  #[test]
+  fn classify_writer_error_survives_anyhow_context_wrapping() {
+    // anyhow::Context rewrites the Display string, which is exactly what
+    // broke the substring match. Typed downcast must still classify this
+    // as an auth failure.
+    let err: anyhow::Error = WriteKeyError::MetadataTampered.into();
+    let wrapped = err.context("opening writer").context("during compaction");
+    assert_eq!(
+      classify_writer_error(&wrapped, false),
+      StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(classify_writer_error(&wrapped, true), StatusCode::FORBIDDEN);
+  }
+
+  #[test]
+  fn classify_writer_error_does_not_auth_classify_substring_lookalikes() {
+    // The pre-BUG-406 substring match flipped a benign storage error whose
+    // `Display` text happened to include "write key" (e.g. "failed to read
+    // write key binding from WAL") into a 401/403. The typed downcast must
+    // return 500 for such errors.
+    let err = anyhow::anyhow!("failed to read write key binding from WAL");
+    assert_eq!(
+      classify_writer_error(&err, false),
+      StatusCode::INTERNAL_SERVER_ERROR
+    );
+    assert_eq!(
+      classify_writer_error(&err, true),
+      StatusCode::INTERNAL_SERVER_ERROR
+    );
+  }
+
+  #[test]
+  fn classify_writer_error_maps_non_auth_errors_to_internal() {
+    let err = anyhow::anyhow!("disk full");
+    assert_eq!(
+      classify_writer_error(&err, false),
+      StatusCode::INTERNAL_SERVER_ERROR
+    );
+    assert_eq!(
+      classify_writer_error(&err, true),
+      StatusCode::INTERNAL_SERVER_ERROR
+    );
   }
 
   #[tokio::test]

--- a/searchlite-http/src/lib.rs
+++ b/searchlite-http/src/lib.rs
@@ -963,13 +963,15 @@ impl HttpError {
   }
 }
 
-/// Classify an error from `Index::writer_with_key` / `Index::commit_with_key`
-/// / `Index::compact_with_key` into the HTTP status code the caller should
-/// receive. Uses `anyhow::Error::downcast_ref::<WriteKeyError>()` so the
-/// classification stays correct if the error's `Display` text changes or a
-/// non-auth error coincidentally mentions "write key" — the substring match
-/// this replaces flipped classifications whenever either shifted. Mirrors the
-/// FFI-side `classify_writer_err` (see BUG-020).
+/// Classify an error surfaced by a write-key-gated path — currently
+/// `Index::writer_with_key`, the `writer.commit()` that follows it in the
+/// commit endpoint, and `Index::compact_with_key` — into the HTTP status code
+/// the caller should receive. Uses
+/// `anyhow::Error::downcast_ref::<WriteKeyError>()` so the classification
+/// stays correct if the error's `Display` text changes or a non-auth error
+/// coincidentally mentions "write key" — the substring match this replaces
+/// flipped classifications whenever either shifted. Mirrors the FFI-side
+/// `classify_writer_err` (see BUG-020).
 ///
 /// `write_key_provided` selects 401 (no key supplied) vs 403 (wrong key) on
 /// auth failures, matching the pre-existing behaviour.
@@ -2899,27 +2901,35 @@ mod tests {
   #[test]
   fn classify_writer_error_routes_write_key_variants_to_auth_status() {
     // Every `WriteKeyError` variant must map to an auth status regardless of
-    // its `Display` text, which is what the previous substring match got
-    // wrong (BUG-406, mirrors the FFI-side BUG-020).
-    for err in [
-      WriteKeyError::Required,
-      WriteKeyError::Mismatch("segment binding; index may be tampered"),
-      WriteKeyError::MetadataTampered,
-      WriteKeyError::Empty,
-      WriteKeyError::FeatureDisabled,
-    ] {
-      let anyhow_err: anyhow::Error = err.into();
+    // its `Display` text, under both the no-client-key (401) and
+    // client-key-provided (403) branches. This is what the previous
+    // substring match got wrong (BUG-406, mirrors the FFI-side BUG-020).
+    //
+    // `WriteKeyError` is not `Clone`, so build each variant twice via a
+    // closure: once per assertion branch.
+    let variants: &[fn() -> WriteKeyError] = &[
+      || WriteKeyError::Required,
+      || WriteKeyError::Mismatch("segment binding; index may be tampered"),
+      || WriteKeyError::MetadataTampered,
+      || WriteKeyError::Empty,
+      || WriteKeyError::FeatureDisabled,
+    ];
+
+    for build in variants {
+      let no_key_err: anyhow::Error = build().into();
       assert_eq!(
-        classify_writer_error(&anyhow_err, false),
+        classify_writer_error(&no_key_err, false),
         StatusCode::UNAUTHORIZED,
-        "no client key → 401"
+        "variant {:?} without client key must map to 401",
+        build()
       );
 
-      let anyhow_err: anyhow::Error = WriteKeyError::Required.into();
+      let with_key_err: anyhow::Error = build().into();
       assert_eq!(
-        classify_writer_error(&anyhow_err, true),
+        classify_writer_error(&with_key_err, true),
         StatusCode::FORBIDDEN,
-        "client sent a key → 403"
+        "variant {:?} with client key must map to 403",
+        build()
       );
     }
   }


### PR DESCRIPTION
## Summary

- Replace substring-matching (`err.to_string().contains("write key")`) with typed `err.downcast_ref::<WriteKeyError>()` across all seven HTTP write-key error sites (ndjson ingest, delete, update, bulk-delete, bulk-update, commit, compact).
- Extract a shared `classify_writer_error` helper mirroring the FFI-side `classify_writer_err` from BUG-020.
- Add unit tests covering every `WriteKeyError` variant, `anyhow::Context` wrapping, the substring-lookalike false-positive case, and plain non-auth errors.

Closes #406.

## Why

The pre-existing classification logic would silently flip HTTP status codes whenever:

1. `WriteKeyError`'s `Display` output changes (e.g. removing the substring "write key") — auth failures would surface as 500.
2. A non-auth error's message happened to contain "write key" (e.g. `"failed to read write key binding from WAL"`) — a storage/WAL error would be reported as 401/403.
3. An `.context(...)` wrapper shadowed the Display text — classification depended on the exact string surfacing at the top of the chain.

The FFI layer was already hardened against this in BUG-020 (#237); this change brings the HTTP layer in line.

## Test plan

- [x] `cargo test -p searchlite-http --lib` — 53 tests pass (49 existing + 4 new)
- [x] `cargo build --all --all-features` — clean
- [ ] CI: full `cargo test --all --all-features` + `cargo clippy --all --all-features --all-targets -- -D warnings`