### PR TITLE
fix(wasm): release cached IndexedDB connections at end of each lib test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,13 @@ jobs:
       - name: Test
         run: cargo test --all --all-features
 
+  # Lib tests pass (fixed by closing cached IDB connections). Integration
+  # tests still flake on headless Chrome in current runner images (likely
+  # setTimeout throttling in lifecycle.rs); Firefox gates correctness.
   test-wasm-browser:
     name: WASM Browser
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,12 +44,9 @@ jobs:
       - name: Test
         run: cargo test --all --all-features
 
-  # Headless Chrome hangs after 8 of 11 lib tests (hosted runner regression).
-  # Firefox still gates correctness; see test-wasm-browser-diagnose below.
   test-wasm-browser:
     name: WASM Browser
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -67,36 +64,6 @@ jobs:
           RUST_TEST_THREADS: "1"
           WASM_BINDGEN_TEST_TIMEOUT: "120"
         run: wasm-pack test --headless --chrome searchlite-wasm
-
-  # Runs each suspect test individually to pinpoint the Chrome hang.
-  # Remove once root-caused.
-  test-wasm-browser-diagnose:
-    name: WASM Browser Diagnose (${{ matrix.test }})
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    timeout-minutes: 20
-    strategy:
-      fail-fast: false
-      matrix:
-        test:
-          - indexes_and_searches
-          - commit_surfaces_quota_exceeded_error_type
-          - cleanup_orphaned_files_removes_only_unknown_paths
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked
-      - name: Run single test in Chrome
-        env:
-          RUST_TEST_THREADS: "1"
-          WASM_BINDGEN_TEST_TIMEOUT: "30"
-        run: wasm-pack test --headless --chrome searchlite-wasm --lib -- --exact "wasm::tests::${{ matrix.test }}"
 
   test-wasm-browser-firefox:
     name: WASM Browser (Firefox)

--- a/searchlite-wasm/src/wasm.rs
+++ b/searchlite-wasm/src/wasm.rs
@@ -2571,9 +2571,10 @@ mod tests {
     storage.write_all(&path, b"hello wasm").unwrap();
     storage.flush().await.unwrap();
     drop(storage);
-    let restored = JsStorage::new(db, root.clone()).await.unwrap();
+    let restored = JsStorage::new(db.clone(), root.clone()).await.unwrap();
     let contents = restored.read_to_end(&path).unwrap();
     assert_eq!(contents, b"hello wasm");
+    Searchlite::drop_index(db).await.unwrap();
   }
 
   #[wasm_bindgen_test]
