### PR TITLE
ci: limit Chrome WASM job to lib tests, drop continue-on-error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,12 @@ jobs:
       - name: Test
         run: cargo test --all --all-features
 
-  # Lib tests pass (fixed by closing cached IDB connections). Integration
-  # tests still flake on headless Chrome in current runner images (likely
-  # setTimeout throttling in lifecycle.rs); Firefox gates correctness.
+  # Chrome runs lib tests only — integration tests in tests/*.rs hang in
+  # headless Chrome on current hosted runner images (looks like setTimeout
+  # throttling in lifecycle.rs). Firefox runs the full suite below.
   test-wasm-browser:
     name: WASM Browser
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -63,11 +62,11 @@ jobs:
         run: cargo install wasm-pack --locked
       - name: Build WASM package
         run: wasm-pack build searchlite-wasm --target web --release
-      - name: Run browser tests
+      - name: Run lib tests
         env:
           RUST_TEST_THREADS: "1"
           WASM_BINDGEN_TEST_TIMEOUT: "120"
-        run: wasm-pack test --headless --chrome searchlite-wasm
+        run: wasm-pack test --headless --chrome searchlite-wasm --lib
 
   test-wasm-browser-firefox:
     name: WASM Browser (Firefox)


### PR DESCRIPTION
## Summary
Integration tests under \`searchlite-wasm/tests/*.rs\` still hang in headless Chrome on the current hosted runner images (the first \`set_timeout_once\`-based test in \`tests/lifecycle.rs\` never completes — looks like a Chrome timer-throttling regression). The lib tests pass cleanly after #444.

This PR narrows the \`WASM Browser\` job to lib tests only and drops \`continue-on-error\`, so the job becomes a real, passing required check. \`WASM Browser (Firefox)\` continues to run the full suite (lib + integration) and gates correctness.

## Why now
Dependabot PRs are getting blocked because \`WASM Browser\` was a required status check but failing under \`continue-on-error\`. Switching it to a narrower-but-passing command lets the merge queue move again.

## Follow-up
Investigate why \`tests/lifecycle.rs::cleanup_indexes_drops_only_stale_entries\` (and its \`cleanup_indexes_dry_run_does_not_delete\` twin) hang in headless Chrome — both await a \`setTimeout(120ms)\` via \`common::set_timeout_once\` + \`oneshot\`. Once fixed, restore the full \`wasm-pack test --headless --chrome searchlite-wasm\` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)