### PR TITLE
build(deps-dev): bump typescript from 5.9.3 to 6.0.3

### DIFF
--- a/searchlite-node/package-lock.json
+++ b/searchlite-node/package-lock.json
@@ -14,7 +14,7 @@
 				"@swc/cli": "^0.8",
 				"@swc/core": "^1",
 				"@types/node": "^25.6.0",
-				"typescript": "^5",
+				"typescript": "^6",
 				"vitest": "^4",
 				"zod": "^4.3.6"
 			},
@@ -3529,9 +3529,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
-			"integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+			"integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5142,9 +5142,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -44,7 +44,7 @@
 		"@swc/cli": "^0.8",
 		"@swc/core": "^1",
 		"@types/node": "^25.6.0",
-		"typescript": "^5",
+		"typescript": "^6",
 		"vitest": "^4"
 	},
 	"engines": {

--- a/searchlite-node/tsconfig.json
+++ b/searchlite-node/tsconfig.json
@@ -6,12 +6,13 @@
 		"declarationDir": "dist",
 		"outDir": "dist",
 		"rootDir": "src",
-		"moduleResolution": "node",
-		"module": "commonjs",
+		"moduleResolution": "node16",
+		"module": "node16",
 		"target": "es2022",
 		"lib": ["es2022", "esnext.disposable"],
 		"esModuleInterop": true,
-		"skipLibCheck": true
+		"skipLibCheck": true,
+		"types": ["node"]
 	},
 	"include": ["src"]
 }


### PR DESCRIPTION
## Summary
- Bumps `typescript` from 5.9.3 to 6.0.3 in `searchlite-node` (matches what dependabot opened in #427).
- Migrates [searchlite-node/tsconfig.json](searchlite-node/tsconfig.json) off the `moduleResolution: "node"` (alias of `node10`) option, which TS 6.0 deprecated and TS 7.0 will remove. CI was failing on `tsc` with `error TS5107: Option 'moduleResolution=node10' is deprecated`.
- Pairs `moduleResolution: "node16"` with `module: "node16"` (TS 6 requires them aligned). With no `"type": "module"` in [package.json](searchlite-node/package.json), `node16` resolves to CommonJS — same runtime contract as before.
- Adds an explicit `"types": ["node"]`. Under `node16` resolution TS 6 no longer auto-loads `@types/node` from `node_modules` for files that import `node:fs`/`node:path`, so the node types have to be listed (the test config was already doing this).

Supersedes #427.

## Test plan
- [x] `npm install` (with TypeScript 6.0.3)
- [x] `npm run build:native:debug`
- [x] `npm run build:ts` (the previously failing step)
- [x] `npm run typecheck` (`tsc` + `tsc -p tsconfig.test.json`)
- [x] `npm run lint`
- [x] `npm test` — 267/267 pass
- [x] `npm pack --dry-run` — `dist/index.js` and `dist/index.d.ts` present, native `.node` packed

🤖 Generated with [Claude Code](https://claude.com/claude-code)