@@ -2601,7 +2602,7 @@ mod tests {
   async fn js_storage_methods_roundtrip() {
     let db = unique_db("searchlite-storage-methods");
     let root = PathBuf::from("idx-methods");
-    let storage = JsStorage::new(db, root.clone()).await.unwrap();
+    let storage = JsStorage::new(db.clone(), root.clone()).await.unwrap();
     let path = root.join("notes.txt");
 
     storage.ensure_dir(&root).unwrap();
@@ -2636,6 +2637,7 @@ mod tests {
     storage.flush().await.unwrap();
     let contents = storage.read_to_end(&atomic_path).unwrap();
     assert_eq!(contents, b"atomic");
+    Searchlite::drop_index(db).await.unwrap();
   }
 
   #[wasm_bindgen_test]
@@ -2674,7 +2676,7 @@ mod tests {
   async fn js_file_seek_behaves() {
     let db = unique_db("searchlite-seek");
     let root = PathBuf::from("idx-seek");
-    let storage = JsStorage::new(db, root.clone()).await.unwrap();
+    let storage = JsStorage::new(db.clone(), root.clone()).await.unwrap();
     let path = root.join("seek.txt");
     let mut file = storage.open_write(&path).unwrap();
 
@@ -2690,13 +2692,16 @@ mod tests {
     assert_eq!(&tail, b"ef");
     file.seek(SeekFrom::Start(0)).unwrap();
     assert!(file.seek(SeekFrom::Current(-1)).is_err());
+    drop(file);
+    storage.flush().await.unwrap();
+    Searchlite::drop_index(db).await.unwrap();
   }
 
   #[wasm_bindgen_test]
   async fn indexes_and_searches() {
     let db = unique_db("searchlite-index");
     let root = PathBuf::from("idx2");
-    let storage = Arc::new(JsStorage::new(db, root.clone()).await.unwrap());
+    let storage = Arc::new(JsStorage::new(db.clone(), root.clone()).await.unwrap());
     let schema = Schema::default_text_body();
     let opts = IndexOptions {
       path: root.clone(),
@@ -2757,13 +2762,16 @@ mod tests {
     };
     let result = reader.search(&request).unwrap();
     assert_eq!(result.hits.len(), 1);
+    Searchlite::drop_index(db).await.unwrap();
   }
 
   #[wasm_bindgen_test]
   async fn wasm_core_parity_search_mget_multi_search_update_delete() {
     let db = unique_db("searchlite-parity");
     let schema_json = serde_json::to_string(&Schema::default_text_body()).unwrap();
-    let idx = Searchlite::init(db, schema_json, None).await.unwrap();
+    let idx = Searchlite::init(db.clone(), schema_json, None)
+      .await
+      .unwrap();
     let docs = vec![
       serde_json::json!({ "_id": "doc-1", "body": "alpha token" }),
       serde_json::json!({ "_id": "doc-2", "body": "beta token" }),
@@ -2876,6 +2884,7 @@ mod tests {
     })
     .unwrap();
     assert_eq!(wasm_verify_json, core_verify_json);
+    Searchlite::drop_index(db).await.unwrap();
   }
 
   #[wasm_bindgen_test]
@@ -2978,11 +2987,12 @@ mod tests {
     let hits = result_json["hits"].as_array().unwrap();
     assert_eq!(hits.len(), 1);
 
-    let mismatch = match Searchlite::init(db, schema_v2_json, None).await {
+    let mismatch = match Searchlite::init(db.clone(), schema_v2_json, None).await {
       Ok(_) => panic!("expected schema mismatch after rollback"),
       Err(err) => err,
     };
     let mismatch_payload: WasmErrorPayload = serde_wasm_bindgen::from_value(mismatch).unwrap();
     assert_eq!(mismatch_payload.error_type, "schema_mismatch");
+    Searchlite::drop_index(db).await.unwrap();
   }
 }


### PR DESCRIPTION
## Summary
- **Lib test fix:** Six lib tests leaked IndexedDB connections in `DB_CACHE`, which caused headless Chrome to hang once ~8 connections accumulated. Added `Searchlite::drop_index(db).await.unwrap();` at the end of each leaky test (matching the pattern used by the four tests that don't hang). All 11 lib tests now pass in Chrome.
- **Chrome job remains non-blocking:** The integration-test binaries (e.g. `tests/lifecycle.rs`) hang on a separate issue — the first test that awaits a `set_timeout_once(120, ...)` never completes, which looks like a Chrome-headless timer-throttling regression in the current hosted runner images. Firefox runs the full suite and gates correctness, so we keep the Chrome job `continue-on-error` and investigate the integration-test flake as a follow-up.

## Before / after on headless Chrome
- Before: lib binary hung at 8/11 tests; `WASM Browser` job failed.
- After: lib binary reports `11 passed; 0 failed; 0 ignored; 0 filtered out; finished in 0.42s`. Integration-test hang moved to `tests/lifecycle.rs` (separate root cause, not gating).

## Follow-ups
- Investigate why `tests/lifecycle.rs::cleanup_indexes_drops_only_stale_entries` (and its `cleanup_indexes_dry_run_does_not_delete` twin) hang in headless Chrome — they both await a `setTimeout(120ms)` via `common::set_timeout_once` + `oneshot`.
- Once that's root-caused, remove `continue-on-error` from the Chrome job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)