### PR TITLE
fix(aggs): reject histogram bucket ids whose reconstruction overflows (BUG-410)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"5669fcc5-7c12-4dc6-ad0d-2429d27edacb","pid":90853,"acquiredAt":1776888493226}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"5669fcc5-7c12-4dc6-ad0d-2429d27edacb","pid":90853,"acquiredAt":1776888493226}

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4124,10 +4124,15 @@ fn default_percentiles_list() -> Vec<f64> {
 ///    `±Infinity`. `i64 -> f64` rounding (values above `2^53` are not all
 ///    exactly representable) can nudge the product past `f64::MAX` even when
 ///    the original quotient was within bounds — for example with
-///    `interval ≈ 2e289` and `val ≈ f64::MAX` the quotient is a finite
+///    `interval = 3e289` and `val = f64::MAX` the quotient is a finite
 ///    in-range i64 but the reverse product evaluates to `f64::INFINITY`,
-///    which `serde_json::Number::from_f64` rejects and the call sites' silent
-///    `unwrap_or_else(|| Number::from(0))` fallback would key at `0`.
+///    which `serde_json::Number::from_f64` rejects. The JSON key
+///    serialization paths in `HistogramCollector::collect` and `finish` then
+///    fall back to `unwrap_or_else(|| Number::from(0))`, silently keying the
+///    bucket at `0`. The `hard_bounds` filter compares the reconstruction
+///    directly without a JSON fallback, but treating the infinite product as
+///    a bucket value there is still wrong; centralizing the guard covers
+///    every site uniformly.
 ///
 /// Note: `i64::MAX as f64` rounds up to `2^63` because `2^63 - 1` is not
 /// representable in f64, so the upper bound uses `>=` to keep every `q` whose
@@ -4142,11 +4147,13 @@ fn finite_bucket_id(val: f64, offset: f64, interval: f64) -> Option<i64> {
   let id = q as i64;
   // Guard the inverse reconstruction (BUG-410). Downstream call sites
   // (`HistogramCollector::collect`, `finish`, and the `hard_bounds` filter)
-  // recompute `id as f64 * interval + offset` to emit the bucket key; if that
-  // overflows to non-finite, `serde_json::Number::from_f64` returns `None` and
-  // the `unwrap_or_else(|| Number::from(0))` fallback at those sites keys the
-  // bucket at `0`, potentially colliding with a legitimate bucket. Rejecting
-  // here centralizes the guard so every call site is protected.
+  // recompute `id as f64 * interval + offset`. On the JSON key serialization
+  // paths a non-finite product flows into `serde_json::Number::from_f64`,
+  // which returns `None`, and the `unwrap_or_else(|| Number::from(0))`
+  // fallback then silently keys the bucket at `0`; the `hard_bounds`
+  // comparison does not re-key but still treats an infinite product as a
+  // bucket value. Rejecting here centralizes the guard so every site is
+  // protected uniformly.
   if !(id as f64 * interval + offset).is_finite() {
     return None;
   }

--- a/searchlite-core/src/query/aggs/mod.rs
+++ b/searchlite-core/src/query/aggs/mod.rs
@@ -4105,12 +4105,14 @@ fn default_percentiles_list() -> Vec<f64> {
 }
 
 /// Map `(val - offset) / interval` to a bucket id, returning `None` when the
-/// quotient cannot be represented as an `i64` without loss (BUG-358).
+/// quotient cannot be represented as an `i64` without loss (BUG-358) or when
+/// the inverse reconstruction `id * interval + offset` used by downstream key
+/// serialization would overflow to a non-finite f64 (BUG-410).
 ///
-/// Two overflow modes must be rejected for histogram arithmetic so that
-/// documents whose bucket id would saturate the `as i64` cast are dropped
-/// rather than silently coalesced into a shared `i64::MAX` / `i64::MIN` bucket
-/// with a wrong reconstructed key:
+/// Three overflow modes must be rejected for histogram arithmetic so that
+/// documents whose bucket id would saturate the `as i64` cast, or whose
+/// reconstructed key would be non-finite, are dropped rather than silently
+/// coalesced into a wrong bucket:
 ///
 /// 1. The quotient itself overflows f64 to `±Infinity` (for example
 ///    `f64::MAX / 0.5`); `is_finite()` rejects this shape.
@@ -4118,6 +4120,14 @@ fn default_percentiles_list() -> Vec<f64> {
 ///    range (for example `1e16 / 0.001 = 1e19 > i64::MAX ≈ 9.22e18`); the
 ///    magnitude comparison against `i64::MAX as f64 = 2^63` rejects this
 ///    shape.
+/// 3. The reconstruction `id as f64 * interval + offset` overflows to
+///    `±Infinity`. `i64 -> f64` rounding (values above `2^53` are not all
+///    exactly representable) can nudge the product past `f64::MAX` even when
+///    the original quotient was within bounds — for example with
+///    `interval ≈ 2e289` and `val ≈ f64::MAX` the quotient is a finite
+///    in-range i64 but the reverse product evaluates to `f64::INFINITY`,
+///    which `serde_json::Number::from_f64` rejects and the call sites' silent
+///    `unwrap_or_else(|| Number::from(0))` fallback would key at `0`.
 ///
 /// Note: `i64::MAX as f64` rounds up to `2^63` because `2^63 - 1` is not
 /// representable in f64, so the upper bound uses `>=` to keep every `q` whose
@@ -4129,7 +4139,18 @@ fn finite_bucket_id(val: f64, offset: f64, interval: f64) -> Option<i64> {
   if !q.is_finite() || q >= (i64::MAX as f64) || q < (i64::MIN as f64) {
     return None;
   }
-  Some(q as i64)
+  let id = q as i64;
+  // Guard the inverse reconstruction (BUG-410). Downstream call sites
+  // (`HistogramCollector::collect`, `finish`, and the `hard_bounds` filter)
+  // recompute `id as f64 * interval + offset` to emit the bucket key; if that
+  // overflows to non-finite, `serde_json::Number::from_f64` returns `None` and
+  // the `unwrap_or_else(|| Number::from(0))` fallback at those sites keys the
+  // bucket at `0`, potentially colliding with a legitimate bucket. Rejecting
+  // here centralizes the guard so every call site is protected.
+  if !(id as f64 * interval + offset).is_finite() {
+    return None;
+  }
+  Some(id)
 }
 
 /// Compute the effective fill range for `HistogramCollector::finish`.
@@ -5634,6 +5655,34 @@ mod tests {
     // casts back to `i64::MIN` — legitimate, so the guard accepts it.
     let neg_boundary = i64::MIN as f64;
     assert_eq!(finite_bucket_id(neg_boundary, 0.0, 1.0), Some(i64::MIN));
+  }
+
+  /// BUG-410: even when the quotient is finite and within the `i64`
+  /// representable range (so the BUG-358 guard accepts it), the inverse
+  /// reconstruction `id as f64 * interval + offset` can still overflow to
+  /// `±Infinity`. At `val = ±f64::MAX` with `interval = 3e289` the quotient
+  /// `val / interval ≈ ±5.99e18` is within the i64 range, but the reverse
+  /// product exceeds `f64::MAX` once i64→f64 rounding is applied.
+  /// `serde_json::Number::from_f64` rejects non-finite values, and the
+  /// downstream `unwrap_or_else(|| Number::from(0))` fallback at each call
+  /// site would silently re-key the bucket at `0`, colliding with a
+  /// legitimate bucket at zero. Reject here so every call site is covered.
+  #[test]
+  fn finite_bucket_id_rejects_reconstruction_overflow() {
+    assert_eq!(finite_bucket_id(f64::MAX, 0.0, 3e289), None);
+    assert_eq!(finite_bucket_id(-f64::MAX, 0.0, 3e289), None);
+  }
+
+  /// A near-neighbor case whose reconstruction stays finite must still be
+  /// accepted: the guard should reject only the overflow shape, not every
+  /// extreme interval. `val = f64::MAX` with `interval = 2e289` produces a
+  /// product that is finite (equal to `f64::MAX` within rounding) and must
+  /// round-trip to a valid `i64` bucket id.
+  #[test]
+  fn finite_bucket_id_accepts_near_boundary_finite_reconstruction() {
+    let id = finite_bucket_id(f64::MAX, 0.0, 2e289).expect("reconstruction is finite");
+    let reconstructed = id as f64 * 2e289;
+    assert!(reconstructed.is_finite());
   }
 
   #[test]

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -3922,3 +3922,144 @@ mod bug_358 {
     assert_eq!(buckets[0].doc_count, 1);
   }
 }
+
+/// Regression tests for BUG-410 — `HistogramCollector` reconstructs each
+/// bucket's display key via `bucket_id as f64 * interval + offset`. The
+/// BUG-358 guard protects the forward quotient against overflow and
+/// `i64`-range saturation, but does not guard the inverse reconstruction.
+/// `i64 → f64` rounding (values above `2^53` are not all exactly representable
+/// in f64) can nudge the product past `f64::MAX` and evaluate to `±Infinity`
+/// even when the original quotient was finite and within i64 range.
+///
+/// At that point `serde_json::Number::from_f64(±Infinity)` returns `None` and
+/// the `unwrap_or_else(|| Number::from(0))` fallback at each call site
+/// silently re-keys the bucket at `0`, potentially colliding with a
+/// legitimate bucket. The fix extends `finite_bucket_id` to also reject
+/// quotients whose reconstruction is non-finite, so the affected documents
+/// are dropped (matching the composite-histogram policy from BUG-356 and the
+/// forward-quotient policy from BUG-358) rather than keyed at `0`.
+mod bug_410 {
+  use super::*;
+
+  fn f64_score_index(path: &std::path::Path) -> searchlite_core::api::Index {
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "score".into(),
+      i64: false,
+      fast: true,
+      stored: true,
+      nullable: false,
+    });
+    Index::create(path, schema, build_base_options(path)).unwrap()
+  }
+
+  fn index_scores(idx: &searchlite_core::api::Index, scores: &[f64]) {
+    let mut writer = idx.writer().unwrap();
+    for (i, score) in scores.iter().enumerate() {
+      writer
+        .add_document(&doc(
+          &format!("d-{i}"),
+          vec![("body", json!("rust")), ("score", json!(score))],
+        ))
+        .unwrap();
+    }
+    writer.commit().unwrap();
+  }
+
+  fn run_histogram(
+    idx: &searchlite_core::api::Index,
+    interval: f64,
+  ) -> searchlite_core::api::types::AggregationResponse {
+    let mut aggs = BTreeMap::new();
+    aggs.insert(
+      "hist".into(),
+      Aggregation::Histogram(Box::new(HistogramAggregation {
+        field: "score".into(),
+        interval,
+        offset: None,
+        min_doc_count: None,
+        extended_bounds: None,
+        hard_bounds: None,
+        missing: None,
+        sampling: None,
+        aggs: BTreeMap::new(),
+      })),
+    );
+    let mut req = SearchRequest::new("rust");
+    req.aggs = aggs;
+    let resp = idx.reader().unwrap().search(&req).expect("search");
+    resp.aggregations.get("hist").cloned().expect("histogram")
+  }
+
+  fn extract_histogram(
+    resp: &searchlite_core::api::types::AggregationResponse,
+  ) -> &[searchlite_core::api::types::BucketResponse] {
+    match resp {
+      searchlite_core::api::types::AggregationResponse::Histogram { buckets, .. } => buckets,
+      _ => panic!("expected histogram aggregation response"),
+    }
+  }
+
+  /// Primary regression: `val = f64::MAX, interval = 3e289`. The quotient
+  /// `val / interval ≈ 5.99e18` is within the i64 range (BUG-358 guard
+  /// passes), but the reconstruction `id as f64 * 3e289` overflows to
+  /// `+Infinity`. Before the fix the bucket was silently keyed at `0` via
+  /// `serde_json::Number::from_f64(inf).unwrap_or_else(|| Number::from(0))`.
+  #[test]
+  fn histogram_drops_document_when_reconstruction_overflows_to_infinity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    index_scores(&idx, &[f64::MAX]);
+
+    let resp = run_histogram(&idx, 3e289);
+    let buckets = extract_histogram(&resp);
+    assert!(
+      buckets.is_empty(),
+      "document whose reconstruction overflows must be dropped, got {buckets:?}"
+    );
+  }
+
+  /// Symmetric negative overflow: `-f64::MAX` with `interval = 3e289`
+  /// reconstructs to `-Infinity`. Same fallback would key at `0`.
+  #[test]
+  fn histogram_drops_document_when_reconstruction_overflows_to_neg_infinity() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    index_scores(&idx, &[-f64::MAX]);
+
+    let resp = run_histogram(&idx, 3e289);
+    let buckets = extract_histogram(&resp);
+    assert!(
+      buckets.is_empty(),
+      "document whose negative reconstruction overflows must be dropped, got {buckets:?}"
+    );
+  }
+
+  /// Key-collision regression: an overflow document must not coalesce with a
+  /// legitimate document whose bucket key really is `0`. Before the fix the
+  /// overflow document's key was silently replaced with `0` via the
+  /// `unwrap_or_else(|| Number::from(0))` fallback, merging its count into
+  /// the `0` bucket.
+  #[test]
+  fn histogram_reconstruction_overflow_does_not_collide_with_zero_bucket() {
+    let tmp = tempfile::tempdir().unwrap();
+    let idx = f64_score_index(tmp.path());
+    // A legitimate doc at key 0 (value lands in bucket [0, interval)) plus
+    // an overflow doc. The overflow doc must NOT land in the same bucket.
+    index_scores(&idx, &[0.0, f64::MAX]);
+
+    let resp = run_histogram(&idx, 3e289);
+    let buckets = extract_histogram(&resp);
+    assert_eq!(
+      buckets.len(),
+      1,
+      "expected one bucket (zero), overflow doc dropped; got {buckets:?}"
+    );
+    let bucket = &buckets[0];
+    assert!(bucket.key.is_number());
+    assert_eq!(
+      bucket.doc_count, 1,
+      "overflow doc must not be coalesced into the zero bucket"
+    );
+  }
+}

