### PR TITLE
ci: unblock PRs by making Chrome WASM job non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,12 @@ jobs:
       - name: Test
         run: cargo test --all --all-features
 
+  # Headless Chrome hangs after 8 of 11 lib tests (hosted runner regression).
+  # Firefox still gates correctness; see test-wasm-browser-diagnose below.
   test-wasm-browser:
     name: WASM Browser
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -64,6 +67,36 @@ jobs:
           RUST_TEST_THREADS: "1"
           WASM_BINDGEN_TEST_TIMEOUT: "120"
         run: wasm-pack test --headless --chrome searchlite-wasm
+
+  # Runs each suspect test individually to pinpoint the Chrome hang.
+  # Remove once root-caused.
+  test-wasm-browser-diagnose:
+    name: WASM Browser Diagnose (${{ matrix.test }})
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - indexes_and_searches
+          - commit_surfaces_quota_exceeded_error_type
+          - cleanup_orphaned_files_removes_only_unknown_paths
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+      - name: Run single test in Chrome
+        env:
+          RUST_TEST_THREADS: "1"
+          WASM_BINDGEN_TEST_TIMEOUT: "30"
+        run: wasm-pack test --headless --chrome searchlite-wasm --lib -- --exact "wasm::tests::${{ matrix.test }}"
 
   test-wasm-browser-firefox:
     name: WASM Browser (Firefox)


### PR DESCRIPTION
## Summary
- Makes the `WASM Browser` (headless Chrome) job `continue-on-error: true` so failing PRs can merge again. Firefox continues to run the full WASM suite and gates correctness.
- Adds a diagnostic matrix job `WASM Browser Diagnose` that runs each of the three tests that never complete individually, so the next CI run identifies which one hangs.

## Why
Headless Chrome in the hosted runners started hanging in `wasm-bindgen-test` after 8 of 11 lib tests — at least 10 open PRs failed CI on this alone. The exact same SHA (`65977e0`) passed the Chrome job ~30 min earlier on its PR branch (runner image `20260420.95`) and began hanging on subsequent runs (runner image `20260413.86`), so the code is identical across pass and fail — this is a runner/Chrome environment regression, not a code regression.

The three tests that never print completion (one of them hangs — the other two simply never start):
- \`indexes_and_searches\`
- \`commit_surfaces_quota_exceeded_error_type\`
- \`cleanup_orphaned_files_removes_only_unknown_paths\`

## Follow-up
Once the diagnostic run identifies the hanging test, fix the underlying issue (likely an IndexedDB transaction lifecycle edge case in Chrome 147 headless) and remove both \`continue-on-error\` flags and the diagnostic job.

## Test plan
- [ ] CI on this PR shows \`Lint / Build / Test (stable)\`, \`WASM Browser (Firefox)\`, \`Node.js\`, etc. all green
- [ ] \`WASM Browser\` is allowed to fail without failing the workflow
- [ ] \`WASM Browser Diagnose\` matrix isolates which of the 3 tests hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)