### PR TITLE
build(deps): bump rand from 0.8.6 to 0.9.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2284,7 +2284,7 @@ dependencies = [
  "log",
  "memmap2",
  "parking_lot",
- "rand 0.8.6",
+ "rand 0.9.4",
  "rayon",
  "regex",
  "rust-stemmers",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2278,6 +2278,7 @@ dependencies = [
  "crc32fast",
  "criterion",
  "getrandom 0.2.16",
+ "getrandom 0.3.4",
  "hashbrown 0.16.1",
  "hmac",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ crc32fast = "1.3.2"
 hashbrown = "0.16.1"
 rayon = "1.12.0"
 clap = { version = "4.5.60", features = ["derive"] }
-rand = "0.8.6"
+rand = "0.9.4"
 criterion = { version = "0.5.1", features = ["cargo_bench_support"] }
 uuid = { version = "1.23.1", features = ["v4", "serde"] }
 chrono = { version = "0.4.44", features = ["serde", "clock"] }

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -52,6 +52,10 @@ memmap2 = { workspace = true }
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 uuid = { workspace = true, features = ["js"] }
 getrandom = { version = "0.2", features = ["js"] }
+# rand 0.9 transitively pulls in getrandom 0.3, which needs the wasm_js
+# feature on wasm32 targets (paired with the `getrandom_backend="wasm_js"`
+# rustflag set in searchlite-wasm/.cargo/config.toml).
+getrandom_v03 = { package = "getrandom", version = "0.3", features = ["wasm_js"] }
 js-sys = "0.3.69"
 
 [dev-dependencies]

--- a/searchlite-core/benches/aggs.rs
+++ b/searchlite-core/benches/aggs.rs
@@ -49,8 +49,8 @@ fn build_bench_index(doc_count: usize, cardinality: usize) -> BenchIndex {
   let mut writer = idx.writer().unwrap();
   let mut rng = StdRng::seed_from_u64(42);
   for i in 0..doc_count {
-    let tag_id = rng.gen_range(0..cardinality);
-    let score = rng.gen_range(0..10_000i64);
+    let tag_id = rng.random_range(0..cardinality);
+    let score = rng.random_range(0..10_000i64);
     writer
       .add_document(&Document {
         fields: [
@@ -120,10 +120,10 @@ fn build_nested_bench_index(
   let mut rng = StdRng::seed_from_u64(1337);
   for i in 0..doc_count {
     let mut metadata = Vec::with_capacity(3);
-    let category_seed = rng.gen_range(0..category_count);
+    let category_seed = rng.random_range(0..category_count);
     for slot in 0..3 {
       let category = (category_seed + slot) % category_count;
-      let value_id = rng.gen_range(0..value_cardinality);
+      let value_id = rng.random_range(0..value_cardinality);
       metadata.push(serde_json::json!({
         "key": format!("Category_{category}"),
         "value": format!("Value_{value_id}")

--- a/searchlite-core/benches/datagen.rs
+++ b/searchlite-core/benches/datagen.rs
@@ -289,7 +289,7 @@ fn zipfian_pick(rng: &mut impl Rng, n: usize) -> usize {
     return 0;
   }
   let harmonic: f64 = (1..=n).map(|r| 1.0 / r as f64).sum();
-  let u: f64 = rng.gen::<f64>() * harmonic;
+  let u: f64 = rng.random::<f64>() * harmonic;
   let mut cumulative = 0.0;
   for rank in 1..=n {
     cumulative += 1.0 / rank as f64;
@@ -302,10 +302,10 @@ fn zipfian_pick(rng: &mut impl Rng, n: usize) -> usize {
 
 /// Generate a random text string with `min_words..=max_words` words from the vocabulary.
 fn random_text(rng: &mut impl Rng, min_words: usize, max_words: usize) -> String {
-  let count = rng.gen_range(min_words..=max_words);
+  let count = rng.random_range(min_words..=max_words);
   let mut words = Vec::with_capacity(count);
   for _ in 0..count {
-    let idx = rng.gen_range(0..VOCABULARY.len());
+    let idx = rng.random_range(0..VOCABULARY.len());
     words.push(VOCABULARY[idx]);
   }
   words.join(" ")
@@ -315,7 +315,7 @@ fn random_text(rng: &mut impl Rng, min_words: usize, max_words: usize) -> String
 fn random_date(rng: &mut impl Rng) -> String {
   // Span: ~730 days in seconds
   let seconds_in_2_years: u64 = 2 * 365 * 24 * 3600;
-  let offset = rng.gen_range(0..seconds_in_2_years);
+  let offset = rng.random_range(0..seconds_in_2_years);
   // Base: 2024-01-01T00:00:00Z
   let base_epoch: u64 = 1_704_067_200;
   let ts = base_epoch + offset;
@@ -357,8 +357,8 @@ pub fn generate_docs(count: usize, seed: u64) -> Vec<Document> {
     let body = random_text(&mut rng, 20, 100);
     let category_idx = zipfian_pick(&mut rng, CATEGORIES.len());
     let category = CATEGORIES[category_idx];
-    let price = rng.gen_range(1..=10000i64);
-    let rating = 1.0 + rng.gen::<f64>() * 4.0; // 1.0..5.0
+    let price = rng.random_range(1..=10000i64);
+    let rating = 1.0 + rng.random::<f64>() * 4.0; // 1.0..5.0
     let created_at = random_date(&mut rng);
 
     let mut fields = std::collections::BTreeMap::new();
@@ -441,10 +441,10 @@ pub fn generate_schema() -> Schema {
 
 /// Sample a few query terms from the vocabulary for use in benchmark queries.
 pub fn sample_query_terms(rng: &mut impl Rng) -> Vec<String> {
-  let count = rng.gen_range(2..=4);
+  let count = rng.random_range(2..=4);
   let mut terms = Vec::with_capacity(count);
   for _ in 0..count {
-    let idx = rng.gen_range(0..VOCABULARY.len());
+    let idx = rng.random_range(0..VOCABULARY.len());
     terms.push(VOCABULARY[idx].to_string());
   }
   terms

--- a/searchlite-core/examples/pruning.rs
+++ b/searchlite-core/examples/pruning.rs
@@ -32,11 +32,11 @@ fn main() -> Result<()> {
 
   let idx = Index::create(&path, Schema::default_text_body(), opts.clone())?;
   {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     let mut writer = idx.writer()?;
     for i in 0..docs {
       let body_tokens: Vec<&str> = (0..12)
-        .map(|_| vocab[rng.gen_range(0..vocab.len())])
+        .map(|_| vocab[rng.random_range(0..vocab.len())])
         .collect();
       let body = body_tokens.join(" ");
       writer.add_document(&Document {
@@ -60,11 +60,11 @@ fn main() -> Result<()> {
     .map(|f| f.name.clone())
     .collect();
   let queries: Vec<String> = {
-    let mut rng = rand::thread_rng();
+    let mut rng = rand::rng();
     (0..query_count)
       .map(|_| {
         let tokens: Vec<&str> = (0..3)
-          .map(|_| vocab[rng.gen_range(0..vocab.len())])
+          .map(|_| vocab[rng.random_range(0..vocab.len())])
           .collect();
         tokens.join(" ")
       })

--- a/searchlite-core/src/util/write_key.rs
+++ b/searchlite-core/src/util/write_key.rs
@@ -42,10 +42,10 @@ pub fn default_kdf_params() -> KdfParams {
 #[cfg(feature = "write-key")]
 mod crypto {
   use anyhow::{anyhow, Result};
+  use argon2::password_hash::rand_core::OsRng;
   use argon2::{password_hash::SaltString, Argon2, Params, PasswordHasher};
   use base64::{engine::general_purpose::STANDARD, Engine as _};
   use hmac::{Hmac, Mac};
-  use rand::rngs::OsRng;
   use sha2::Sha256;
   use subtle::ConstantTimeEq;
 

--- a/searchlite-core/tests/pruning.rs
+++ b/searchlite-core/tests/pruning.rs
@@ -24,7 +24,7 @@ fn add_random_docs(idx: &Index, vocab: &[&str], doc_count: usize, rng: &mut StdR
   let mut writer = idx.writer().unwrap();
   for i in 0..doc_count {
     let body_tokens: Vec<&str> = (0..6)
-      .map(|_| vocab[rng.gen_range(0..vocab.len())])
+      .map(|_| vocab[rng.random_range(0..vocab.len())])
       .collect();
     let body = body_tokens.join(" ");
     writer

--- a/searchlite-wasm/.cargo/config.toml
+++ b/searchlite-wasm/.cargo/config.toml
@@ -1,5 +1,6 @@
 [target.wasm32-unknown-unknown]
 rustflags = [
+  "--cfg", "getrandom_backend=\"wasm_js\"",
   "-C", "target-feature=+atomics,+bulk-memory",
   "-C", "link-arg=--shared-memory",
   # Set max linear memory to 1 GiB (1073741824 bytes) to balance typical workloads


### PR DESCRIPTION
## Summary

Supersedes [#431](https://github.com/davidkelley/searchlite/pull/431) — applies the dependabot rand 0.8 → 0.9 bump and the manual fixes needed to make CI green.

The bump itself is unchanged (cherry-picked from #431). The added migration commit covers two breaking-change fallouts dependabot can't handle on its own:

- **`searchlite-core` lib (write-key feature)** — argon2 0.5 still pins password-hash 0.5, whose `SaltString::generate` takes a `CryptoRngCore` from rand_core 0.6. rand 0.9's `rand::rngs::OsRng` is a rand_core 0.9 type and no longer implements that trait. Switched the import to `argon2::password_hash::rand_core::OsRng`, which is the right rand_core 0.6 type already in the dep tree.
- **wasm32 build** — rand 0.9 transitively brings in getrandom 0.3, whose wasm32 backend has to be opted into via the `wasm_js` cargo feature *and* the `getrandom_backend="wasm_js"` rustflag. Added a renamed `getrandom_v03` dep on the wasm32 target and set the rustflag in `searchlite-wasm/.cargo/config.toml` (the existing getrandom 0.2 + js setup uuid needs is left in place).
- **Tests/benches/example** — replaced the deprecated `gen_range` / `gen` / `thread_rng` aliases with `random_range` / `random` / `rand::rng`, since `clippy -D warnings` treats the deprecation lints as errors.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings`
- [x] `cargo build --all --all-features`
- [x] `cargo test --all --all-features` (all suites pass)
- [x] `cargo build --target wasm32-unknown-unknown -p searchlite-wasm`
- [x] `wasm-pack build searchlite-wasm --target web --release`
- [x] `searchlite-node`: `npm run build:native:debug && npm run build:ts && npm run typecheck && npm run lint && npm test` (300/300 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)