--- a/searchlite-core/tests/aggregation_bounds.rs
+++ b/searchlite-core/tests/aggregation_bounds.rs
@@ -3931,12 +3931,15 @@ mod bug_358 {
 /// in f64) can nudge the product past `f64::MAX` and evaluate to `±Infinity`
 /// even when the original quotient was finite and within i64 range.
 ///
-/// At that point `serde_json::Number::from_f64(±Infinity)` returns `None` and
-/// the `unwrap_or_else(|| Number::from(0))` fallback at each call site
-/// silently re-keys the bucket at `0`, potentially colliding with a
-/// legitimate bucket. The fix extends `finite_bucket_id` to also reject
-/// quotients whose reconstruction is non-finite, so the affected documents
-/// are dropped (matching the composite-histogram policy from BUG-356 and the
+/// At that point `serde_json::Number::from_f64(±Infinity)` returns `None`, so
+/// the JSON key serialization paths in `HistogramCollector::collect` and
+/// `finish` fall back to `unwrap_or_else(|| Number::from(0))` and silently
+/// re-key the bucket at `0`, potentially colliding with a legitimate bucket.
+/// (The `hard_bounds` filter compares the reconstruction directly without a
+/// JSON fallback, but still treats an infinite product as a bucket value.)
+/// The fix extends `finite_bucket_id` to also reject quotients whose
+/// reconstruction is non-finite, so the affected documents are dropped
+/// (matching the composite-histogram policy from BUG-356 and the
 /// forward-quotient policy from BUG-358) rather than keyed at `0`.
 mod bug_410 {
   use super::*;


### PR DESCRIPTION
## Summary

- Extends `finite_bucket_id` to reject quotients whose inverse reconstruction `id as f64 * interval + offset` overflows to `±Infinity`, so every `HistogramCollector` call site (`collect`, `finish`, `hard_bounds`) is covered without per-site checks.
- Closes BUG-410.

## Root cause

`HistogramCollector` reconstructs each bucket's display key via `bucket_id as f64 * interval + offset`. The BUG-358 `finite_bucket_id` guard covered the forward quotient `(val - offset) / interval` but not the inverse product. For very large intervals (e.g. `3e289`) with a document value near `f64::MAX`, the quotient sits within i64 range but i64→f64 rounding (values above 2^53 are not all exactly representable) nudges the product past `f64::MAX`. `serde_json::Number::from_f64(±Infinity)` returns `None` and the `unwrap_or_else(|| Number::from(0))` fallback silently re-keys the bucket at `0`, potentially coalescing the overflow doc with a legitimate zero bucket.

## Fix

Add a finitude check on `id as f64 * interval + offset` inside `finite_bucket_id`. Matches the BUG-356 composite-histogram policy — affected documents are dropped rather than silently misbucketed.

## Test plan

- [x] New unit test `finite_bucket_id_rejects_reconstruction_overflow` — verifies `val = ±f64::MAX, interval = 3e289` returns `None`.
- [x] New unit test `finite_bucket_id_accepts_near_boundary_finite_reconstruction` — pins a near-neighbor case (`interval = 2e289`) whose reconstruction is finite so the guard only rejects overflow, not every extreme interval.
- [x] New integration tests under `bug_410`: positive overflow drops the doc, negative overflow drops the doc, and an overflow doc is not coalesced with a legitimate zero-key bucket.
- [x] Existing `bug_358` regression tests and the full `aggregation_bounds` integration suite still pass (68/68).
- [x] `cargo clippy --package searchlite-core --tests -- -D warnings` clean.