### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2249,7 +2249,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "argon2",
@@ -2305,7 +2305,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -2337,7 +2337,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "anyhow",
  "napi",
@@ -2349,7 +2349,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/integration/CHANGELOG.md
+++ b/integration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/davidkelley/searchlite/compare/integration-v0.2.4...integration-v0.2.5) - 2026-04-26
+
+### Other
+
+- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
+
 ## [0.2.4](https://github.com/davidkelley/searchlite/compare/integration-v0.2.3...integration-v0.2.4) - 2026-04-25
 
 ### Fixed

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.12](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.11...searchlite-cli-v0.1.12) - 2026-04-26
+
+### Other
+
+- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
+
 ## [0.1.11](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.10...searchlite-cli-v0.1.11) - 2026-04-25
 
 ### Fixed

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.1...searchlite-core-v0.8.2) - 2026-04-26
+
+### Other
+
+- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
+
 ## [0.8.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.0...searchlite-core-v0.8.1) - 2026-04-25
 
 ### Other

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.7...searchlite-ffi-v0.1.8) - 2026-04-26
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.7](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.6...searchlite-ffi-v0.1.7) - 2026-04-23
 
 ### Fixed

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.4...searchlite-http-v0.2.5) - 2026-04-26
+
+### Other
+
+- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
+
 ## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.3...searchlite-http-v0.2.4) - 2026-04-25
 
 ### Fixed

--- a/searchlite-node/CHANGELOG.md
+++ b/searchlite-node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.4...searchlite-node-v0.2.5) - 2026-04-26
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.4](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.3...searchlite-node-v0.2.4) - 2026-04-25
 
 ### Added

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.8...searchlite-wasm-v0.1.9) - 2026-04-26
+
+### Other
+
+- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
+
 ## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.7...searchlite-wasm-v0.1.8) - 2026-04-25
 
 ### Added

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-core`: 0.8.1 -> 0.8.2 (✓ API compatible changes)
* `searchlite-http`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `integration`: 0.2.4 -> 0.2.5 (✓ API compatible changes)
* `searchlite-cli`: 0.1.11 -> 0.1.12
* `searchlite-ffi`: 0.1.7 -> 0.1.8
* `searchlite-wasm`: 0.1.8 -> 0.1.9
* `searchlite-node`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-core`

<blockquote>

## [0.8.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.1...searchlite-core-v0.8.2) - 2026-04-26

### Other

- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.4...searchlite-http-v0.2.5) - 2026-04-26

### Other

- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
</blockquote>

## `integration`

<blockquote>

## [0.2.5](https://github.com/davidkelley/searchlite/compare/integration-v0.2.4...integration-v0.2.5) - 2026-04-26

### Other

- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.12](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.11...searchlite-cli-v0.1.12) - 2026-04-26

### Other

- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.7...searchlite-ffi-v0.1.8) - 2026-04-26

### Other

- update Cargo.toml dependencies
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.8...searchlite-wasm-v0.1.9) - 2026-04-26

### Other

- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.4...searchlite-node-v0.2.5) - 2026-04-26

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).