### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,7 +1256,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2103,7 +2103,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2152,7 +2152,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "axum",
@@ -2174,7 +2174,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "napi",
@@ -2186,7 +2186,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/integration/CHANGELOG.md
+++ b/integration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/davidkelley/searchlite/compare/integration-v0.2.3...integration-v0.2.4) - 2026-04-23
+
+### Fixed
+
+- *(http)* drop index_path from /stats response (BUG-015) ([#178](https://github.com/davidkelley/searchlite/pull/178))
+
 ## [0.2.2](https://github.com/davidkelley/searchlite/compare/integration-v0.2.1...integration-v0.2.2) - 2026-04-13
 
 ### Added

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.11](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.10...searchlite-cli-v0.1.11) - 2026-04-23
+
+### Fixed
+
+- *(cli)* stream add/delete input instead of loading whole file (BUG-017) ([#235](https://github.com/davidkelley/searchlite/pull/235))
+
 ## [0.1.10](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.9...searchlite-cli-v0.1.10) - 2026-04-13
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.0...searchlite-core-v0.8.1) - 2026-04-23
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.8.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.7.0...searchlite-core-v0.8.0) - 2026-04-23
 
 ### Added

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.3...searchlite-http-v0.2.4) - 2026-04-23
+
+### Fixed
+
+- *(http)* classify write-key errors via typed downcast (BUG-406) ([#407](https://github.com/davidkelley/searchlite/pull/407))
+- *(http)* drop path from /indexes response (BUG-219) ([#220](https://github.com/davidkelley/searchlite/pull/220))
+- *(http)* redact internal error detail from client responses (BUG-016) ([#197](https://github.com/davidkelley/searchlite/pull/197))
+- *(http)* drop index_path from /stats response (BUG-015) ([#178](https://github.com/davidkelley/searchlite/pull/178))
+
+### Other
+
+- *(http)* share IndexReader pool across parallel multi_search ([#282](https://github.com/davidkelley/searchlite/pull/282))
+
 ## [0.2.3](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.2...searchlite-http-v0.2.3) - 2026-04-13
 
 ### Other

--- a/searchlite-node/CHANGELOG.md
+++ b/searchlite-node/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.3...searchlite-node-v0.2.4) - 2026-04-23
+
+### Added
+
+- *(node)* Zod-native schema authoring ([#244](https://github.com/davidkelley/searchlite/pull/244))
+
+### Fixed
+
+- *(schema)* reject documents that omit non-nullable top-level fields (BUG-224) ([#226](https://github.com/davidkelley/searchlite/pull/226))
+
 ## [0.2.2](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.1...searchlite-node-v0.2.2) - 2026-04-13
 
 ### Added

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.7...searchlite-wasm-v0.1.8) - 2026-04-23
+
+### Added
+
+- *(wasm)* harden browser runtime and production workflows ([#179](https://github.com/davidkelley/searchlite/pull/179))
+
 ## [0.1.7](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.6...searchlite-wasm-v0.1.7) - 2026-04-23
 
 ### Added

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.8.0 -> 0.8.1 (✓ API compatible changes)
* `searchlite-http`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `integration`: 0.2.3 -> 0.2.4 (✓ API compatible changes)
* `searchlite-cli`: 0.1.10 -> 0.1.11
* `searchlite-wasm`: 0.1.7 -> 0.1.8
* `searchlite-node`: 0.2.3 -> 0.2.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.8.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.0...searchlite-core-v0.8.1) - 2026-04-23

### Other

- update Cargo.toml dependencies
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.3...searchlite-http-v0.2.4) - 2026-04-23

### Fixed

- *(http)* classify write-key errors via typed downcast (BUG-406) ([#407](https://github.com/davidkelley/searchlite/pull/407))
- *(http)* drop path from /indexes response (BUG-219) ([#220](https://github.com/davidkelley/searchlite/pull/220))
- *(http)* redact internal error detail from client responses (BUG-016) ([#197](https://github.com/davidkelley/searchlite/pull/197))
- *(http)* drop index_path from /stats response (BUG-015) ([#178](https://github.com/davidkelley/searchlite/pull/178))

### Other

- *(http)* share IndexReader pool across parallel multi_search ([#282](https://github.com/davidkelley/searchlite/pull/282))
</blockquote>

## `integration`

<blockquote>

## [0.2.4](https://github.com/davidkelley/searchlite/compare/integration-v0.2.3...integration-v0.2.4) - 2026-04-23

### Fixed

- *(http)* drop index_path from /stats response (BUG-015) ([#178](https://github.com/davidkelley/searchlite/pull/178))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.11](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.10...searchlite-cli-v0.1.11) - 2026-04-23

### Fixed

- *(cli)* stream add/delete input instead of loading whole file (BUG-017) ([#235](https://github.com/davidkelley/searchlite/pull/235))
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.7...searchlite-wasm-v0.1.8) - 2026-04-23

### Added

- *(wasm)* harden browser runtime and production workflows ([#179](https://github.com/davidkelley/searchlite/pull/179))
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.3...searchlite-node-v0.2.4) - 2026-04-23

### Added

- *(node)* Zod-native schema authoring ([#244](https://github.com/davidkelley/searchlite/pull/244))

### Fixed

- *(schema)* reject documents that omit non-nullable top-level fields (BUG-224) ([#226](https://github.com/davidkelley/searchlite/pull/226))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).