### PR TITLE
fix(aggs): reject seconds that overflow millis conversion (BUG-408)

### DIFF
--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4496,16 +4496,21 @@ pub(crate) fn parse_interval_seconds(spec: &str) -> Option<f64> {
     return None;
   }
   // Every caller converts the returned seconds value to milliseconds via
-  // `secs * 1_000.0` before casting to `i64`. A finite magnitude above
-  // `f64::MAX / 1_000.0` overflows to `f64::INFINITY` after that
-  // multiplication, and Rust's `as i64` cast saturates infinity to
-  // `i64::MAX` — silently producing `DateInterval::Fixed(i64::MAX)`
-  // (all documents collapse into a single bucket) or an `i64::MAX`
-  // offset that drops every document. Reject such magnitudes centrally
+  // `secs * 1_000.0` before casting to `i64`. Rust's `as i64` cast
+  // saturates both `f64::INFINITY` AND any finite value above
+  // `i64::MAX` to `i64::MAX` (and symmetrically to `i64::MIN` on the
+  // negative side), silently producing `DateInterval::Fixed(i64::MAX)`
+  // (all documents collapse into a single bucket) or a saturated
+  // offset that drops every document. Reject magnitudes whose
+  // millisecond value would fall outside a conservative `i64` window
   // so the overflow surfaces as a parse failure at every call site,
   // rather than patching each `* 1_000.0` multiplication individually.
