### PR TITLE
build(deps): bump napi and napi-derive from 2 to 3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,9 +418,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "convert_case"
-version = "0.6.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -546,13 +546,19 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.2.9"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
 dependencies = [
- "quote",
- "syn",
+ "ctor-proc-macro",
+ "dtor",
 ]
+
+[[package]]
+name = "ctor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a949c44fcacbbbb7ada007dc7acb34603dd97cd47de5d054f2b6493ecebb483"
 
 [[package]]
 name = "darling"
@@ -625,6 +631,21 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "dtor"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+dependencies = [
+ "dtor-proc-macro",
+]
+
+[[package]]
+name = "dtor-proc-macro"
+version = "0.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2647271c92754afcb174e758003cfd1cbf1e43e5a7853d7b1813e63e19e39a73"
 
 [[package]]
 name = "dyn-clone"
@@ -1371,9 +1392,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -1477,15 +1498,17 @@ dependencies = [
 
 [[package]]
 name = "napi"
-version = "2.16.17"
+version = "3.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55740c4ae1d8696773c78fdafd5d0e5fe9bc9f1b071c7ba493ba5c413a9184f3"
+checksum = "fa73b028610e2b26e9e40bd2c8ff8a98e6d7ed5d67d89ebf4bfd2f992616b024"
 dependencies = [
  "bitflags 2.10.0",
  "ctor",
- "napi-derive",
+ "futures",
+ "napi-build",
  "napi-sys",
- "once_cell",
+ "nohash-hasher",
+ "rustc-hash",
  "serde",
  "serde_json",
 ]
@@ -1498,12 +1521,12 @@ checksum = "d376940fd5b723c6893cd1ee3f33abbfd86acb1cd1ec079f3ab04a2a3bc4d3b1"
 
 [[package]]
 name = "napi-derive"
-version = "2.16.13"
+version = "3.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cbe2585d8ac223f7d34f13701434b9d5f4eb9c332cccce8dee57ea18ab8ab0c"
+checksum = "7430702d3cc05cf55f0a2c9e41d991c3b7a53f91e6146a8f282b1bfc7f3fd133"
 dependencies = [
- "cfg-if",
  "convert_case",
+ "ctor",
  "napi-derive-backend",
  "proc-macro2",
  "quote",
@@ -1512,24 +1535,22 @@ dependencies = [
 
 [[package]]
 name = "napi-derive-backend"
-version = "1.0.75"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1639aaa9eeb76e91c6ae66da8ce3e89e921cd3885e99ec85f4abacae72fc91bf"
+checksum = "1ca5a083f2c9b49a0c7d33ec75c083498849c6fcc46f5497317faa39ea77f5d5"
 dependencies = [
  "convert_case",
- "once_cell",
  "proc-macro2",
  "quote",
- "regex",
  "semver",
  "syn",
 ]
 
 [[package]]
 name = "napi-sys"
-version = "2.4.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427802e8ec3a734331fec1035594a210ce1ff4dc5bc1950530920ab717964ea3"
+checksum = "8eb602b84d7c1edae45e50bbf1374696548f36ae179dfa667f577e384bb90c2b"
 dependencies = [
  "libloading",
 ]
@@ -1550,6 +1571,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
 
 [[package]]
 name = "normalize-line-endings"

--- a/searchlite-node/Cargo.toml
+++ b/searchlite-node/Cargo.toml
@@ -13,8 +13,8 @@ zstd = ["searchlite-core/zstd"]
 
 [dependencies]
 searchlite-core = { path = "../searchlite-core", features = ["write-key"] }
-napi = { version = "2", features = ["serde-json", "napi9"] }
-napi-derive = "2"
+napi = { version = "3", features = ["serde-json", "napi9"] }
+napi-derive = "3"
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 

--- a/searchlite-node/biome.json
+++ b/searchlite-node/biome.json
@@ -19,6 +19,6 @@
 		}
 	},
 	"files": {
-		"includes": ["**", "!**/node_modules", "!**/dist", "!**/*.node"]
+		"includes": ["**", "!**/node_modules", "!**/dist", "!**/*.node", "!index.js", "!index.d.ts"]
 	}
 }

--- a/searchlite-node/src/index.rs
+++ b/searchlite-node/src/index.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 use std::sync::Mutex;
 
 use napi::bindgen_prelude::*;
-use napi::JsUnknown;
 use napi_derive::napi;
 use std::collections::BTreeMap;
 
@@ -98,7 +97,7 @@ impl Index {
   }
 
   #[napi]
-  pub fn add(&self, env: Env, doc: JsUnknown) -> napi::Result<()> {
+  pub fn add(&self, env: Env, doc: Unknown) -> napi::Result<()> {
     catch_panic("Index::add", || {
       let value: serde_json::Value = env.from_js_value(doc)?;
       let document = value_to_document(value)?;
@@ -113,7 +112,7 @@ impl Index {
   }
 
   #[napi(js_name = "addMany")]
-  pub fn add_many(&self, env: Env, docs: JsUnknown) -> napi::Result<u32> {
+  pub fn add_many(&self, env: Env, docs: Unknown) -> napi::Result<u32> {
     catch_panic("Index::addMany", || {
       let value: serde_json::Value = env.from_js_value(docs)?;
       let documents = value_to_documents(value)?;
@@ -142,7 +141,7 @@ impl Index {
   }
 
   #[napi]
-  pub fn search(&self, env: Env, query: JsUnknown) -> napi::Result<JsUnknown> {
+  pub fn search(&self, env: Env, query: Unknown) -> napi::Result<Unknown<'_>> {
     catch_panic("Index::search", || {
       self.with_index(|index| {
         let value: serde_json::Value = env.from_js_value(query)?;


### PR DESCRIPTION
## Summary

Combines #435 (napi-derive 2.16.13 → 3.5.4) and #438 (napi 2.16.17 → 3.8.5) into a single PR. Both crates must be bumped together since `napi-derive`'s generated code targets a specific major version of `napi` — splitting them caused build failures on the dependabot PRs.

## Changes

- Bump `napi` `2` → `3` and `napi-derive` `2` → `3` in [searchlite-node/Cargo.toml](searchlite-node/Cargo.toml).
- Update `Cargo.lock` accordingly.
- Replace `JsUnknown` with the new lifetime-parameterized `Unknown` type in [searchlite-node/src/index.rs](searchlite-node/src/index.rs) (the only source-level breaking change touched by our code).

Supersedes #435 and #438.

## Test plan

- [x] `cargo build --release -p searchlite-node`
- [x] `cargo clippy --release -- -D warnings`
- [x] `cargo check --workspace`
- [x] `npm run build:debug` in `searchlite-node`
- [x] `npm test` (300/300 vitest tests pass)
- [ ] CI green on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)