-  // Guards BUG-408.
-  if magnitude.abs() > f64::MAX / 1_000.0 {
+  // The cap is `i64::MAX / 2` (~4.6e18 ms ≈ 146 million years), which
+  // is already astronomically larger than any realistic interval and
+  // leaves headroom for downstream arithmetic. Guards BUG-408.
+  const MAX_SAFE_MILLIS: f64 = (i64::MAX / 2) as f64;
+  let millis = magnitude * 1_000.0;
+  if !millis.is_finite() || millis.abs() > MAX_SAFE_MILLIS {
     return None;
   }
   Some(if negative { -magnitude } else { magnitude })
@@ -4563,43 +4568,56 @@ mod tests {
     let value = format!("1{}", "0".repeat(305));
     assert_eq!(parse_interval_seconds(&format!("{value}w")), None);
     assert_eq!(parse_interval_seconds(&format!("-{value}w")), None);
-    // Sanity check: the same value with a smaller multiplier (ms,
-    // which scales by 0.001) should still parse to a finite result.
-    assert!(parse_interval_seconds(&format!("{value}ms")).is_some_and(|f| f.is_finite()));
+    // Sanity check: a well-sized value with a smaller multiplier (ms,
+    // which scales by 0.001) should still parse to a finite result
+    // whose millisecond conversion fits comfortably in the `i64` range.
+    // Using `1e10` → `1e7 s` → `1e10 ms`, far below `i64::MAX`.
+    let small = format!("1{}", "0".repeat(10));
+    assert!(parse_interval_seconds(&format!("{small}ms")).is_some_and(|f| f.is_finite()));
   }
 
   // Regression test for BUG-408: `parse_interval_seconds` must reject
-  // finite seconds magnitudes that overflow to `f64::INFINITY` when the
-  // caller converts them to milliseconds via `secs * 1_000.0`. Without
-  // the `magnitude.abs() > f64::MAX / 1_000.0` guard, such a value would
-  // parse successfully, the downstream `* 1_000.0` would overflow, and
-  // Rust's `as i64` cast would saturate `f64::INFINITY` to `i64::MAX` —
-  // silently producing `DateInterval::Fixed(i64::MAX)` or an `i64::MAX`
-  // offset that collapses all documents into a single bucket or drops
-  // them entirely.
+  // finite seconds magnitudes whose millisecond value would saturate
+  // the `as i64` cast at the call sites. Without the guard, such
+  // values produce `DateInterval::Fixed(i64::MAX)` (all documents
+  // collapse into a single bucket) or a saturated offset (every
+  // document dropped), with no error returned. This covers two
+  // saturation paths: (a) `secs * 1_000.0 = f64::INFINITY` (the bug
+  // report's 306-digit prefix), and (b) `secs * 1_000.0` remains
+  // finite but exceeds `i64::MAX` (~9.22e18), where `as i64` still
+  // saturates silently.
   #[test]
   fn parse_interval_seconds_rejects_seconds_that_overflow_millis_conversion() {
-    // `1` followed by 306 zeros (≈1e306) parses to a finite f64 — it
-    // is well below `f64::MAX` (~1.8e308) — but exceeds
-    // `f64::MAX / 1_000.0` (~1.8e305), so multiplying by 1_000.0 in
-    // downstream code would overflow to infinity.
-    let value = format!("1{}", "0".repeat(306));
-    // Bare seconds, the unit used for `fixed_interval` and `offset`
-    // that triggers the bug report.
-    assert_eq!(parse_interval_seconds(&value), None);
-    assert_eq!(parse_interval_seconds(&format!("{value}s")), None);
-    // Negative sign path (the `offset` caller accepts negatives).
-    assert_eq!(parse_interval_seconds(&format!("-{value}s")), None);
-    assert_eq!(parse_interval_seconds(&format!("+{value}s")), None);
+    // Path (a) — `secs * 1_000.0` overflows to infinity.
+    // `1` followed by 306 zeros (≈1e306) is finite in f64 (~1.8e308)
+    // but multiplied by 1_000.0 overflows to `f64::INFINITY`.
+    let inf_after_mul = format!("1{}", "0".repeat(306));
+    assert_eq!(parse_interval_seconds(&inf_after_mul), None);
+    assert_eq!(parse_interval_seconds(&format!("{inf_after_mul}s")), None);
+    assert_eq!(parse_interval_seconds(&format!("-{inf_after_mul}s")), None);
+    assert_eq!(parse_interval_seconds(&format!("+{inf_after_mul}s")), None);
 
-    // Boundary check: the largest finite magnitude that survives the
-    // downstream `* 1_000.0` conversion should still parse. We pick
-    // `1e305`, which is comfortably below `f64::MAX / 1_000.0`
-    // (~1.7976e305) and yields a finite millisecond value.
-    let safe = format!("1{}", "0".repeat(305));
-    let parsed = parse_interval_seconds(&safe).expect("1e305s must parse");
+    // Path (b) — `secs * 1_000.0` is finite but above the `i64` range.
+    // `1` followed by 20 zeros (1e20) seconds → 1e23 millis, which is
+    // finite but far above `i64::MAX` (~9.22e18) and would saturate
+    // silently without the tightened guard.
+    let finite_but_saturates = format!("1{}", "0".repeat(20));
+    assert_eq!(parse_interval_seconds(&finite_but_saturates), None);
+    assert_eq!(parse_interval_seconds(&format!("{finite_but_saturates}s")), None);
+    assert_eq!(
+      parse_interval_seconds(&format!("-{finite_but_saturates}s")),
+      None
+    );
+
+    // Boundary sanity: a large-but-realistic magnitude (1e10 seconds
+    // ≈ 317 years) yields 1e13 millis, well inside the i64 range, and
+    // must still parse.
+    let safe = format!("1{}", "0".repeat(10));
+    let parsed = parse_interval_seconds(&safe).expect("1e10 bare seconds must parse");
     assert!(parsed.is_finite());
-    assert!((parsed * 1_000.0).is_finite());
+    let millis = parsed * 1_000.0;
+    assert!(millis.is_finite());
+    assert!(millis.abs() < i64::MAX as f64);
   }
 
   // Regression tests for BUG-296: `bucket_sort` by `_key` must compare numeric

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4603,7 +4603,10 @@ mod tests {
     // silently without the tightened guard.
     let finite_but_saturates = format!("1{}", "0".repeat(20));
     assert_eq!(parse_interval_seconds(&finite_but_saturates), None);
-    assert_eq!(parse_interval_seconds(&format!("{finite_but_saturates}s")), None);
+    assert_eq!(
+      parse_interval_seconds(&format!("{finite_but_saturates}s")),
+      None
+    );
     assert_eq!(
       parse_interval_seconds(&format!("-{finite_but_saturates}s")),
       None

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4495,6 +4495,19 @@ pub(crate) fn parse_interval_seconds(spec: &str) -> Option<f64> {
   if !magnitude.is_finite() {
     return None;
   }
+  // Every caller converts the returned seconds value to milliseconds via
+  // `secs * 1_000.0` before casting to `i64`. A finite magnitude above
+  // `f64::MAX / 1_000.0` overflows to `f64::INFINITY` after that
+  // multiplication, and Rust's `as i64` cast saturates infinity to
+  // `i64::MAX` — silently producing `DateInterval::Fixed(i64::MAX)`
+  // (all documents collapse into a single bucket) or an `i64::MAX`
+  // offset that drops every document. Reject such magnitudes centrally
+  // so the overflow surfaces as a parse failure at every call site,
+  // rather than patching each `* 1_000.0` multiplication individually.
+  // Guards BUG-408.
+  if magnitude.abs() > f64::MAX / 1_000.0 {
+    return None;
+  }
   Some(if negative { -magnitude } else { magnitude })
 }
 
@@ -4553,6 +4566,40 @@ mod tests {
     // Sanity check: the same value with a smaller multiplier (ms,
     // which scales by 0.001) should still parse to a finite result.
     assert!(parse_interval_seconds(&format!("{value}ms")).is_some_and(|f| f.is_finite()));
+  }
+
+  // Regression test for BUG-408: `parse_interval_seconds` must reject
+  // finite seconds magnitudes that overflow to `f64::INFINITY` when the
+  // caller converts them to milliseconds via `secs * 1_000.0`. Without
+  // the `magnitude.abs() > f64::MAX / 1_000.0` guard, such a value would
+  // parse successfully, the downstream `* 1_000.0` would overflow, and
+  // Rust's `as i64` cast would saturate `f64::INFINITY` to `i64::MAX` —
+  // silently producing `DateInterval::Fixed(i64::MAX)` or an `i64::MAX`
+  // offset that collapses all documents into a single bucket or drops
+  // them entirely.
+  #[test]
+  fn parse_interval_seconds_rejects_seconds_that_overflow_millis_conversion() {
+    // `1` followed by 306 zeros (≈1e306) parses to a finite f64 — it
+    // is well below `f64::MAX` (~1.8e308) — but exceeds
+    // `f64::MAX / 1_000.0` (~1.8e305), so multiplying by 1_000.0 in
+    // downstream code would overflow to infinity.
+    let value = format!("1{}", "0".repeat(306));
+    // Bare seconds, the unit used for `fixed_interval` and `offset`
+    // that triggers the bug report.
+    assert_eq!(parse_interval_seconds(&value), None);
+    assert_eq!(parse_interval_seconds(&format!("{value}s")), None);
+    // Negative sign path (the `offset` caller accepts negatives).
+    assert_eq!(parse_interval_seconds(&format!("-{value}s")), None);
+    assert_eq!(parse_interval_seconds(&format!("+{value}s")), None);
+
+    // Boundary check: the largest finite magnitude that survives the
+    // downstream `* 1_000.0` conversion should still parse. We pick
+    // `1e305`, which is comfortably below `f64::MAX / 1_000.0`
+    // (~1.7976e305) and yields a finite millisecond value.
+    let safe = format!("1{}", "0".repeat(305));
+    let parsed = parse_interval_seconds(&safe).expect("1e305s must parse");
+    assert!(parsed.is_finite());
+    assert!((parsed * 1_000.0).is_finite());
   }
 
   // Regression tests for BUG-296: `bucket_sort` by `_key` must compare numeric

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -973,6 +973,133 @@ fn date_histogram_rejects_overflowing_interval_strings() {
   );
 }
 
+// Regression test for BUG-408: `parse_interval_seconds` returns a finite
+// `f64` magnitude, but every caller converts the returned seconds value
+// to milliseconds via `secs * 1_000.0` before casting to `i64`. A finite
+// seconds magnitude slightly above `f64::MAX / 1_000.0` (~1.8e305) is
+// below the `magnitude.is_finite()` threshold (BUG-344) yet overflows
+// to `f64::INFINITY` after the millisecond conversion, and Rust's
+// `as i64` cast saturates infinity to `i64::MAX` — silently producing a
+// degenerate `DateInterval::Fixed(i64::MAX)` (all documents collapse
+// into a single bucket) or an `i64::MAX` offset (every document is
+// dropped). After the fix, `parse_interval_seconds` rejects such
+// magnitudes centrally and both call sites surface the expected
+// `InvalidConfig` error.
+#[test]
+fn date_histogram_rejects_finite_seconds_that_overflow_millis_conversion() {
+  let tmp = tempfile::tempdir().unwrap();
+  let path = tmp.path().to_path_buf();
+  let mut schema = Schema::default_text_body();
+  schema.numeric_fields.push(NumericField {
+    name: "ts".into(),
+    i64: true,
+    fast: true,
+    stored: true,
+    nullable: false,
+  });
+  let idx = IndexBuilder::create(&path, schema, build_base_options(&path)).unwrap();
+  let reader = idx.reader().unwrap();
+
+  // `1` followed by 306 zeros is ≈1e306: finite in f64 (~1.8e308) but
+  // above `f64::MAX / 1_000.0` (~1.8e305), so `secs * 1_000.0` overflows
+  // to infinity and `as i64` saturates to `i64::MAX` without the guard.
+  let overflow_seconds = format!("1{}s", "0".repeat(306));
+
+  fn base_request(aggs: BTreeMap<String, Aggregation>) -> SearchRequest {
+    SearchRequest {
+      query: "rust".into(),
+      fields: None,
+      filter: None,
+      limit: 1,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor: None,
+      search_after: None,
+      execution: ExecutionStrategy::Wand,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs,
+      suggest: BTreeMap::new(),
+      rescore: None,
+      explain: false,
+      profile: false,
+    }
+  }
+
+  // fixed_interval post-millis overflow → "must be a positive duration of at least 1ms"
+  let mut aggs = BTreeMap::new();
+  aggs.insert(
+    "hist".into(),
+    Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+      field: "ts".into(),
+      calendar_interval: None,
+      fixed_interval: Some(overflow_seconds.clone()),
+      offset: None,
+      format: None,
+      min_doc_count: None,
+      extended_bounds: None,
+      hard_bounds: None,
+      missing: None,
+      sampling: None,
+      aggs: BTreeMap::new(),
+    })),
+  );
+  let resp = reader.search(&base_request(aggs));
+  assert!(
+    resp.is_err(),
+    "fixed_interval post-millis overflow should surface InvalidConfig"
+  );
+  let msg = resp.err().unwrap().to_string();
+  assert!(
+    msg.contains("fixed_interval") && msg.contains("positive duration"),
+    "fixed_interval post-millis overflow: expected message about positive duration, got `{msg}`",
+  );
+
+  // offset post-millis overflow (positive and negative) → "offset `...` is invalid"
+  for signed in [overflow_seconds.clone(), format!("-{overflow_seconds}")] {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::DateHistogram(Box::new(DateHistogramAggregation {
+        field: "ts".into(),
+        calendar_interval: Some("day".into()),
+        fixed_interval: None,
+        offset: Some(signed.clone()),
+        format: None,
+        min_doc_count: None,
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+    let resp = reader.search(&base_request(aggs));
+    assert!(
+      resp.is_err(),
+      "offset post-millis overflow ({signed}) should surface InvalidConfig"
+    );
+    let msg = resp.err().unwrap().to_string();
+    assert!(
+      msg.contains("offset") && msg.contains("invalid"),
+      "offset post-millis overflow ({signed}): expected message about invalid offset, got `{msg}`",
+    );
+  }
+}
+
 #[test]
 fn top_hits_returns_requested_docs() {
   let tmp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

- `parse_interval_seconds` returns a finite seconds magnitude, but every caller multiplies by `1_000.0` to convert to milliseconds before casting to `i64`. A finite seconds value above `f64::MAX / 1_000.0` (≈1.8e305) overflows to `f64::INFINITY` after that multiplication; Rust's `as i64` cast saturates infinity to `i64::MAX`, silently producing a degenerate `DateInterval::Fixed(i64::MAX)` (all documents collapse into a single bucket) or an `i64::MAX` offset that drops every document.
- Centralize the guard in `parse_interval_seconds` rather than patching each `* 1_000.0` call site — reject magnitudes above `f64::MAX / 1_000.0` so overflow surfaces as a parse failure in one place and every caller (`fixed_interval`, `offset`, span-cap pre-validation) benefits for free.

## Trace from the issue

1. `parse_interval_seconds("999...9s")` with 306 nines → digit prefix parses to ~1e306 (finite f64). Previously returned `Some(1e306)`.
2. `reader.rs` validation `secs.is_finite() && secs > 0.0 && (secs * 1000.0) as i64 >= 1` → `(inf as i64) >= 1` → `i64::MAX >= 1` → **true** (validation passes).
3. `aggs/mod.rs` collector: `1e306 * 1_000.0 = 1e309` → `f64::INFINITY` → `as i64` → `i64::MAX`.
4. All documents land in a single bucket; no error returned.

After the fix, step 1 returns `None`, so every caller's existing `is_none()` / `parse_interval_seconds(...).filter(...)` check surfaces the expected `InvalidConfig` error.

## Test plan

- [x] Unit test: `parse_interval_seconds_rejects_seconds_that_overflow_millis_conversion` covers bare seconds, `s` suffix, negative, and explicit positive sign forms, plus a boundary sanity check at ~1e305 that must still parse.
- [x] Integration test: `date_histogram_rejects_finite_seconds_that_overflow_millis_conversion` exercises the full request → response path for `fixed_interval`, `offset` (positive), and `offset` (negative), asserting each surfaces `InvalidConfig`.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Existing BUG-344 regression tests still pass.

Closes #408