### PR TITLE
feat: add Elasticsearch HTTP-API compatibility adapter

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -348,3 +348,65 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           platforms: linux/amd64,linux/arm64
+
+
+  docker-image-elastic:
+    if: startsWith(github.event.release.tag_name, 'searchlite-adapter-elastic-v')
+    name: Publish Docker image (elastic adapter)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Derive release version
+        id: version
+        shell: bash
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          tag="$TAG_NAME"
+          if [[ "$tag" =~ -v([0-9].*)$ ]]; then
+            version="${BASH_REMATCH[1]}"
+          elif [[ "$tag" =~ ^v?(.*)$ ]]; then
+            version="${BASH_REMATCH[1]}"
+          else
+            echo "Unable to parse version from tag: $tag" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./searchlite-adapter-elastic/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/searchlite-elastic:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/searchlite-elastic:latest
+          labels: |
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,6 +2281,7 @@ dependencies = [
  "axum",
  "clap",
  "futures-util",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,7 @@ dependencies = [
  "portpicker",
  "predicates",
  "reqwest",
+ "searchlite-adapter-elastic",
  "searchlite-core",
  "searchlite-http",
  "serde",
@@ -2271,6 +2272,26 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "searchlite-adapter-elastic"
+version = "0.2.5"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tower 0.4.13",
+ "tower-http 0.5.2",
+ "tracing",
+ "tracing-subscriber",
+]
 
 [[package]]
 name = "searchlite-cli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "searchlite-wasm",
   "searchlite-http",
   "searchlite-node",
+  "searchlite-adapter-elastic",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Benchmarked on Apple M3 Max (36 GB), Rust 1.92.0, in-memory storage. All times a
 | **C FFI** | [`searchlite-ffi`](searchlite-ffi/) | Stable &mdash; shared library + C header |
 | **Node.js** | [`searchlite-js`](searchlite-node/) | Stable &mdash; native bindings + HTTP client, TypeScript + Zod |
 | **WASM** | [`searchlite-wasm`](searchlite-wasm/README.md) | Pre-1.0 &mdash; IndexedDB-backed browser search with worker runtime, migrations, quota handling |
+| **Elasticsearch adapter** | [`searchlite-adapter-elastic`](searchlite-adapter-elastic/README.md) | Pre-1.0 &mdash; read-only Elasticsearch HTTP-API compatibility for existing ES clients (Kibana, official SDKs) |
 
 ---
 
@@ -243,6 +244,7 @@ Benchmarked on Apple M3 Max (36 GB), Rust 1.92.0, in-memory storage. All times a
 | Schema and fields | [docs/schema.md](docs/schema.md) |
 | CLI reference | [docs/cli.md](docs/cli.md) |
 | HTTP service | [docs/http.md](docs/http.md) |
+| Elasticsearch adapter | [docs/adapters/elasticsearch.md](docs/adapters/elasticsearch.md) |
 | Query DSL | [docs/queries.md](docs/queries.md) |
 | Filters | [docs/filters.md](docs/filters.md) |
 | Aggregations | [docs/aggregations.md](docs/aggregations.md) |

--- a/docs/adapters/elasticsearch.md
+++ b/docs/adapters/elasticsearch.md
@@ -1,0 +1,419 @@
+# Elasticsearch Adapter
+
+`searchlite-adapter-elastic` is a standalone HTTP service that speaks the Elasticsearch HTTP API on the front and translates each request to SearchLite's native API on the back. Existing Elasticsearch clients — Kibana, the official ES SDKs, query builders, curl, your own scripts — can point at the adapter on port 9200 and get results from a SearchLite index without code changes.
+
+The adapter is **read-only in v1**: search, mget, msearch, mapping read, and cluster stubs all work; writes and DDL return `400 not_supported_in_v1` and should still go through the SearchLite native HTTP API on port 8080.
+
+> **Note:** Like SearchLite's native HTTP service, the adapter ships with no built-in authentication or rate limiting. Front it with your own proxy or API gateway when exposing it beyond localhost.
+
+---
+
+## When to use it
+
+- You have an existing tool that only speaks the Elasticsearch HTTP API (Kibana, an SDK, a query builder, an internal dashboard).
+- You're evaluating SearchLite as a cheaper or simpler alternative to a small Elasticsearch deployment and want to test it with the queries you already have.
+- You want a stepping-stone migration from a real Elasticsearch cluster: keep your read clients pointed at the adapter while you migrate ingestion to the native SearchLite API.
+
+If you're starting fresh and writing your own integration, the [native SearchLite HTTP API](../http.md) is simpler, more capable (write + DDL), and has no protocol translation overhead.
+
+## Architecture
+
+```
+   ES client (Kibana, SDK, curl)
+            │
+            │ Elasticsearch query DSL
+            │ port 9200
+            ▼
+   ┌──────────────────────────┐
+   │ searchlite-adapter-elastic │  JSON ↔ JSON translation; no SearchLite types
+   │  ghcr.io/davidkelley/      │
+   │  searchlite-elastic        │
+   └────────────┬─────────────┘
+                │
+                │ SearchLite native API
+                │ port 8080
+                ▼
+   ┌──────────────────────────┐
+   │ searchlite-http          │  the real engine
+   │  ghcr.io/davidkelley/    │
+   │  searchlite              │
+   └────────────┬─────────────┘
+                │
+                ▼
+            on-disk index
+```
+
+Each adapter request becomes one (or two, in the case of `_count`) upstream HTTP calls. Adapter ↔ upstream traffic is keep-alive and uses connection pooling via `reqwest`.
+
+---
+
+## Quick start (Docker Compose)
+
+This is the fastest way to try the adapter end-to-end. It uses the published images at `ghcr.io/davidkelley/searchlite:latest` and `ghcr.io/davidkelley/searchlite-elastic:latest`.
+
+```yaml
+# docker-compose.yml
+services:
+  searchlite:
+    image: ghcr.io/davidkelley/searchlite:latest
+    command:
+      - http
+      - --index
+      - demo:/data
+      - --bind
+      - 0.0.0.0:8080
+      - --refresh-on-commit
+    volumes:
+      - searchlite-data:/data
+    # Expose 8080 too if you want to write directly via the native API
+    ports:
+      - "8080:8080"
+
+  elastic:
+    image: ghcr.io/davidkelley/searchlite-elastic:latest
+    depends_on:
+      - searchlite
+    command:
+      - --bind
+      - 0.0.0.0:9200
+      - --upstream-url
+      - http://searchlite:8080
+    ports:
+      - "9200:9200"
+    restart: unless-stopped
+
+volumes:
+  searchlite-data:
+```
+
+Start the stack:
+
+```bash
+docker compose up -d
+```
+
+Confirm both services are reachable:
+
+```bash
+curl -s http://localhost:8080/healthz
+# {"status":"ok"}
+
+curl -s http://localhost:9200/ | jq .version.number
+# "8.11.0"
+
+curl -s http://localhost:9200/_cluster/health | jq .status
+# "green"
+```
+
+### Initialize an index and load data
+
+The adapter's v1 surface is read-only, so initialisation and writes go through the native API on port 8080:
+
+```bash
+# 1. Create the schema
+curl -X POST http://localhost:8080/indexes/demo/init \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "type": "object",
+    "searchlite:docIdField": "_id",
+    "properties": {
+      "title":       { "type": "string" },
+      "description": { "type": "string" },
+      "category":    { "type": "string", "searchlite:kind": "keyword" },
+      "price":       { "type": "integer" }
+    }
+  }'
+
+# 2. Add a few documents (NDJSON, one per line)
+curl -X POST http://localhost:8080/indexes/demo/add \
+  -H 'Content-Type: application/x-ndjson' \
+  --data-binary $'{"_id":"1","title":"rust safety guide","description":"ownership and borrowing","category":"books","price":25}\n{"_id":"2","title":"go concurrency patterns","description":"goroutines and channels","category":"books","price":30}\n{"_id":"3","title":"kitchen essentials","description":"knives, pans, cutting boards","category":"kitchen","price":50}\n'
+
+# 3. Commit + refresh so writes are searchable
+curl -X POST http://localhost:8080/indexes/demo/commit
+curl -X POST http://localhost:8080/indexes/demo/refresh
+```
+
+### Query through the adapter
+
+Now everything goes through the ES-compatible port:
+
+```bash
+# Match-all
+curl -s -X POST http://localhost:9200/demo/_search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"match_all":{}},"size":10}' | jq
+
+# Term filter on category
+curl -s -X POST http://localhost:9200/demo/_search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"term":{"category":"books"}},"size":10}' | jq '.hits.hits[]._id'
+
+# Multi-token relevance match
+curl -s -X POST http://localhost:9200/demo/_search \
+  -H 'Content-Type: application/json' \
+  -d '{"query":{"match":{"description":"goroutines"}},"size":3}' | jq '.hits.hits[0]._source'
+
+# Aggregation
+curl -s -X POST http://localhost:9200/demo/_search \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "size": 0,
+    "aggs": { "by_category": { "terms": { "field": "category", "size": 10 } } }
+  }' | jq '.aggregations.by_category.buckets'
+
+# Mapping
+curl -s http://localhost:9200/demo/_mapping | jq
+
+# Cluster health (always green; single-node)
+curl -s http://localhost:9200/_cluster/health | jq
+```
+
+### Tear down
+
+```bash
+docker compose down -v
+```
+
+---
+
+## Connecting common ES clients
+
+The adapter advertises itself as Elasticsearch 8.11.0 by default. Any client that accepts an arbitrary host should connect.
+
+### Kibana
+
+Add a Kibana service to the same Compose file:
+
+```yaml
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.11.0
+    depends_on:
+      - elastic
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elastic:9200"]'
+      # Disable security plugin features the adapter doesn't implement
+      ELASTICSEARCH_REQUESTTIMEOUT: 60000
+      XPACK_SECURITY_ENABLED: "false"
+    ports:
+      - "5601:5601"
+```
+
+Browse to `http://localhost:5601`. Discover and basic visualisations work against the supported query DSL surface; features that depend on writes, ILM, security, or transforms will not work.
+
+### Python (`elasticsearch` client)
+
+```python
+from elasticsearch import Elasticsearch
+
+es = Elasticsearch("http://localhost:9200")
+
+resp = es.search(
+    index="demo",
+    query={"match": {"description": "goroutines"}},
+    size=3,
+)
+for hit in resp["hits"]["hits"]:
+    print(hit["_id"], hit["_score"], hit["_source"]["title"])
+```
+
+If the client tries to negotiate transport-level features (security headers, sniffing) and complains, disable them:
+
+```python
+es = Elasticsearch(
+    "http://localhost:9200",
+    verify_certs=False,
+    request_timeout=30,
+    # Some client versions probe /_security or /_xpack on connect — those
+    # return 400 from the adapter; pass headers={'accept': 'application/json'}
+    # if you see warnings.
+)
+```
+
+### JavaScript / TypeScript (`@elastic/elasticsearch` client)
+
+```js
+import { Client } from '@elastic/elasticsearch';
+
+const client = new Client({ node: 'http://localhost:9200' });
+
+const result = await client.search({
+  index: 'demo',
+  query: { match: { description: 'goroutines' } },
+  size: 3,
+});
+
+console.log(result.hits.hits.map(h => h._id));
+```
+
+### curl / shell
+
+Already shown above.
+
+---
+
+## Configuration reference
+
+All flags can also be set via the matching `SEARCHLITE_ELASTIC_*` environment variable.
+
+| Flag | Env Var | Default | Purpose |
+|---|---|---|---|
+| `--bind` | `SEARCHLITE_ELASTIC_BIND_ADDR` | `127.0.0.1:9200` | Listen address. **WARNING:** Binding to `0.0.0.0` exposes this unauthenticated service. Use a proxy. |
+| `--upstream-url` | `SEARCHLITE_ELASTIC_UPSTREAM_URL` | `http://127.0.0.1:8080` | Base URL of the upstream `searchlite-http`. http/https only; trailing slash and path prefix are preserved. |
+| `--write-key` | `SEARCHLITE_ELASTIC_WRITE_KEY` | -- | Optional write key forwarded to upstream as `x-searchlite-write-key` |
+| `--version-banner` | `SEARCHLITE_ELASTIC_VERSION_BANNER` | `8.11.0` | Version returned in `GET /` and `_nodes`. Some clients pin to a major. |
+| `--request-timeout-secs` | `SEARCHLITE_ELASTIC_REQUEST_TIMEOUT_SECS` | `30` | Per-request timeout for upstream calls |
+| `--max-body-bytes` | `SEARCHLITE_ELASTIC_MAX_BODY_BYTES` | `100 MiB` | Max request body size |
+| `--max-concurrency` | `SEARCHLITE_ELASTIC_MAX_CONCURRENCY` | `64` | Max concurrent in-flight requests |
+| `--shutdown-grace-secs` | `SEARCHLITE_ELASTIC_GRACEFUL_SHUTDOWN_SECS` | `5` | Grace period after SIGTERM/SIGINT before forced shutdown |
+
+All errors return `{"error": {"type": "...", "reason": "...", "root_cause": [...]}, "status": <int>}`.
+
+---
+
+## Compatibility matrix
+
+### Supported endpoints
+
+| Endpoint | Notes |
+|---|---|
+| `GET /` | Static version banner |
+| `GET /_cluster/health` | Always green; single-node |
+| `GET /_cluster/state`, `GET /_nodes` | Minimal stubs |
+| `GET /_mapping` | Returns mappings for all indexes |
+| `HEAD /{index}` | 200/404 |
+| `GET /{index}` | mappings + settings + aliases |
+| `GET /{index}/_mapping` | Per-index mapping |
+| `GET /{index}/_settings` | Minimal settings stub; 404 on unknown |
+| `GET /{index}/_aliases`, `GET /{index}/_alias` | Path-scoped; resolves alias names too |
+| `POST /{index}/_search`, `GET /{index}/_search` | Full search surface |
+| `POST /{index}/_count`, `GET /{index}/_count` | Exact count |
+| `POST /{index}/_mget`, `POST /_mget` | Multi-get by ID |
+| `POST /_msearch`, `POST /{index}/_msearch` | NDJSON multi-search |
+
+### Rejected endpoints (return `400 not_supported_in_v1`)
+
+- All write endpoints: `PUT/POST /{index}/_doc[/{id}]`, `_bulk`, `_update`, `_delete_by_query`, `_update_by_query`
+- All DDL: `PUT /{index}`, `DELETE /{index}`, `PUT /_mapping`
+- `POST /{index}/_refresh`
+- Cross-index search via `POST /_search` (specify exactly one index in the path instead)
+- ES auth / security / ILM / snapshots / transforms / watcher / scroll
+
+### Query DSL
+
+| Clause | Status | Notes |
+|---|---|---|
+| `match_all`, `match_none` | ✓ / ✗ | `match_none` rejected |
+| `match` | ✓ | Single-field; translated to `query_string` |
+| `match_phrase` | ✓ | `slop=0` uses analyzer-aware quoted `query_string`; `slop > 0` uses literal-token phrase |
+| `match_phrase_prefix` | ✗ | Not supported |
+| `multi_match` | ✓ | `best_fields` / `most_fields` / `cross_fields` types; field boost (`title^2`); fuzziness; tie-breaker; minimum-should-match |
+| `term` | ✓ | String → keyword equality; numeric → constant-score range with `min == max` |
+| `terms` | ✓ | Mixed string/numeric arrays handled per element; field literally named `boost` is queryable |
+| `prefix`, `wildcard`, `regexp` | ✓ | Single-field, string only |
+| `range` | ✓ | i64/f64 inferred from value type; `gt`/`lt` converted to inclusive ranges via IEEE next-up/next-down |
+| `bool` | ✓ | `must`, `should`, `must_not`, `filter`; `minimum_should_match` accepts integer, percentage `"75%"`, and integer-string |
+| `query_string`, `simple_query_string` | ✓ | Forwarded; SearchLite's parser supports the common subset |
+| `constant_score` | ✓ | Filter context |
+| `dis_max` | ✓ | With tie-breaker |
+| `function_score`, `script_score` | partial | Limited to SearchLite's whitelist |
+| `exists` | ✗ | No SearchLite equivalent |
+| `geo_*`, `more_like_this`, `terms_set`, `combined_fields`, `intervals`, `pinned`, `parent/child`, `has_child`, `has_parent`, `nested` (query form) | ✗ | Rejected with `x_content_parse_exception` |
+
+### Aggregations
+
+| Aggregation | Status |
+|---|---|
+| `terms`, `significant_terms`, `rare_terms` | ✓ |
+| `range`, `date_range` | ✓ |
+| `histogram`, `date_histogram` | ✓ |
+| `composite` (terms + histogram sources) | ✓ |
+| `filter`, `nested` | ✓ |
+| `stats`, `extended_stats`, `value_count`, `cardinality` | ✓ |
+| `percentiles`, `percentile_ranks` | ✓ |
+| `top_hits` | ✓ |
+| Pipeline: `bucket_sort`, `avg_bucket`, `sum_bucket`, `derivative`, `moving_avg`, `bucket_script` | ✓ |
+| `avg`, `sum`, `min`, `max` (single-metric) | ✗ | Use `stats` and read the corresponding field |
+| `geo_*`, `geohash_grid`, `adjacency_matrix`, `diversified_sampler`, `auto_date_histogram`, `serial_diff`, `cumulative_sum`, `cumulative_cardinality`, `scripted_metric` | ✗ |
+
+### Sort / pagination / highlight
+
+| Feature | Status |
+|---|---|
+| `sort` (asc/desc, `_score`, mixed) | ✓ — `_score` defaults to desc, other fields to asc, matching ES |
+| `from` + `size` | ✓ |
+| `search_after` | ✓ |
+| `scroll` | ✗ — recommend `search_after` migration |
+| `_source: true/false`, `_source: ["fields"]`, `_source.includes` | ✓ |
+| `_source.excludes` | ✗ |
+| `highlight` (per-field, fragment_size, number_of_fragments, pre/post tags) | ✓ |
+| `track_total_hits` (boolean or integer cap; cap mapped to true/false) | ✓ |
+
+---
+
+## Mapping translation
+
+The adapter exposes SearchLite's JSON Schema-style mapping as an Elasticsearch mapping when you call `GET /{index}/_mapping`:
+
+| SearchLite | Elasticsearch |
+|---|---|
+| `string` (default kind) | `text` (with `analyzer` and `search_analyzer` carried) |
+| `string` + `searchlite:kind: keyword` | `keyword` |
+| `integer` | `long` |
+| `number` | `double` |
+| `boolean` | `boolean` |
+| `array` of `object` (nested) | `nested` (with sub-properties recursed) |
+| `object` + `searchlite:vector` | `dense_vector` (with `dims` and `similarity` derived from the metric) |
+
+The reverse direction (`PUT /{index}/_mapping`) is **not supported** in v1. Define the schema using the SearchLite native API on port 8080 — see [docs/schema.md](../schema.md).
+
+---
+
+## Behavioural notes
+
+A few places where SearchLite's defaults match (or surprise next to) real Elasticsearch:
+
+- **`_score` defaults to descending** for both bare-string (`"sort": ["_score"]`) and object form (`"sort": [{"_score": {}}]`), matching ES.
+- **`match_phrase` is analyzer-aware** when `slop = 0` (the default). The adapter emits a `query_string` with a quoted phrase so SearchLite's per-field analyzer drives tokenization. Punctuation, contractions, and non-ASCII text are handled the same way ES would. With `slop > 0`, the adapter falls back to a literal-token phrase to preserve proximity control — known limitation.
+- **No stemming or stopword removal** by default on either engine (matches ES's `standard` analyzer). `match: pattern` will not find a doc with `patterns` unless you configure a stemming analyzer per field.
+- **BM25 length normalization matches**: shorter documents with the same query-term frequency outrank longer ones on both engines. This was verified across 30 parity test cases against real Elasticsearch 9.0.0.
+- **`_count` returns an exact count** because the adapter always sets `track_total_hits: true` for that endpoint.
+- **`track_total_hits` integer cap** (e.g. `10000`) is mapped to `true` since SearchLite has no lower-bound mode. `0` maps to `false`. Negatives are rejected.
+- **`bool.minimum_should_match: "75%"`** is resolved adapter-side by counting the `should` clauses and computing `floor(should_count * pct / 100)`. Combinator syntax like `"3<90%"` is rejected.
+- **Single-shard pretense**: the adapter always returns `"_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 }` since SearchLite has no sharding concept.
+
+---
+
+## Operations
+
+- **Single node only.** SearchLite has no clustering. The adapter returns single-node stubs for `_cluster/health` and `_nodes`.
+- **Healthcheck.** The adapter has no dedicated `/healthz` endpoint (use `GET /` for liveness; it's always 200 once bound). For Kubernetes, an HTTP probe against `/` works.
+- **TLS.** Terminate TLS at a reverse proxy in front of the adapter. The adapter only speaks HTTP.
+- **Behind a path prefix.** If the upstream is hosted under a path prefix (e.g. `https://internal.example.com/searchlite/`), pass `--upstream-url https://internal.example.com/searchlite` — the adapter normalises the trailing slash and preserves the prefix on every upstream call.
+- **Restart safety.** The adapter is stateless. All persistent state lives in the upstream's index directory.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `502 connection_exception` from adapter | Upstream `searchlite-http` not running or wrong URL | `curl http://upstream:8080/healthz` and check `--upstream-url` |
+| `400 x_content_parse_exception` with "feature `X` not supported" | Query uses an ES feature outside the adapter's surface | Check the [compatibility matrix](#compatibility-matrix); rewrite the query or use the native SearchLite API |
+| `400 not_supported_in_v1` on a write or DDL | Adapter is read-only in v1 | Send writes/DDL to the native HTTP API on port 8080 |
+| `404 index_not_found_exception` on `GET /demo/_settings` | Index doesn't exist (or the upstream listing hasn't refreshed) | Confirm with `curl http://upstream:8080/indexes` |
+| Adapter accepts query but returns zero hits where ES would match | Tokenization or stemming mismatch — adapter uses analyzer-aware `match_phrase` and SearchLite's per-field analyzers | Verify your schema's `searchlite:analyzer`; for stemming you need a stemming analyzer wired into the index manifest |
+| `400 illegal_argument_exception` on `POST /_search` | Cross-index search not supported | Specify exactly one index in the path: `POST /myindex/_search` |
+| `_score` ordering looks reversed | Likely you sorted by `_score` ascending; ES defaults to descending | Default is now respected — confirm you're on adapter ≥ the build that landed the `_score` desc fix |
+
+For deeper investigation, the adapter logs every upstream call at `tracing` level info (set `RUST_LOG=info,searchlite_adapter_elastic=debug` for translation details).
+
+---
+
+## See also
+
+- [searchlite-adapter-elastic crate README](../../searchlite-adapter-elastic/README.md)
+- [Native HTTP API](../http.md) — what the adapter calls under the hood, and where writes go
+- [Query DSL](../queries.md) — the SearchLite-side query language the adapter targets
+- [Schema](../schema.md) — how to define the index
+- [Aggregations](../aggregations.md) — SearchLite's aggregation reference

--- a/docs/adapters/elasticsearch.md
+++ b/docs/adapters/elasticsearch.md
@@ -316,7 +316,7 @@ All errors return `{"error": {"type": "...", "reason": "...", "root_cause": [...
 | `query_string`, `simple_query_string` | ✓ | Forwarded; SearchLite's parser supports the common subset |
 | `constant_score` | ✓ | Filter context |
 | `dis_max` | ✓ | With tie-breaker |
-| `function_score`, `script_score` | partial | Limited to SearchLite's whitelist |
+| `function_score`, `script_score` | ✗ | Rejected for v1; SearchLite has the underlying query types but the adapter doesn't translate them yet |
 | `exists` | ✗ | No SearchLite equivalent |
 | `geo_*`, `more_like_this`, `terms_set`, `combined_fields`, `intervals`, `pinned`, `parent/child`, `has_child`, `has_parent`, `nested` (query form) | ✗ | Rejected with `x_content_parse_exception` |
 

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -22,6 +22,7 @@ reqwest = { version = "0.12.28", features = ["json", "rustls-tls", "blocking"] }
 portpicker = "0.1.1"
 searchlite-core = { path = "../searchlite-core", package = "searchlite-core" }
 searchlite-http = { path = "../searchlite-http", package = "searchlite-http" }
+searchlite-adapter-elastic = { path = "../searchlite-adapter-elastic", package = "searchlite-adapter-elastic" }
 
 [dev-dependencies]
 assert_cmd = "2.2.1"

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -553,6 +553,65 @@ fn mapping_all_returns_every_mounted_index() {
 }
 
 #[test]
+fn mapping_for_alias_returns_target_index_mapping() {
+  // Regression: get_mapping passed the raw path token to upstream `inspect`.
+  // Calling with an alias name returned 404 even though HEAD /<alias> and
+  // GET /<alias>/_settings already resolve aliases. Should resolve the alias
+  // and return the target's mapping keyed by the target index name.
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h.es_get("/demo_alias/_mapping").expect("get mapping");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  assert!(
+    body.get(INDEX).is_some(),
+    "mapping should be keyed by the target `{INDEX}`, got: {body}"
+  );
+  assert!(
+    body.get("demo_alias").is_none(),
+    "mapping must not be keyed by the alias name; got: {body}"
+  );
+}
+
+#[test]
+fn get_index_includes_real_aliases_in_payload() {
+  // Regression: GET /{index} hard-coded `"aliases": {}` regardless of what
+  // aliases actually point at the index. Should reflect the upstream alias
+  // listing so management/discovery flows see the correct topology.
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h.es_get(&format!("/{INDEX}")).expect("get index");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let aliases = body
+    .pointer(&format!("/{INDEX}/aliases"))
+    .expect("aliases key");
+  assert!(
+    aliases.get("demo_alias").is_some(),
+    "expected the configured alias to appear in /{INDEX} aliases; got: {body}"
+  );
+}
+
+#[test]
+fn get_index_called_with_alias_resolves_to_target_with_aliases_listed() {
+  // Combined alias-resolution test: GET /<alias> should return the response
+  // keyed by the concrete target with the alias listed in the aliases map.
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h.es_get("/demo_alias").expect("get alias as index");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  assert!(
+    body.get(INDEX).is_some(),
+    "GET /<alias> should be keyed by the target `{INDEX}`, got: {body}"
+  );
+  let aliases = body
+    .pointer(&format!("/{INDEX}/aliases"))
+    .expect("aliases key");
+  assert!(
+    aliases.get("demo_alias").is_some(),
+    "aliases map should contain the requested alias; got: {body}"
+  );
+}
+
+#[test]
 fn settings_for_alias_returns_target_index_payload() {
   // Regression: get_settings used to fabricate a settings payload keyed by
   // the request path token, even when that token was an alias name.

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -521,6 +521,36 @@ fn settings_on_unknown_index_returns_404() {
 }
 
 #[test]
+fn msearch_with_non_string_in_index_array_is_rejected() {
+  // Regression: the index-array parser dropped non-string elements via
+  // filter_map, so a malformed header like {"index":["demo",42]} was
+  // silently accepted as a single-index ("demo") request, possibly
+  // routing queries to an unintended index.
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let ndjson = format!(
+    "{}\n{}\n",
+    json!({"index": [INDEX, 42]}),
+    json!({"query": {"match_all": {}}}),
+  );
+  let (status, body) = h.es_post_ndjson("/_msearch", &ndjson).expect("post");
+  assert_eq!(status, StatusCode::BAD_REQUEST, "body: {body}");
+}
+
+#[test]
+fn msearch_with_single_string_in_index_array_still_works() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let ndjson = format!(
+    "{}\n{}\n",
+    json!({"index": [INDEX]}),
+    json!({"query": {"match_all": {}}}),
+  );
+  let (status, body) = h.es_post_ndjson("/_msearch", &ndjson).expect("post");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+}
+
+#[test]
 fn global_mget_with_source_false_omits_source_field() {
   // Regression: the global `_mget` handler always forwarded
   // `return_stored: true` to upstream, ignoring `_source: false` on the

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -137,7 +137,11 @@ impl ElasticHarness {
     let url = format!("{}/indexes/{INDEX}/refresh", self.upstream_base);
     let resp = self.client.post(url).send()?;
     if !resp.status().is_success() {
-      return Err(anyhow!("refresh failed {}: {}", resp.status(), resp.text()?));
+      return Err(anyhow!(
+        "refresh failed {}: {}",
+        resp.status(),
+        resp.text()?
+      ));
     }
     Ok(())
   }
@@ -208,11 +212,7 @@ impl Drop for ElasticHarness {
   }
 }
 
-fn wait_for_path(
-  client: &reqwest::blocking::Client,
-  url: &str,
-  child: &mut Child,
-) -> Result<()> {
+fn wait_for_path(client: &reqwest::blocking::Client, url: &str, child: &mut Child) -> Result<()> {
   for _ in 0..200 {
     if let Some(status) = child.try_wait()? {
       return Err(anyhow!("process exited early with status {status}"));
@@ -331,12 +331,18 @@ fn get_mapping_returns_es_shape() {
   assert_eq!(status, StatusCode::OK);
   let mappings = body.get(INDEX).unwrap().get("mappings").unwrap();
   let props = mappings.get("properties").unwrap();
-  assert_eq!(props.get("title").unwrap().get("type").unwrap(), &json!("text"));
+  assert_eq!(
+    props.get("title").unwrap().get("type").unwrap(),
+    &json!("text")
+  );
   assert_eq!(
     props.get("category").unwrap().get("type").unwrap(),
     &json!("keyword")
   );
-  assert_eq!(props.get("price").unwrap().get("type").unwrap(), &json!("long"));
+  assert_eq!(
+    props.get("price").unwrap().get("type").unwrap(),
+    &json!("long")
+  );
 }
 
 #[test]
@@ -416,15 +422,15 @@ fn mget_by_ids() {
   let h = ElasticHarness::new().expect("harness");
   seed_index(&h).expect("seed");
   let (status, body) = h
-    .es_post(
-      &format!("/{INDEX}/_mget"),
-      &json!({ "ids": ["a", "c"] }),
-    )
+    .es_post(&format!("/{INDEX}/_mget"), &json!({ "ids": ["a", "c"] }))
     .expect("mget");
   assert_eq!(status, StatusCode::OK, "body: {body}");
   let docs = body.get("docs").unwrap().as_array().unwrap();
   assert_eq!(docs.len(), 2);
-  let a = docs.iter().find(|d| d.get("_id") == Some(&json!("a"))).unwrap();
+  let a = docs
+    .iter()
+    .find(|d| d.get("_id") == Some(&json!("a")))
+    .unwrap();
   assert_eq!(a.get("found").unwrap(), &json!(true));
   assert_eq!(a.get("_index").unwrap(), &json!(INDEX));
 }
@@ -440,9 +446,7 @@ fn msearch_runs_two_searches() {
     json!({"index": INDEX}),
     json!({"query": {"term": {"category": "music"}}}),
   );
-  let (status, body) = h
-    .es_post_ndjson("/_msearch", &ndjson)
-    .expect("msearch");
+  let (status, body) = h.es_post_ndjson("/_msearch", &ndjson).expect("msearch");
   assert_eq!(status, StatusCode::OK, "body: {body}");
   let responses = body.get("responses").unwrap().as_array().unwrap();
   assert_eq!(responses.len(), 2);
@@ -498,10 +502,7 @@ fn unsupported_geo_query_is_rejected() {
 fn cross_index_search_path_is_rejected() {
   let h = ElasticHarness::new().expect("harness");
   let (status, _) = h
-    .es_post(
-      "/_search",
-      &json!({ "query": { "match_all": {} } }),
-    )
+    .es_post("/_search", &json!({ "query": { "match_all": {} } }))
     .expect("post");
   assert_eq!(status, StatusCode::BAD_REQUEST);
 }

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -330,6 +330,29 @@ fn cluster_health_returns_green() {
 }
 
 #[test]
+fn cluster_health_advertises_one_active_shard_consistent_with_green() {
+  // Regression: previously the response carried `status: green` alongside
+  // `active_primary_shards: 0` and `active_shards: 0`. That combination
+  // tripped Kibana / SDK probes that warn on green-with-no-active-shards.
+  // SearchLite's single-node single-shard model should advertise exactly
+  // that — one primary, one active.
+  let h = ElasticHarness::new().expect("harness");
+  let (status, body) = h.es_get("/_cluster/health").expect("get health");
+  assert_eq!(status, StatusCode::OK);
+  assert_eq!(body.get("status").unwrap(), &json!("green"));
+  assert_eq!(
+    body.get("active_primary_shards").unwrap(),
+    &json!(1),
+    "expected 1 active primary shard for single-node single-shard model"
+  );
+  assert_eq!(
+    body.get("active_shards").unwrap(),
+    &json!(1),
+    "expected 1 active shard for single-node single-shard model"
+  );
+}
+
+#[test]
 fn head_index_finds_known_index() {
   let h = ElasticHarness::new().expect("harness");
   seed_index(&h).expect("seed");

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -553,6 +553,127 @@ fn mapping_all_returns_every_mounted_index() {
 }
 
 #[test]
+fn aggregation_meta_field_is_round_tripped_in_response() {
+  // Regression: ES preserves and echoes the `meta` blob on each agg verbatim,
+  // and Kibana visualizations rely on this for correlation IDs. The adapter
+  // used to silently drop `meta` because the type-key filter excluded it.
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      &format!("/{INDEX}/_search"),
+      &json!({
+        "size": 0,
+        "aggs": {
+          "by_cat": {
+            "terms": { "field": "category" },
+            "meta": { "kibana_id": "abc-123", "type": "facet" }
+          }
+        }
+      }),
+    )
+    .expect("search");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  assert_eq!(
+    body.pointer("/aggregations/by_cat/meta").unwrap(),
+    &json!({"kibana_id": "abc-123", "type": "facet"})
+  );
+}
+
+#[test]
+fn search_via_alias_returns_target_index_in_hit_index_field() {
+  // Regression: search responses stamped `_index` from the URL path token,
+  // so requests via an alias returned hits with `_index: "<alias>"`. ES
+  // returns the resolved target index name. Downstream tooling that
+  // round-trips `_index` from a hit into a write request would otherwise
+  // hit the wrong index.
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      "/demo_alias/_search",
+      &json!({ "query": { "match_all": {} }, "size": 5 }),
+    )
+    .expect("search");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let hits = body.pointer("/hits/hits").unwrap().as_array().unwrap();
+  assert!(!hits.is_empty(), "expected hits; got: {body}");
+  for hit in hits {
+    assert_eq!(
+      hit.get("_index").unwrap(),
+      &json!(INDEX),
+      "_index should be the resolved target, not the alias; got: {hit}"
+    );
+  }
+}
+
+#[test]
+fn mget_via_alias_returns_target_index_in_each_doc_index_field() {
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post("/demo_alias/_mget", &json!({ "ids": ["a"] }))
+    .expect("mget");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let docs = body.get("docs").unwrap().as_array().unwrap();
+  for doc in docs {
+    assert_eq!(
+      doc.get("_index").unwrap(),
+      &json!(INDEX),
+      "_index should be the target, not the alias; got: {doc}"
+    );
+  }
+}
+
+#[test]
+fn mget_global_with_alias_in_doc_index_returns_target_in_response() {
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      "/_mget",
+      &json!({
+        "docs": [{ "_index": "demo_alias", "_id": "a" }]
+      }),
+    )
+    .expect("mget global");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let docs = body.get("docs").unwrap().as_array().unwrap();
+  assert_eq!(docs.len(), 1);
+  assert_eq!(
+    docs[0].get("_index").unwrap(),
+    &json!(INDEX),
+    "_index should be the target, not the alias; got: {body}"
+  );
+}
+
+#[test]
+fn msearch_via_alias_path_returns_target_in_each_response_hit_index() {
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let ndjson = format!(
+    "{}\n{}\n",
+    json!({ "index": "demo_alias" }),
+    json!({ "query": { "match_all": {} }, "size": 2 }),
+  );
+  let (status, body) = h.es_post_ndjson("/_msearch", &ndjson).expect("msearch");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let hits = body
+    .pointer("/responses/0/hits/hits")
+    .unwrap()
+    .as_array()
+    .unwrap();
+  assert!(!hits.is_empty(), "expected hits; got: {body}");
+  for hit in hits {
+    assert_eq!(
+      hit.get("_index").unwrap(),
+      &json!(INDEX),
+      "_index should be the target, not the alias; got: {hit}"
+    );
+  }
+}
+
+#[test]
 fn mapping_for_alias_returns_target_index_mapping() {
   // Regression: get_mapping passed the raw path token to upstream `inspect`.
   // Calling with an alias name returned 404 even though HEAD /<alias> and

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -25,6 +25,13 @@ struct ElasticHarness {
 
 impl ElasticHarness {
   fn new() -> Result<Self> {
+    Self::with_config(&[], &[])
+  }
+
+  /// Boot the harness with the default `demo` index plus extra index mounts
+  /// and aliases. Used by tests that need to exercise alias resolution or
+  /// multi-index endpoints.
+  fn with_config(extra_indexes: &[&str], aliases: &[(&str, &str)]) -> Result<Self> {
     let upstream_bin = common::searchlite_bin();
     let adapter_bin = elastic_bin();
     let index_dir = tempfile::tempdir().context("creating temp index dir")?;
@@ -44,16 +51,29 @@ impl ElasticHarness {
     let adapter_log_file = std::fs::File::create(&adapter_log)
       .with_context(|| format!("creating log {}", adapter_log.display()))?;
 
-    let mut upstream = Command::new(&upstream_bin)
-      .arg("http")
+    let mut spawn = Command::new(&upstream_bin);
+    spawn.arg("http");
+    spawn
       .arg("--index")
-      .arg(format!("{INDEX}:{}", index_path.display()))
+      .arg(format!("{INDEX}:{}", index_path.display()));
+    for extra in extra_indexes {
+      spawn.arg("--index").arg(format!(
+        "{extra}:{}",
+        index_dir.path().join(extra).display()
+      ));
+    }
+    for (alias, target) in aliases {
+      spawn.arg("--alias").arg(format!("{alias}:{target}"));
+    }
+    spawn
       .arg("--bind")
       .arg(&upstream_bind)
       .arg("--shutdown-grace-secs")
       .arg("0")
       .stdout(Stdio::null())
-      .stderr(Stdio::from(upstream_log_file))
+      .stderr(Stdio::from(upstream_log_file));
+
+    let mut upstream = spawn
       .spawn()
       .with_context(|| format!("spawning upstream via {}", upstream_bin.display()))?;
 
@@ -100,12 +120,16 @@ impl ElasticHarness {
   }
 
   fn init_index(&self, schema: &Value) -> Result<()> {
-    let url = format!("{}/indexes/{INDEX}/init", self.upstream_base);
+    self.init_named(INDEX, schema)
+  }
+
+  fn init_named(&self, name: &str, schema: &Value) -> Result<()> {
+    let url = format!("{}/indexes/{name}/init", self.upstream_base);
     let resp = self.client.post(url).json(schema).send()?;
     let status = resp.status();
     let text = resp.text()?;
     if !status.is_success() {
-      return Err(anyhow!("init failed {status}: {text}"));
+      return Err(anyhow!("init {name} failed {status}: {text}"));
     }
     Ok(())
   }
@@ -508,6 +532,47 @@ fn cross_index_search_path_is_rejected() {
 }
 
 #[test]
+fn mapping_all_returns_every_mounted_index() {
+  // Smoke test for the all-index mapping endpoint after parallelizing the
+  // per-index inspect calls. Verifies cardinality and key-naming for two
+  // mounted indexes.
+  let h = ElasticHarness::with_config(&["secondary"], &[]).expect("harness");
+  let schema = json!({
+    "type": "object",
+    "searchlite:docIdField": "_id",
+    "properties": { "title": { "type": "string" } }
+  });
+  h.init_named(INDEX, &schema).expect("init demo");
+  h.init_named("secondary", &schema).expect("init secondary");
+  let (status, body) = h.es_get("/_mapping").expect("get all mappings");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let map = body.as_object().expect("object body");
+  assert!(map.contains_key(INDEX), "missing demo: {body}");
+  assert!(map.contains_key("secondary"), "missing secondary: {body}");
+  assert_eq!(map.len(), 2, "expected exactly two index entries: {body}");
+}
+
+#[test]
+fn settings_for_alias_returns_target_index_payload() {
+  // Regression: get_settings used to fabricate a settings payload keyed by
+  // the request path token, even when that token was an alias name.
+  // Per ES, alias requests should resolve to the concrete target index and
+  // key the response by the target — not the alias.
+  let h = ElasticHarness::with_config(&[], &[("demo_alias", INDEX)]).expect("harness with alias");
+  seed_index(&h).expect("seed");
+  let (status, body) = h.es_get("/demo_alias/_settings").expect("get settings");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  assert!(
+    body.get(INDEX).is_some(),
+    "settings should be keyed by the target index `{INDEX}`, got: {body}"
+  );
+  assert!(
+    body.get("demo_alias").is_none(),
+    "settings must not be keyed by the alias name; got: {body}"
+  );
+}
+
+#[test]
 fn settings_on_unknown_index_returns_404() {
   let h = ElasticHarness::new().expect("harness");
   let (status, body) = h.es_get("/no-such-index/_settings").expect("get");
@@ -601,6 +666,36 @@ fn global_mget_with_source_true_includes_source_field() {
     docs[0].get("_source").is_some(),
     "_source should be present when _source:true is requested"
   );
+}
+
+#[test]
+fn search_get_sort_param_with_spaces_after_commas_is_parsed_cleanly() {
+  // Regression: previously `?sort=foo:desc, _score` produced a field literally
+  // named " _score" (leading space) because tokens were not trimmed after the
+  // comma split. Both human-typed URLs and some SDKs emit spaces after commas.
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_get(&format!("/{INDEX}/_search?sort=price:desc, _score&size=3"))
+    .expect("get");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  // Top hit should be the most expensive doc per the price:desc sort ordering.
+  let first_id = body
+    .pointer("/hits/hits/0/_id")
+    .and_then(Value::as_str)
+    .unwrap_or("");
+  assert!(!first_id.is_empty(), "expected a top hit; got: {body}");
+}
+
+#[test]
+fn search_get_sort_param_with_space_after_colon_is_parsed_cleanly() {
+  // Both `field` and `order` should be trimmed.
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_get(&format!("/{INDEX}/_search?sort=price : desc&size=3"))
+    .expect("get");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
 }
 
 #[test]

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -521,6 +521,82 @@ fn settings_on_unknown_index_returns_404() {
 }
 
 #[test]
+fn global_mget_with_source_false_omits_source_field() {
+  // Regression: the global `_mget` handler always forwarded
+  // `return_stored: true` to upstream, ignoring `_source: false` on the
+  // request. The index-scoped handler honors it; this brings the global
+  // form into parity.
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      "/_mget",
+      &json!({
+        "_source": false,
+        "docs": [
+          { "_index": INDEX, "_id": "a" },
+          { "_index": INDEX, "_id": "c" },
+        ]
+      }),
+    )
+    .expect("mget");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let docs = body.get("docs").unwrap().as_array().unwrap();
+  assert_eq!(docs.len(), 2);
+  for doc in docs {
+    assert!(
+      doc.get("_source").is_none(),
+      "_source should be omitted when _source:false is requested; got {doc}"
+    );
+    assert_eq!(doc.get("found").unwrap(), &json!(true));
+  }
+}
+
+#[test]
+fn global_mget_with_source_true_includes_source_field() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      "/_mget",
+      &json!({
+        "_source": true,
+        "docs": [{ "_index": INDEX, "_id": "a" }]
+      }),
+    )
+    .expect("mget");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let docs = body.get("docs").unwrap().as_array().unwrap();
+  assert!(
+    docs[0].get("_source").is_some(),
+    "_source should be present when _source:true is requested"
+  );
+}
+
+#[test]
+fn search_get_with_integer_track_total_hits_query_param_is_accepted() {
+  // Regression: ES allows `?track_total_hits=10000` (integer cap). Previously
+  // the adapter typed the URL param as Option<bool> and rejected the integer
+  // form during query-string deserialization before the handler even ran.
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_get(&format!("/{INDEX}/_search?q=*&track_total_hits=10000"))
+    .expect("get");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+}
+
+#[test]
+fn search_get_with_boolean_track_total_hits_query_param_is_accepted() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, _) = h
+    .es_get(&format!("/{INDEX}/_search?q=*&track_total_hits=true"))
+    .expect("get");
+  assert_eq!(status, StatusCode::OK);
+}
+
+#[test]
 fn settings_on_known_index_returns_payload() {
   let h = ElasticHarness::new().expect("harness");
   seed_index(&h).expect("seed");

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -506,3 +506,54 @@ fn cross_index_search_path_is_rejected() {
     .expect("post");
   assert_eq!(status, StatusCode::BAD_REQUEST);
 }
+
+#[test]
+fn settings_on_unknown_index_returns_404() {
+  let h = ElasticHarness::new().expect("harness");
+  let (status, body) = h.es_get("/no-such-index/_settings").expect("get");
+  assert_eq!(status, StatusCode::NOT_FOUND);
+  let kind = body
+    .get("error")
+    .and_then(|e| e.get("type"))
+    .and_then(Value::as_str)
+    .unwrap_or("");
+  assert_eq!(kind, "index_not_found_exception");
+}
+
+#[test]
+fn settings_on_known_index_returns_payload() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_get(&format!("/{INDEX}/_settings"))
+    .expect("get settings");
+  assert_eq!(status, StatusCode::OK);
+  assert!(body.get(INDEX).is_some(), "expected `{INDEX}` key in body");
+}
+
+#[test]
+fn aliases_for_index_with_no_aliases_returns_empty_entry() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_get(&format!("/{INDEX}/_aliases"))
+    .expect("get aliases");
+  assert_eq!(status, StatusCode::OK);
+  // Existing index with no aliases configured → ES returns
+  // `{<index>: {aliases: {}}}`. Verifies the handler is path-scoped (would
+  // return all indexes if it weren't) and that empty-alias indexes don't 404.
+  assert_eq!(body, json!({ INDEX: { "aliases": {} } }), "got {body}",);
+}
+
+#[test]
+fn aliases_for_unknown_index_returns_404() {
+  let h = ElasticHarness::new().expect("harness");
+  let (status, body) = h.es_get("/no-such-index/_aliases").expect("get");
+  assert_eq!(status, StatusCode::NOT_FOUND);
+  let kind = body
+    .get("error")
+    .and_then(|e| e.get("type"))
+    .and_then(Value::as_str)
+    .unwrap_or("");
+  assert_eq!(kind, "index_not_found_exception");
+}

--- a/integration/tests/elastic_compat.rs
+++ b/integration/tests/elastic_compat.rs
@@ -1,0 +1,507 @@
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+mod common;
+
+const INDEX: &str = "demo";
+
+struct ElasticHarness {
+  upstream: Child,
+  adapter: Child,
+  upstream_base: String,
+  adapter_base: String,
+  client: reqwest::blocking::Client,
+  _index_dir: TempDir,
+  _upstream_log: PathBuf,
+  _adapter_log: PathBuf,
+}
+
+impl ElasticHarness {
+  fn new() -> Result<Self> {
+    let upstream_bin = common::searchlite_bin();
+    let adapter_bin = elastic_bin();
+    let index_dir = tempfile::tempdir().context("creating temp index dir")?;
+    let index_path = index_dir.path().join("index");
+
+    let upstream_port =
+      portpicker::pick_unused_port().ok_or_else(|| anyhow!("no free port for upstream"))?;
+    let adapter_port =
+      portpicker::pick_unused_port().ok_or_else(|| anyhow!("no free port for adapter"))?;
+    let upstream_bind = format!("127.0.0.1:{upstream_port}");
+    let adapter_bind = format!("127.0.0.1:{adapter_port}");
+
+    let upstream_log = index_path.with_extension("upstream.log");
+    let adapter_log = index_path.with_extension("adapter.log");
+    let upstream_log_file = std::fs::File::create(&upstream_log)
+      .with_context(|| format!("creating log {}", upstream_log.display()))?;
+    let adapter_log_file = std::fs::File::create(&adapter_log)
+      .with_context(|| format!("creating log {}", adapter_log.display()))?;
+
+    let mut upstream = Command::new(&upstream_bin)
+      .arg("http")
+      .arg("--index")
+      .arg(format!("{INDEX}:{}", index_path.display()))
+      .arg("--bind")
+      .arg(&upstream_bind)
+      .arg("--shutdown-grace-secs")
+      .arg("0")
+      .stdout(Stdio::null())
+      .stderr(Stdio::from(upstream_log_file))
+      .spawn()
+      .with_context(|| format!("spawning upstream via {}", upstream_bin.display()))?;
+
+    let client = reqwest::blocking::Client::builder()
+      .timeout(Duration::from_secs(10))
+      .build()
+      .context("building harness client")?;
+
+    let upstream_base = format!("http://{upstream_bind}");
+    if let Err(err) = wait_for_path(&client, &format!("{upstream_base}/healthz"), &mut upstream) {
+      let _ = upstream.kill();
+      return Err(err);
+    }
+
+    let mut adapter = Command::new(&adapter_bin)
+      .arg("--bind")
+      .arg(&adapter_bind)
+      .arg("--upstream-url")
+      .arg(&upstream_base)
+      .arg("--shutdown-grace-secs")
+      .arg("0")
+      .stdout(Stdio::null())
+      .stderr(Stdio::from(adapter_log_file))
+      .spawn()
+      .with_context(|| format!("spawning adapter via {}", adapter_bin.display()))?;
+
+    let adapter_base = format!("http://{adapter_bind}");
+    if let Err(err) = wait_for_path(&client, &format!("{adapter_base}/"), &mut adapter) {
+      let _ = upstream.kill();
+      let _ = adapter.kill();
+      return Err(err);
+    }
+
+    Ok(Self {
+      upstream,
+      adapter,
+      upstream_base,
+      adapter_base,
+      client,
+      _index_dir: index_dir,
+      _upstream_log: upstream_log,
+      _adapter_log: adapter_log,
+    })
+  }
+
+  fn init_index(&self, schema: &Value) -> Result<()> {
+    let url = format!("{}/indexes/{INDEX}/init", self.upstream_base);
+    let resp = self.client.post(url).json(schema).send()?;
+    let status = resp.status();
+    let text = resp.text()?;
+    if !status.is_success() {
+      return Err(anyhow!("init failed {status}: {text}"));
+    }
+    Ok(())
+  }
+
+  fn add_ndjson(&self, ndjson: &str) -> Result<()> {
+    let url = format!("{}/indexes/{INDEX}/add", self.upstream_base);
+    let resp = self
+      .client
+      .post(url)
+      .header("Content-Type", "application/x-ndjson")
+      .body(ndjson.to_string())
+      .send()?;
+    if !resp.status().is_success() {
+      return Err(anyhow!("add failed {}: {}", resp.status(), resp.text()?));
+    }
+    Ok(())
+  }
+
+  fn commit(&self) -> Result<()> {
+    let url = format!("{}/indexes/{INDEX}/commit", self.upstream_base);
+    let resp = self.client.post(url).send()?;
+    if !resp.status().is_success() {
+      return Err(anyhow!("commit failed {}: {}", resp.status(), resp.text()?));
+    }
+    Ok(())
+  }
+
+  fn refresh(&self) -> Result<()> {
+    let url = format!("{}/indexes/{INDEX}/refresh", self.upstream_base);
+    let resp = self.client.post(url).send()?;
+    if !resp.status().is_success() {
+      return Err(anyhow!("refresh failed {}: {}", resp.status(), resp.text()?));
+    }
+    Ok(())
+  }
+
+  fn es_get(&self, path: &str) -> Result<(StatusCode, Value)> {
+    let url = format!("{}{path}", self.adapter_base);
+    let resp = self.client.get(url).send()?;
+    let status = resp.status();
+    let body = resp.text()?;
+    let parsed = if body.is_empty() {
+      Value::Null
+    } else {
+      serde_json::from_str(&body).unwrap_or(Value::String(body))
+    };
+    Ok((status, parsed))
+  }
+
+  fn es_head(&self, path: &str) -> Result<StatusCode> {
+    let url = format!("{}{path}", self.adapter_base);
+    let resp = self.client.head(url).send()?;
+    Ok(resp.status())
+  }
+
+  fn es_post(&self, path: &str, body: &Value) -> Result<(StatusCode, Value)> {
+    let url = format!("{}{path}", self.adapter_base);
+    let resp = self.client.post(url).json(body).send()?;
+    let status = resp.status();
+    let text = resp.text()?;
+    let parsed = if text.is_empty() {
+      Value::Null
+    } else {
+      serde_json::from_str(&text).unwrap_or(Value::String(text))
+    };
+    Ok((status, parsed))
+  }
+
+  fn es_post_ndjson(&self, path: &str, body: &str) -> Result<(StatusCode, Value)> {
+    let url = format!("{}{path}", self.adapter_base);
+    let resp = self
+      .client
+      .post(url)
+      .header("Content-Type", "application/x-ndjson")
+      .body(body.to_string())
+      .send()?;
+    let status = resp.status();
+    let text = resp.text()?;
+    let parsed = if text.is_empty() {
+      Value::Null
+    } else {
+      serde_json::from_str(&text).unwrap_or(Value::String(text))
+    };
+    Ok((status, parsed))
+  }
+
+  fn es_put(&self, path: &str) -> Result<StatusCode> {
+    let url = format!("{}{path}", self.adapter_base);
+    let resp = self.client.put(url).send()?;
+    Ok(resp.status())
+  }
+}
+
+impl Drop for ElasticHarness {
+  fn drop(&mut self) {
+    let _ = self.adapter.kill();
+    let _ = self.upstream.kill();
+    let _ = self.adapter.wait();
+    let _ = self.upstream.wait();
+  }
+}
+
+fn wait_for_path(
+  client: &reqwest::blocking::Client,
+  url: &str,
+  child: &mut Child,
+) -> Result<()> {
+  for _ in 0..200 {
+    if let Some(status) = child.try_wait()? {
+      return Err(anyhow!("process exited early with status {status}"));
+    }
+    if let Ok(resp) = client.get(url).send() {
+      if resp.status().is_success() {
+        return Ok(());
+      }
+    }
+    thread::sleep(Duration::from_millis(50));
+  }
+  Err(anyhow!("process did not become healthy at {url}"))
+}
+
+fn elastic_bin() -> PathBuf {
+  if let Ok(path) = std::env::var("CARGO_BIN_EXE_searchlite-elastic") {
+    return PathBuf::from(path);
+  }
+  let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .parent()
+    .expect("workspace root")
+    .to_path_buf();
+  let candidate = workspace_root
+    .join("target")
+    .join("debug")
+    .join(if cfg!(windows) {
+      "searchlite-elastic.exe"
+    } else {
+      "searchlite-elastic"
+    });
+  if candidate.exists() {
+    return candidate;
+  }
+  let status = Command::new("cargo")
+    .arg("build")
+    .arg("-p")
+    .arg("searchlite-adapter-elastic")
+    .arg("--bin")
+    .arg("searchlite-elastic")
+    .current_dir(&workspace_root)
+    .status()
+    .expect("build searchlite-elastic binary");
+  assert!(status.success(), "building searchlite-elastic failed");
+  workspace_root
+    .join("target")
+    .join("debug")
+    .join(if cfg!(windows) {
+      "searchlite-elastic.exe"
+    } else {
+      "searchlite-elastic"
+    })
+}
+
+fn seed_index(h: &ElasticHarness) -> Result<()> {
+  let schema = json!({
+    "type": "object",
+    "searchlite:docIdField": "_id",
+    "properties": {
+      "title": { "type": "string" },
+      "category": { "type": "string", "searchlite:kind": "keyword" },
+      "price": { "type": "integer" },
+    }
+  });
+  h.init_index(&schema)?;
+  let ndjson = "\
+    {\"_id\":\"a\",\"title\":\"rust safety\",\"category\":\"books\",\"price\":20}\n\
+    {\"_id\":\"b\",\"title\":\"go concurrency\",\"category\":\"books\",\"price\":15}\n\
+    {\"_id\":\"c\",\"title\":\"music history\",\"category\":\"music\",\"price\":40}\n";
+  h.add_ndjson(ndjson)?;
+  h.commit()?;
+  h.refresh()?;
+  Ok(())
+}
+
+#[test]
+fn root_returns_es_version_banner() {
+  let h = ElasticHarness::new().expect("harness");
+  let (status, body) = h.es_get("/").expect("get /");
+  assert_eq!(status, StatusCode::OK);
+  let version = body.get("version").expect("version key");
+  assert!(version.get("number").is_some(), "missing version.number");
+  assert_eq!(body.get("tagline").unwrap(), &json!("You Know, for Search"));
+}
+
+#[test]
+fn cluster_health_returns_green() {
+  let h = ElasticHarness::new().expect("harness");
+  let (status, body) = h.es_get("/_cluster/health").expect("get health");
+  assert_eq!(status, StatusCode::OK);
+  assert_eq!(body.get("status").unwrap(), &json!("green"));
+}
+
+#[test]
+fn head_index_finds_known_index() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let status = h.es_head(&format!("/{INDEX}")).expect("head");
+  assert_eq!(status, StatusCode::OK);
+}
+
+#[test]
+fn head_index_missing_returns_404() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let status = h.es_head("/nope").expect("head");
+  assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+#[test]
+fn get_mapping_returns_es_shape() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_get(&format!("/{INDEX}/_mapping"))
+    .expect("get mapping");
+  assert_eq!(status, StatusCode::OK);
+  let mappings = body.get(INDEX).unwrap().get("mappings").unwrap();
+  let props = mappings.get("properties").unwrap();
+  assert_eq!(props.get("title").unwrap().get("type").unwrap(), &json!("text"));
+  assert_eq!(
+    props.get("category").unwrap().get("type").unwrap(),
+    &json!("keyword")
+  );
+  assert_eq!(props.get("price").unwrap().get("type").unwrap(), &json!("long"));
+}
+
+#[test]
+fn search_match_all_returns_seeded_docs() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      &format!("/{INDEX}/_search"),
+      &json!({ "query": { "match_all": {} }, "size": 10 }),
+    )
+    .expect("search");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let total = body
+    .get("hits")
+    .unwrap()
+    .get("total")
+    .unwrap()
+    .get("value")
+    .unwrap()
+    .as_u64()
+    .unwrap();
+  assert_eq!(total, 3);
+  let hits = body
+    .get("hits")
+    .unwrap()
+    .get("hits")
+    .unwrap()
+    .as_array()
+    .unwrap();
+  assert_eq!(hits.len(), 3);
+  for hit in hits {
+    assert_eq!(hit.get("_index").unwrap(), &json!(INDEX));
+    assert!(hit.get("_id").is_some());
+    assert!(hit.get("_source").is_some());
+  }
+}
+
+#[test]
+fn search_term_query_filters() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      &format!("/{INDEX}/_search"),
+      &json!({ "query": { "term": { "category": "music" } }, "size": 10 }),
+    )
+    .expect("search");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let hits = body
+    .get("hits")
+    .unwrap()
+    .get("hits")
+    .unwrap()
+    .as_array()
+    .unwrap();
+  assert_eq!(hits.len(), 1);
+  assert_eq!(hits[0].get("_id").unwrap(), &json!("c"));
+}
+
+#[test]
+fn count_returns_total() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      &format!("/{INDEX}/_count"),
+      &json!({ "query": { "match_all": {} } }),
+    )
+    .expect("count");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  assert_eq!(body.get("count").unwrap().as_u64().unwrap(), 3);
+}
+
+#[test]
+fn mget_by_ids() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      &format!("/{INDEX}/_mget"),
+      &json!({ "ids": ["a", "c"] }),
+    )
+    .expect("mget");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let docs = body.get("docs").unwrap().as_array().unwrap();
+  assert_eq!(docs.len(), 2);
+  let a = docs.iter().find(|d| d.get("_id") == Some(&json!("a"))).unwrap();
+  assert_eq!(a.get("found").unwrap(), &json!(true));
+  assert_eq!(a.get("_index").unwrap(), &json!(INDEX));
+}
+
+#[test]
+fn msearch_runs_two_searches() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let ndjson = format!(
+    "{}\n{}\n{}\n{}\n",
+    json!({"index": INDEX}),
+    json!({"query": {"match_all": {}}}),
+    json!({"index": INDEX}),
+    json!({"query": {"term": {"category": "music"}}}),
+  );
+  let (status, body) = h
+    .es_post_ndjson("/_msearch", &ndjson)
+    .expect("msearch");
+  assert_eq!(status, StatusCode::OK, "body: {body}");
+  let responses = body.get("responses").unwrap().as_array().unwrap();
+  assert_eq!(responses.len(), 2);
+  let total_first = responses[0]
+    .get("hits")
+    .unwrap()
+    .get("total")
+    .unwrap()
+    .get("value")
+    .unwrap()
+    .as_u64()
+    .unwrap();
+  assert_eq!(total_first, 3);
+  let total_second = responses[1]
+    .get("hits")
+    .unwrap()
+    .get("total")
+    .unwrap()
+    .get("value")
+    .unwrap()
+    .as_u64()
+    .unwrap();
+  assert_eq!(total_second, 1);
+}
+
+#[test]
+fn put_index_is_rejected_with_400() {
+  let h = ElasticHarness::new().expect("harness");
+  let status = h.es_put("/some-index").expect("put");
+  assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn unsupported_geo_query_is_rejected() {
+  let h = ElasticHarness::new().expect("harness");
+  seed_index(&h).expect("seed");
+  let (status, body) = h
+    .es_post(
+      &format!("/{INDEX}/_search"),
+      &json!({ "query": { "geo_distance": { "distance": "5km", "loc": "0,0" } } }),
+    )
+    .expect("search");
+  assert_eq!(status, StatusCode::BAD_REQUEST);
+  let kind = body
+    .get("error")
+    .and_then(|e| e.get("type"))
+    .and_then(Value::as_str)
+    .unwrap_or("");
+  assert!(kind.contains("parse"), "got error kind {kind}");
+}
+
+#[test]
+fn cross_index_search_path_is_rejected() {
+  let h = ElasticHarness::new().expect("harness");
+  let (status, _) = h
+    .es_post(
+      "/_search",
+      &json!({ "query": { "match_all": {} } }),
+    )
+    .expect("post");
+  assert_eq!(status, StatusCode::BAD_REQUEST);
+}

--- a/integration/tests/elastic_parity.rs
+++ b/integration/tests/elastic_parity.rs
@@ -39,9 +39,7 @@ fn skip_unless_docker(test_name: &str) -> Option<()> {
   if docker_available() {
     return Some(());
   }
-  eprintln!(
-    "[skip] {test_name}: docker is not available — start Docker to run this test"
-  );
+  eprintln!("[skip] {test_name}: docker is not available — start Docker to run this test");
   None
 }
 
@@ -465,7 +463,9 @@ fn ingest_into_es(client: &reqwest::blocking::Client, base: &str, docs: &[Value]
     let id = doc.get("_id").and_then(Value::as_str).unwrap();
     let mut body = doc.clone();
     body.as_object_mut().unwrap().remove("_id");
-    bulk.push_str(&format!(r#"{{"index":{{"_index":"{INDEX}","_id":"{id}"}}}}"#));
+    bulk.push_str(&format!(
+      r#"{{"index":{{"_index":"{INDEX}","_id":"{id}"}}}}"#
+    ));
     bulk.push('\n');
     bulk.push_str(&serde_json::to_string(&body)?);
     bulk.push('\n');
@@ -482,9 +482,7 @@ fn ingest_into_es(client: &reqwest::blocking::Client, base: &str, docs: &[Value]
   if body.get("errors").and_then(Value::as_bool).unwrap_or(false) {
     bail!("ES bulk reported errors: {body}");
   }
-  let resp = client
-    .post(format!("{base}/{INDEX}/_refresh"))
-    .send()?;
+  let resp = client.post(format!("{base}/{INDEX}/_refresh")).send()?;
   if !resp.status().is_success() {
     bail!("ES refresh failed: {} {}", resp.status(), resp.text()?);
   }
@@ -501,11 +499,7 @@ fn ingest_into_searchlite(
     .json(&searchlite_schema())
     .send()?;
   if !resp.status().is_success() {
-    bail!(
-      "searchlite init failed: {} {}",
-      resp.status(),
-      resp.text()?
-    );
+    bail!("searchlite init failed: {} {}", resp.status(), resp.text()?);
   }
   let mut ndjson = String::new();
   for doc in docs {
@@ -518,11 +512,7 @@ fn ingest_into_searchlite(
     .body(ndjson)
     .send()?;
   if !resp.status().is_success() {
-    bail!(
-      "searchlite add failed: {} {}",
-      resp.status(),
-      resp.text()?
-    );
+    bail!("searchlite add failed: {} {}", resp.status(), resp.text()?);
   }
   let resp = client
     .post(format!("{base}/indexes/{INDEX}/commit"))
@@ -981,7 +971,9 @@ fn evaluate(parity: &Parity, es: &Value, adapter: &Value) -> Vec<String> {
       a.sort();
       b.sort();
       if a != b {
-        vec![format!("hit id sets differ:\n    es      = {a:?}\n    adapter = {b:?}")]
+        vec![format!(
+          "hit id sets differ:\n    es      = {a:?}\n    adapter = {b:?}"
+        )]
       } else {
         vec![]
       }
@@ -1104,7 +1096,11 @@ fn total(response: &Value) -> u64 {
   response
     .get("count")
     .and_then(Value::as_u64)
-    .or_else(|| response.pointer("/hits/total/value").and_then(Value::as_u64))
+    .or_else(|| {
+      response
+        .pointer("/hits/total/value")
+        .and_then(Value::as_u64)
+    })
     .unwrap_or(0)
 }
 

--- a/integration/tests/elastic_parity.rs
+++ b/integration/tests/elastic_parity.rs
@@ -54,8 +54,17 @@ impl EsContainer {
   fn start() -> Result<Self> {
     pull_image(ES_IMAGE)?;
     let port = portpicker::pick_unused_port().ok_or_else(|| anyhow!("no free port for ES"))?;
-    // Container name needs to be unique per test process to avoid collisions.
-    let name = format!("searchlite-es-parity-{}", std::process::id());
+    // Container name needs to be unique per test process to avoid
+    // collisions. PID alone isn't enough — `cargo test` reuses PIDs across
+    // runs, and on CI a stale container with the same PID-derived name from
+    // a previous job could exist. Append nanosecond-precision time so two
+    // concurrent test processes (or a fresh run racing a slow `docker rm`)
+    // get distinct names.
+    let nanos = std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .map(|d| d.subsec_nanos())
+      .unwrap_or(0);
+    let name = format!("searchlite-es-parity-{}-{}", std::process::id(), nanos);
     // Best-effort cleanup if a previous run left a stale container around.
     let _ = Command::new("docker")
       .args(["rm", "-f", &name])

--- a/integration/tests/elastic_parity.rs
+++ b/integration/tests/elastic_parity.rs
@@ -1,0 +1,1274 @@
+//! Parity test: load identical corpora into a real Elasticsearch 9 container
+//! and into a searchlite-elastic adapter pointed at a searchlite-http upstream,
+//! then run the same queries against both and assert their semantically-relevant
+//! responses match.
+//!
+//! Auto-skips when Docker is unavailable. CI runs Docker on ubuntu-latest by
+//! default, so this test runs there without extra setup.
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, bail, Context, Result};
+use reqwest::StatusCode;
+use serde_json::{json, Value};
+use tempfile::TempDir;
+
+mod common;
+
+const ES_IMAGE: &str = "docker.elastic.co/elasticsearch/elasticsearch:9.0.0";
+const INDEX: &str = "parity";
+const ES_BOOT_TIMEOUT: Duration = Duration::from_secs(180);
+const SL_BOOT_TIMEOUT: Duration = Duration::from_secs(15);
+
+// ── Docker availability gate ─────────────────────────────────────────────────
+
+fn docker_available() -> bool {
+  Command::new("docker")
+    .arg("info")
+    .stdout(Stdio::null())
+    .stderr(Stdio::null())
+    .status()
+    .map(|s| s.success())
+    .unwrap_or(false)
+}
+
+fn skip_unless_docker(test_name: &str) -> Option<()> {
+  if docker_available() {
+    return Some(());
+  }
+  eprintln!(
+    "[skip] {test_name}: docker is not available — start Docker to run this test"
+  );
+  None
+}
+
+// ── Real Elasticsearch container ─────────────────────────────────────────────
+
+struct EsContainer {
+  name: String,
+  base_url: String,
+}
+
+impl EsContainer {
+  fn start() -> Result<Self> {
+    pull_image(ES_IMAGE)?;
+    let port = portpicker::pick_unused_port().ok_or_else(|| anyhow!("no free port for ES"))?;
+    // Container name needs to be unique per test process to avoid collisions.
+    let name = format!("searchlite-es-parity-{}", std::process::id());
+    // Best-effort cleanup if a previous run left a stale container around.
+    let _ = Command::new("docker")
+      .args(["rm", "-f", &name])
+      .stdout(Stdio::null())
+      .stderr(Stdio::null())
+      .status();
+
+    let status = Command::new("docker")
+      .args([
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        &name,
+        "-p",
+        &format!("{port}:9200"),
+        "-e",
+        "discovery.type=single-node",
+        "-e",
+        "xpack.security.enabled=false",
+        "-e",
+        "xpack.security.http.ssl.enabled=false",
+        "-e",
+        "ES_JAVA_OPTS=-Xms512m -Xmx512m",
+        ES_IMAGE,
+      ])
+      .stdout(Stdio::null())
+      .stderr(Stdio::piped())
+      .output()
+      .context("running `docker run` for ES")?;
+    if !status.status.success() {
+      bail!(
+        "docker run failed: {}",
+        String::from_utf8_lossy(&status.stderr)
+      );
+    }
+
+    let base_url = format!("http://127.0.0.1:{port}");
+    let client = blocking_client();
+    let started = Instant::now();
+    loop {
+      match client.get(format!("{base_url}/_cluster/health")).send() {
+        Ok(resp) if resp.status().is_success() => {
+          if let Ok(body) = resp.json::<Value>() {
+            let status = body.get("status").and_then(Value::as_str).unwrap_or("");
+            if status == "yellow" || status == "green" {
+              return Ok(Self { name, base_url });
+            }
+          }
+        }
+        _ => {}
+      }
+      if started.elapsed() > ES_BOOT_TIMEOUT {
+        // Capture container logs for diagnostics before dropping.
+        let logs = Command::new("docker")
+          .args(["logs", "--tail", "80", &name])
+          .output()
+          .map(|o| {
+            format!(
+              "stdout: {}\nstderr: {}",
+              String::from_utf8_lossy(&o.stdout),
+              String::from_utf8_lossy(&o.stderr)
+            )
+          })
+          .unwrap_or_else(|err| format!("could not read logs: {err}"));
+        let _ = Command::new("docker")
+          .args(["rm", "-f", &name])
+          .stdout(Stdio::null())
+          .stderr(Stdio::null())
+          .status();
+        bail!(
+          "elasticsearch did not become healthy within {:?}\n{logs}",
+          ES_BOOT_TIMEOUT
+        );
+      }
+      thread::sleep(Duration::from_millis(500));
+    }
+  }
+}
+
+impl Drop for EsContainer {
+  fn drop(&mut self) {
+    let _ = Command::new("docker")
+      .args(["rm", "-f", &self.name])
+      .stdout(Stdio::null())
+      .stderr(Stdio::null())
+      .status();
+  }
+}
+
+fn pull_image(image: &str) -> Result<()> {
+  let output = Command::new("docker")
+    .args(["pull", image])
+    .stdout(Stdio::piped())
+    .stderr(Stdio::piped())
+    .output()
+    .context("invoking `docker pull`")?;
+  if !output.status.success() {
+    bail!(
+      "docker pull {image} failed: {}",
+      String::from_utf8_lossy(&output.stderr)
+    );
+  }
+  Ok(())
+}
+
+fn blocking_client() -> reqwest::blocking::Client {
+  reqwest::blocking::Client::builder()
+    .timeout(Duration::from_secs(15))
+    .build()
+    .expect("build reqwest client")
+}
+
+// ── searchlite + adapter pair ────────────────────────────────────────────────
+
+struct AdapterStack {
+  upstream: Child,
+  adapter: Child,
+  upstream_base: String,
+  adapter_base: String,
+  _index_dir: TempDir,
+  _logs: (PathBuf, PathBuf),
+}
+
+impl AdapterStack {
+  fn start() -> Result<Self> {
+    let upstream_bin = common::searchlite_bin();
+    let adapter_bin = elastic_bin();
+    let index_dir = tempfile::tempdir().context("create temp index dir")?;
+    let index_path = index_dir.path().join("index");
+
+    let upstream_port =
+      portpicker::pick_unused_port().ok_or_else(|| anyhow!("no port for upstream"))?;
+    let adapter_port =
+      portpicker::pick_unused_port().ok_or_else(|| anyhow!("no port for adapter"))?;
+    let upstream_bind = format!("127.0.0.1:{upstream_port}");
+    let adapter_bind = format!("127.0.0.1:{adapter_port}");
+
+    let upstream_log = index_path.with_extension("upstream.log");
+    let adapter_log = index_path.with_extension("adapter.log");
+    let upstream_log_file = std::fs::File::create(&upstream_log)?;
+    let adapter_log_file = std::fs::File::create(&adapter_log)?;
+
+    let mut upstream = Command::new(&upstream_bin)
+      .arg("http")
+      .arg("--index")
+      .arg(format!("{INDEX}:{}", index_path.display()))
+      .arg("--bind")
+      .arg(&upstream_bind)
+      .arg("--shutdown-grace-secs")
+      .arg("0")
+      .stdout(Stdio::null())
+      .stderr(Stdio::from(upstream_log_file))
+      .spawn()
+      .with_context(|| format!("spawn upstream {}", upstream_bin.display()))?;
+
+    let client = blocking_client();
+    let upstream_base = format!("http://{upstream_bind}");
+    if let Err(err) = wait_for_path(
+      &client,
+      &format!("{upstream_base}/healthz"),
+      &mut upstream,
+      SL_BOOT_TIMEOUT,
+    ) {
+      let _ = upstream.kill();
+      return Err(err);
+    }
+
+    let mut adapter = Command::new(&adapter_bin)
+      .arg("--bind")
+      .arg(&adapter_bind)
+      .arg("--upstream-url")
+      .arg(&upstream_base)
+      .arg("--shutdown-grace-secs")
+      .arg("0")
+      .stdout(Stdio::null())
+      .stderr(Stdio::from(adapter_log_file))
+      .spawn()
+      .with_context(|| format!("spawn adapter {}", adapter_bin.display()))?;
+
+    let adapter_base = format!("http://{adapter_bind}");
+    if let Err(err) = wait_for_path(
+      &client,
+      &format!("{adapter_base}/"),
+      &mut adapter,
+      SL_BOOT_TIMEOUT,
+    ) {
+      let _ = upstream.kill();
+      let _ = adapter.kill();
+      return Err(err);
+    }
+
+    Ok(Self {
+      upstream,
+      adapter,
+      upstream_base,
+      adapter_base,
+      _index_dir: index_dir,
+      _logs: (upstream_log, adapter_log),
+    })
+  }
+}
+
+impl Drop for AdapterStack {
+  fn drop(&mut self) {
+    let _ = self.adapter.kill();
+    let _ = self.upstream.kill();
+    let _ = self.adapter.wait();
+    let _ = self.upstream.wait();
+  }
+}
+
+fn wait_for_path(
+  client: &reqwest::blocking::Client,
+  url: &str,
+  child: &mut Child,
+  timeout: Duration,
+) -> Result<()> {
+  let start = Instant::now();
+  while start.elapsed() < timeout {
+    if let Some(status) = child.try_wait()? {
+      bail!("process exited early with status {status}");
+    }
+    if let Ok(resp) = client.get(url).send() {
+      if resp.status().is_success() {
+        return Ok(());
+      }
+    }
+    thread::sleep(Duration::from_millis(50));
+  }
+  bail!("process did not become healthy at {url}");
+}
+
+fn elastic_bin() -> PathBuf {
+  if let Ok(path) = std::env::var("CARGO_BIN_EXE_searchlite-elastic") {
+    return PathBuf::from(path);
+  }
+  let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    .parent()
+    .expect("workspace root")
+    .to_path_buf();
+  let candidate = workspace_root
+    .join("target")
+    .join("debug")
+    .join(if cfg!(windows) {
+      "searchlite-elastic.exe"
+    } else {
+      "searchlite-elastic"
+    });
+  if candidate.exists() {
+    return candidate;
+  }
+  let status = Command::new("cargo")
+    .arg("build")
+    .arg("-p")
+    .arg("searchlite-adapter-elastic")
+    .arg("--bin")
+    .arg("searchlite-elastic")
+    .current_dir(&workspace_root)
+    .status()
+    .expect("build searchlite-elastic");
+  assert!(status.success(), "building searchlite-elastic failed");
+  workspace_root
+    .join("target")
+    .join("debug")
+    .join(if cfg!(windows) {
+      "searchlite-elastic.exe"
+    } else {
+      "searchlite-elastic"
+    })
+}
+
+// ── Corpus + schemas ─────────────────────────────────────────────────────────
+
+fn corpus() -> Vec<Value> {
+  // Each doc has a `description` field of long-form text so we can exercise
+  // multi-field matching, longer-document relevance, stopword behaviour and
+  // plural/singular tokenization probes alongside the short-title cases.
+  vec![
+    json!({
+      "_id": "1",
+      "title": "rust safety guide",
+      "description": "A practical introduction to writing memory-safe code in rust. Covers ownership, borrowing, and common pitfalls for systems programmers learning the language for the first time.",
+      "category": "books",
+      "price": 25,
+      "rating": 4.5
+    }),
+    json!({
+      "_id": "2",
+      "title": "go concurrency patterns",
+      "description": "Patterns for managing goroutines, channels, and synchronization in modern services. The book covers worker pools, fan-in pipelines, and graceful shutdown of long-running daemons.",
+      "category": "books",
+      "price": 30,
+      "rating": 4.2
+    }),
+    json!({
+      "_id": "3",
+      "title": "music history vol 1",
+      "description": "From the early classical period through the baroque and into the romantic era of European music. Composer biographies and notation samples included.",
+      "category": "music",
+      "price": 15,
+      "rating": 3.8
+    }),
+    json!({
+      "_id": "4",
+      "title": "music history vol 2",
+      "description": "Modern jazz, rock, and electronic music traditions of the twentieth century. Discusses the rise of recording technology and its influence on composition.",
+      "category": "music",
+      "price": 18,
+      "rating": 4.0
+    }),
+    json!({
+      "_id": "5",
+      "title": "kitchen essentials",
+      "description": "Knives, pans, and cutting boards every home cook needs in the kitchen. Reviews of starter kits and care instructions to keep the gear sharp.",
+      "category": "kitchen",
+      "price": 50,
+      "rating": 4.7
+    }),
+    json!({
+      "_id": "6",
+      "title": "kitchen tools advanced",
+      "description": "Specialized tools for advanced cooking techniques such as sous vide, smoking, and fermentation. Recommended brands and storage tips for a working kitchen.",
+      "category": "kitchen",
+      "price": 75,
+      "rating": 4.3
+    }),
+    json!({
+      "_id": "7",
+      "title": "rust web frameworks",
+      "description": "Building production web services with axum, actix, and rocket. Performance comparisons, deployment guidance, and migration paths for systems written in other languages.",
+      "category": "books",
+      "price": 35,
+      "rating": 4.6
+    }),
+    json!({
+      "_id": "8",
+      "title": "guitar basics",
+      "description": "Learn to play guitar from scratch. Chords, strumming patterns, and your first songs. No prior music theory required.",
+      "category": "music",
+      "price": 22,
+      "rating": 4.1
+    }),
+    json!({
+      "_id": "9",
+      "title": "advanced cooking",
+      "description": "Sauces, stocks, and braising. Techniques borrowed from professional kitchens, presented for the home cook willing to spend an afternoon with a good book.",
+      "category": "kitchen",
+      "price": 65,
+      "rating": 4.8
+    }),
+    json!({
+      "_id": "10",
+      "title": "rust async deep dive",
+      "description": "Tokio, futures, and the async runtime model. For experienced rust developers ready to reason about cancellation, structured concurrency, and performance.",
+      "category": "books",
+      "price": 40,
+      "rating": 4.9
+    }),
+  ]
+}
+
+fn es_mapping() -> Value {
+  json!({
+    "settings": { "number_of_shards": 1, "number_of_replicas": 0 },
+    "mappings": {
+      "properties": {
+        "title": { "type": "text" },
+        "description": { "type": "text" },
+        "category": { "type": "keyword" },
+        "price": { "type": "long" },
+        "rating": { "type": "double" }
+      }
+    }
+  })
+}
+
+fn searchlite_schema() -> Value {
+  json!({
+    "type": "object",
+    "searchlite:docIdField": "_id",
+    "properties": {
+      "title": { "type": "string" },
+      "description": { "type": "string" },
+      "category": { "type": "string", "searchlite:kind": "keyword" },
+      "price": { "type": "integer" },
+      "rating": { "type": "number" }
+    }
+  })
+}
+
+// ── Ingest helpers ───────────────────────────────────────────────────────────
+
+fn ingest_into_es(client: &reqwest::blocking::Client, base: &str, docs: &[Value]) -> Result<()> {
+  let resp = client
+    .put(format!("{base}/{INDEX}"))
+    .json(&es_mapping())
+    .send()?;
+  if !resp.status().is_success() {
+    bail!("ES create index failed: {} {}", resp.status(), resp.text()?);
+  }
+
+  let mut bulk = String::new();
+  for doc in docs {
+    let id = doc.get("_id").and_then(Value::as_str).unwrap();
+    let mut body = doc.clone();
+    body.as_object_mut().unwrap().remove("_id");
+    bulk.push_str(&format!(r#"{{"index":{{"_index":"{INDEX}","_id":"{id}"}}}}"#));
+    bulk.push('\n');
+    bulk.push_str(&serde_json::to_string(&body)?);
+    bulk.push('\n');
+  }
+  let resp = client
+    .post(format!("{base}/_bulk"))
+    .header("Content-Type", "application/x-ndjson")
+    .body(bulk)
+    .send()?;
+  if !resp.status().is_success() {
+    bail!("ES bulk failed: {} {}", resp.status(), resp.text()?);
+  }
+  let body: Value = resp.json()?;
+  if body.get("errors").and_then(Value::as_bool).unwrap_or(false) {
+    bail!("ES bulk reported errors: {body}");
+  }
+  let resp = client
+    .post(format!("{base}/{INDEX}/_refresh"))
+    .send()?;
+  if !resp.status().is_success() {
+    bail!("ES refresh failed: {} {}", resp.status(), resp.text()?);
+  }
+  Ok(())
+}
+
+fn ingest_into_searchlite(
+  client: &reqwest::blocking::Client,
+  base: &str,
+  docs: &[Value],
+) -> Result<()> {
+  let resp = client
+    .post(format!("{base}/indexes/{INDEX}/init"))
+    .json(&searchlite_schema())
+    .send()?;
+  if !resp.status().is_success() {
+    bail!(
+      "searchlite init failed: {} {}",
+      resp.status(),
+      resp.text()?
+    );
+  }
+  let mut ndjson = String::new();
+  for doc in docs {
+    ndjson.push_str(&serde_json::to_string(doc)?);
+    ndjson.push('\n');
+  }
+  let resp = client
+    .post(format!("{base}/indexes/{INDEX}/add"))
+    .header("Content-Type", "application/x-ndjson")
+    .body(ndjson)
+    .send()?;
+  if !resp.status().is_success() {
+    bail!(
+      "searchlite add failed: {} {}",
+      resp.status(),
+      resp.text()?
+    );
+  }
+  let resp = client
+    .post(format!("{base}/indexes/{INDEX}/commit"))
+    .send()?;
+  if !resp.status().is_success() {
+    bail!(
+      "searchlite commit failed: {} {}",
+      resp.status(),
+      resp.text()?
+    );
+  }
+  let resp = client
+    .post(format!("{base}/indexes/{INDEX}/refresh"))
+    .send()?;
+  if !resp.status().is_success() {
+    bail!(
+      "searchlite refresh failed: {} {}",
+      resp.status(),
+      resp.text()?
+    );
+  }
+  Ok(())
+}
+
+// ── Query suite + parity projections ─────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+enum Parity {
+  /// Compare the unordered set of returned hit IDs.
+  HitIdSet,
+  /// Compare the ordered list of returned hit IDs (use only when sorting is stable).
+  OrderedHitIds,
+  /// Compare the count returned by `_count`.
+  Count,
+  /// Compare bucket key→doc_count map for a named terms aggregation.
+  TermsAggBuckets(&'static str),
+  /// Compare count/min/max/sum (avg derived) of a stats aggregation.
+  StatsAgg(&'static str),
+  /// Relevance check for full-text queries:
+  /// - both sides' top-K hits must each be a subset of `relevant`
+  ///   (catches spurious matches on either side)
+  /// - both sides' top-K must overlap by at least `min_overlap`
+  ///   (catches engines disagreeing on which docs match)
+  ///
+  /// Scoring/ordering differences below the top-K threshold are tolerated
+  /// because BM25 implementations legitimately vary.
+  Relevance {
+    top_k: usize,
+    relevant: &'static [&'static str],
+    min_overlap: usize,
+  },
+  /// Both sides' top-1 hit must be one of the allowlisted IDs. Use when the
+  /// query has an obvious best answer (e.g. exact title match).
+  Top1OneOf(&'static [&'static str]),
+}
+
+struct Case {
+  name: &'static str,
+  endpoint: Endpoint,
+  body: Value,
+  parity: Parity,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Endpoint {
+  Search,
+  Count,
+}
+
+impl Endpoint {
+  fn path(&self) -> &'static str {
+    match self {
+      Endpoint::Search => "_search",
+      Endpoint::Count => "_count",
+    }
+  }
+}
+
+fn cases() -> Vec<Case> {
+  vec![
+    Case {
+      name: "match_all returns all docs",
+      endpoint: Endpoint::Search,
+      body: json!({ "query": { "match_all": {} }, "size": 50 }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "term filter on category=books",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "term": { "category": "books" } },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "term filter on category=music",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "term": { "category": "music" } },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "terms filter on multiple categories",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "bool": {
+            "filter": [{ "terms": { "category": ["books", "music"] } }]
+          }
+        },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "range filter price 30..=60",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "bool": {
+            "filter": [{ "range": { "price": { "gte": 30, "lte": 60 } } }]
+          }
+        },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "bool must match + filter category",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "bool": {
+            "must": [{ "match": { "title": "rust" } }],
+            "filter": [{ "term": { "category": "books" } }]
+          }
+        },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "sort by price asc",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match_all": {} },
+        "sort": [{ "price": "asc" }],
+        "size": 50
+      }),
+      parity: Parity::OrderedHitIds,
+    },
+    Case {
+      name: "sort by price desc",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match_all": {} },
+        "sort": [{ "price": "desc" }],
+        "size": 50
+      }),
+      parity: Parity::OrderedHitIds,
+    },
+    Case {
+      name: "_count with term filter",
+      endpoint: Endpoint::Count,
+      body: json!({ "query": { "term": { "category": "kitchen" } } }),
+      parity: Parity::Count,
+    },
+    Case {
+      name: "terms agg on category",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match_all": {} },
+        "size": 0,
+        "aggs": {
+          "by_cat": { "terms": { "field": "category", "size": 10 } }
+        }
+      }),
+      parity: Parity::TermsAggBuckets("by_cat"),
+    },
+    Case {
+      name: "stats agg on price",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match_all": {} },
+        "size": 0,
+        "aggs": {
+          "price_stats": { "stats": { "field": "price" } }
+        }
+      }),
+      parity: Parity::StatsAgg("price_stats"),
+    },
+    // ── Full-text relevance cases ──────────────────────────────────────────
+    // Corpus reminder (id → title):
+    //   1: "rust safety guide"          7: "rust web frameworks"
+    //   2: "go concurrency patterns"    8: "guitar basics"
+    //   3: "music history vol 1"        9: "advanced cooking"
+    //   4: "music history vol 2"       10: "rust async deep dive"
+    //   5: "kitchen essentials"
+    //   6: "kitchen tools advanced"
+    Case {
+      name: "match: rust → only rust-titled docs",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "rust" } },
+        "size": 3
+      }),
+      parity: Parity::Relevance {
+        top_k: 3,
+        relevant: &["1", "7", "10"],
+        min_overlap: 3,
+      },
+    },
+    Case {
+      name: "match: kitchen → only kitchen-titled docs",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "kitchen" } },
+        "size": 5
+      }),
+      parity: Parity::Relevance {
+        top_k: 2,
+        relevant: &["5", "6"],
+        min_overlap: 2,
+      },
+    },
+    Case {
+      name: "match: music → only docs with 'music' in title",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "music" } },
+        "size": 5
+      }),
+      parity: Parity::Relevance {
+        top_k: 2,
+        relevant: &["3", "4"],
+        min_overlap: 2,
+      },
+    },
+    Case {
+      name: "match: advanced → only docs with 'advanced'",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "advanced" } },
+        "size": 5
+      }),
+      parity: Parity::Relevance {
+        top_k: 2,
+        relevant: &["6", "9"],
+        min_overlap: 2,
+      },
+    },
+    Case {
+      name: "match: 'rust safety' → top-1 must be the doc with both terms",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "rust safety" } },
+        "size": 1
+      }),
+      parity: Parity::Top1OneOf(&["1"]),
+    },
+    Case {
+      name: "match: RUST (uppercase) → still finds rust docs (case-insensitive)",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "RUST" } },
+        "size": 3
+      }),
+      parity: Parity::Relevance {
+        top_k: 3,
+        relevant: &["1", "7", "10"],
+        min_overlap: 3,
+      },
+    },
+    Case {
+      name: "match_phrase: 'music history' → only the two phrase matches",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match_phrase": { "title": "music history" } },
+        "size": 5
+      }),
+      parity: Parity::Relevance {
+        top_k: 2,
+        relevant: &["3", "4"],
+        min_overlap: 2,
+      },
+    },
+    Case {
+      name: "match: 'rust' inside bool with category filter — top hits all rust+books",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "bool": {
+            "must": [{ "match": { "title": "rust" } }],
+            "filter": [{ "term": { "category": "books" } }]
+          }
+        },
+        "size": 3
+      }),
+      parity: Parity::Relevance {
+        top_k: 3,
+        relevant: &["1", "7", "10"],
+        min_overlap: 3,
+      },
+    },
+    // ── Description-field, multi-field, and longer-text cases ────────────
+    Case {
+      name: "match in description: 'goroutines' → only doc 2 (description-only term)",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "description": "goroutines" } },
+        "size": 5
+      }),
+      parity: Parity::Relevance {
+        top_k: 1,
+        relevant: &["2"],
+        min_overlap: 1,
+      },
+    },
+    Case {
+      name: "match in description: 'ownership' → only doc 1 (rust-only concept)",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "description": "ownership" } },
+        "size": 5
+      }),
+      parity: Parity::Relevance {
+        top_k: 1,
+        relevant: &["1"],
+        min_overlap: 1,
+      },
+    },
+    Case {
+      name: "multi_match: 'rust' over title+description → rust-titled docs at top",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "multi_match": {
+            "query": "rust",
+            "fields": ["title", "description"]
+          }
+        },
+        "size": 3
+      }),
+      parity: Parity::Relevance {
+        top_k: 3,
+        relevant: &["1", "7", "10"],
+        min_overlap: 3,
+      },
+    },
+    Case {
+      name: "multi_match: 'kitchen' over title+description → kitchen-titled docs at top",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "multi_match": {
+            "query": "kitchen",
+            "fields": ["title", "description"]
+          }
+        },
+        "size": 2
+      }),
+      parity: Parity::Relevance {
+        top_k: 2,
+        relevant: &["5", "6"],
+        min_overlap: 2,
+      },
+    },
+    Case {
+      name: "multi_match with field boost: title^3, description — top-1 must be exact title match",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": {
+          "multi_match": {
+            "query": "advanced",
+            "fields": ["title^3", "description"]
+          }
+        },
+        "size": 1
+      }),
+      parity: Parity::Top1OneOf(&["6", "9"]),
+    },
+    // ── Tokenization probes (parity, not relevance) ─────────────────────
+    // These check that BOTH engines AGREE on edge-case tokenization. Whether
+    // they stem or strip stopwords is fine as long as they do it consistently.
+    Case {
+      name: "stemming probe: 'patterns' (plural) — should agree on hit set",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "patterns" } },
+        "size": 5
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "stemming probe: 'pattern' (singular) — should agree on hit set",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "pattern" } },
+        "size": 5
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "stemming probe: 'tools' (plural in title 6) vs 'tool' (singular)",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "title": "tool" } },
+        "size": 5
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "stopword probe: 'the' alone — engines must agree (likely most/all docs)",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "description": "the" } },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "stopword probe: 'of the music' — engines must agree on which docs match",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "description": "of the music" } },
+        "size": 50
+      }),
+      parity: Parity::HitIdSet,
+    },
+    Case {
+      name: "long-text scoring: 'kitchen' against description → kitchen-titled docs win",
+      endpoint: Endpoint::Search,
+      body: json!({
+        "query": { "match": { "description": "kitchen" } },
+        "size": 3
+      }),
+      parity: Parity::Relevance {
+        top_k: 2,
+        relevant: &["5", "6"],
+        min_overlap: 2,
+      },
+    },
+  ]
+}
+
+/// Compare an ES response and an adapter response under the given parity rule.
+/// Returns a list of issues; an empty list means the case passed.
+fn evaluate(parity: &Parity, es: &Value, adapter: &Value) -> Vec<String> {
+  match parity {
+    Parity::HitIdSet => {
+      let mut a = collect_hit_ids(es);
+      let mut b = collect_hit_ids(adapter);
+      a.sort();
+      b.sort();
+      if a != b {
+        vec![format!("hit id sets differ:\n    es      = {a:?}\n    adapter = {b:?}")]
+      } else {
+        vec![]
+      }
+    }
+    Parity::OrderedHitIds => {
+      let a = collect_hit_ids(es);
+      let b = collect_hit_ids(adapter);
+      if a != b {
+        vec![format!(
+          "ordered hit ids differ:\n    es      = {a:?}\n    adapter = {b:?}"
+        )]
+      } else {
+        vec![]
+      }
+    }
+    Parity::Count => {
+      let a = total(es);
+      let b = total(adapter);
+      if a != b {
+        vec![format!("counts differ: es={a} adapter={b}")]
+      } else {
+        vec![]
+      }
+    }
+    Parity::TermsAggBuckets(name) => {
+      let a = terms_buckets(es, name);
+      let b = terms_buckets(adapter, name);
+      if a != b {
+        vec![format!(
+          "terms-agg `{name}` buckets differ:\n    es      = {a:?}\n    adapter = {b:?}"
+        )]
+      } else {
+        vec![]
+      }
+    }
+    Parity::StatsAgg(name) => {
+      let a = stats_quad(es, name);
+      let b = stats_quad(adapter, name);
+      if a != b {
+        vec![format!(
+          "stats-agg `{name}` differs:\n    es      = {a}\n    adapter = {b}"
+        )]
+      } else {
+        vec![]
+      }
+    }
+    Parity::Relevance {
+      top_k,
+      relevant,
+      min_overlap,
+    } => {
+      let mut issues = Vec::new();
+      let relevant_set: std::collections::HashSet<&str> = relevant.iter().copied().collect();
+      let es_top: Vec<String> = collect_hit_ids(es).into_iter().take(*top_k).collect();
+      let adapter_top: Vec<String> = collect_hit_ids(adapter).into_iter().take(*top_k).collect();
+
+      let es_extras: Vec<&String> = es_top
+        .iter()
+        .filter(|id| !relevant_set.contains(id.as_str()))
+        .collect();
+      let adapter_extras: Vec<&String> = adapter_top
+        .iter()
+        .filter(|id| !relevant_set.contains(id.as_str()))
+        .collect();
+      if !es_extras.is_empty() {
+        issues.push(format!(
+          "elasticsearch top-{top_k} contains non-relevant ids {:?}; relevant set is {:?}",
+          es_extras, relevant
+        ));
+      }
+      if !adapter_extras.is_empty() {
+        issues.push(format!(
+          "ADAPTER top-{top_k} contains non-relevant ids {:?}; relevant set is {:?}",
+          adapter_extras, relevant
+        ));
+      }
+
+      let es_set: std::collections::HashSet<&String> = es_top.iter().collect();
+      let overlap = adapter_top.iter().filter(|id| es_set.contains(id)).count();
+      if overlap < *min_overlap {
+        issues.push(format!(
+          "es top-{top_k}={es_top:?} and adapter top-{top_k}={adapter_top:?} share only {overlap} ids (need {min_overlap})"
+        ));
+      }
+      issues
+    }
+    Parity::Top1OneOf(allowlist) => {
+      let mut issues = Vec::new();
+      let allow: std::collections::HashSet<&str> = allowlist.iter().copied().collect();
+      let es_top1 = collect_hit_ids(es).into_iter().next();
+      let adapter_top1 = collect_hit_ids(adapter).into_iter().next();
+      match &es_top1 {
+        Some(id) if !allow.contains(id.as_str()) => issues.push(format!(
+          "elasticsearch top-1 = {id:?} but expected one of {:?}",
+          allowlist
+        )),
+        None => issues.push(format!(
+          "elasticsearch returned no hits; expected one of {:?}",
+          allowlist
+        )),
+        _ => {}
+      }
+      match &adapter_top1 {
+        Some(id) if !allow.contains(id.as_str()) => issues.push(format!(
+          "ADAPTER top-1 = {id:?} but expected one of {:?}",
+          allowlist
+        )),
+        None => issues.push(format!(
+          "ADAPTER returned no hits; expected one of {:?}",
+          allowlist
+        )),
+        _ => {}
+      }
+      issues
+    }
+  }
+}
+
+fn total(response: &Value) -> u64 {
+  response
+    .get("count")
+    .and_then(Value::as_u64)
+    .or_else(|| response.pointer("/hits/total/value").and_then(Value::as_u64))
+    .unwrap_or(0)
+}
+
+fn terms_buckets(response: &Value, name: &str) -> Vec<(String, u64)> {
+  let pointer = format!("/aggregations/{name}/buckets");
+  let buckets = response
+    .pointer(&pointer)
+    .and_then(Value::as_array)
+    .cloned()
+    .unwrap_or_default();
+  let mut pairs: Vec<(String, u64)> = buckets
+    .iter()
+    .map(|b| {
+      let key = b
+        .get("key")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .unwrap_or_else(|| b.get("key").map(|v| v.to_string()).unwrap_or_default());
+      let count = b.get("doc_count").and_then(Value::as_u64).unwrap_or(0);
+      (key, count)
+    })
+    .collect();
+  pairs.sort();
+  pairs
+}
+
+fn stats_quad(response: &Value, name: &str) -> Value {
+  let pointer = format!("/aggregations/{name}");
+  let stats = response.pointer(&pointer).cloned().unwrap_or(Value::Null);
+  json!({
+    "count": stats.get("count").cloned().unwrap_or(Value::Null),
+    "min": stats.get("min").cloned().unwrap_or(Value::Null),
+    "max": stats.get("max").cloned().unwrap_or(Value::Null),
+    "sum": stats.get("sum").cloned().unwrap_or(Value::Null),
+  })
+}
+
+fn collect_hit_ids(response: &Value) -> Vec<String> {
+  response
+    .pointer("/hits/hits")
+    .and_then(Value::as_array)
+    .map(|arr| {
+      arr
+        .iter()
+        .filter_map(|h| h.get("_id").and_then(Value::as_str).map(String::from))
+        .collect()
+    })
+    .unwrap_or_default()
+}
+
+fn run_query(
+  client: &reqwest::blocking::Client,
+  base: &str,
+  endpoint: Endpoint,
+  body: &Value,
+) -> Result<Value> {
+  let url = format!("{base}/{INDEX}/{}", endpoint.path());
+  let resp = client.post(url).json(body).send()?;
+  let status = resp.status();
+  let text = resp.text()?;
+  if status != StatusCode::OK {
+    bail!("query failed {status}: {text}");
+  }
+  Ok(serde_json::from_str(&text)?)
+}
+
+/// Compact projection of a response showing just the hits. Used in failure
+/// diagnostics so the panic message is readable.
+fn compact(response: &Value) -> String {
+  if response.get("count").is_some() {
+    return format!("{{count: {}}}", total(response));
+  }
+  let total = total(response);
+  let hits: Vec<Value> = response
+    .pointer("/hits/hits")
+    .and_then(Value::as_array)
+    .cloned()
+    .unwrap_or_default()
+    .into_iter()
+    .map(|h| {
+      json!({
+        "_id": h.get("_id"),
+        "_score": h.get("_score"),
+        "title": h.pointer("/_source/title"),
+      })
+    })
+    .collect();
+  let aggs = response.get("aggregations");
+  match aggs {
+    Some(a) => format!(
+      "{{total: {total}, hits: {}, aggs: {}}}",
+      serde_json::to_string(&hits).unwrap_or_default(),
+      serde_json::to_string(a).unwrap_or_default(),
+    ),
+    None => format!(
+      "{{total: {total}, hits: {}}}",
+      serde_json::to_string(&hits).unwrap_or_default()
+    ),
+  }
+}
+
+// ── The test ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn elasticsearch_parity() {
+  if skip_unless_docker("elasticsearch_parity").is_none() {
+    return;
+  }
+
+  let es = EsContainer::start().expect("start elasticsearch");
+  let stack = AdapterStack::start().expect("start searchlite adapter stack");
+  let docs = corpus();
+
+  let client = blocking_client();
+  ingest_into_es(&client, &es.base_url, &docs).expect("ingest into es");
+  ingest_into_searchlite(&client, &stack.upstream_base, &docs).expect("ingest into searchlite");
+
+  let mut failures: Vec<String> = Vec::new();
+  for case in cases() {
+    let es_resp = match run_query(&client, &es.base_url, case.endpoint, &case.body) {
+      Ok(v) => v,
+      Err(err) => {
+        failures.push(format!("[{}] elasticsearch query failed: {err}", case.name));
+        continue;
+      }
+    };
+    let adapter_resp = match run_query(&client, &stack.adapter_base, case.endpoint, &case.body) {
+      Ok(v) => v,
+      Err(err) => {
+        failures.push(format!("[{}] adapter query failed: {err}", case.name));
+        continue;
+      }
+    };
+    let issues = evaluate(&case.parity, &es_resp, &adapter_resp);
+    let es_top: Vec<String> = collect_hit_ids(&es_resp).into_iter().take(5).collect();
+    let adapter_top: Vec<String> = collect_hit_ids(&adapter_resp).into_iter().take(5).collect();
+    if issues.is_empty() {
+      eprintln!(
+        "  ok   [{}] es={es_top:?} adapter={adapter_top:?}",
+        case.name
+      );
+    } else {
+      eprintln!(
+        "  FAIL [{}] es={es_top:?} adapter={adapter_top:?}",
+        case.name
+      );
+      let raw = format!(
+        "    es raw:      {}\n    adapter raw: {}",
+        compact(&es_resp),
+        compact(&adapter_resp),
+      );
+      failures.push(format!(
+        "[{}]:\n  - {}\n{raw}",
+        case.name,
+        issues.join("\n  - ")
+      ));
+    }
+  }
+
+  if !failures.is_empty() {
+    panic!(
+      "{} parity case(s) failed:\n\n{}",
+      failures.len(),
+      failures.join("\n\n")
+    );
+  }
+}

--- a/searchlite-adapter-elastic/Cargo.toml
+++ b/searchlite-adapter-elastic/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 axum = "0.8.9"
 clap = { workspace = true, features = ["derive", "env"] }
 futures-util = "0.3.32"
+percent-encoding = "2.3"
 reqwest = { version = "0.12.28", features = ["json", "rustls-tls"], default-features = false }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }

--- a/searchlite-adapter-elastic/Cargo.toml
+++ b/searchlite-adapter-elastic/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "searchlite-adapter-elastic"
+edition.workspace = true
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "searchlite-elastic"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = "0.8.9"
+clap = { workspace = true, features = ["derive", "env"] }
+futures-util = "0.3.32"
+reqwest = { version = "0.12.28", features = ["json", "rustls-tls"], default-features = false }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { version = "1.52.1", features = ["macros", "rt-multi-thread", "signal", "io-util"] }
+tower = { version = "0.4.13", features = ["timeout", "limit"] }
+tower-http = { version = "0.5.2", features = ["limit", "trace"] }
+tracing = "0.1.40"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter", "fmt", "json"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/searchlite-adapter-elastic/Dockerfile
+++ b/searchlite-adapter-elastic/Dockerfile
@@ -1,0 +1,65 @@
+# syntax=docker/dockerfile:1.7
+#
+# Build: docker build -f searchlite-adapter-elastic/Dockerfile -t searchlite-elastic .
+# Run:   docker run --rm -p 9200:9200 \
+#          -e SEARCHLITE_ELASTIC_UPSTREAM_URL=http://searchlite-http-host:8080 \
+#          searchlite-elastic --bind 0.0.0.0:9200
+#
+# Build context must be the repo root so cargo can resolve the workspace.
+
+# Builder stage: compile the searchlite-elastic adapter binary.
+FROM rust:1.95-bookworm AS builder
+WORKDIR /workspace
+
+# Install minimal build tooling (ca-certificates so released binary can validate
+# TLS backends if used to talk to an upstream over HTTPS).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates pkg-config \
+ && rm -rf /var/lib/apt/lists/*
+
+# Cache dependencies separately to speed up iterative builds. We copy every
+# workspace member's Cargo.toml so cargo can resolve the workspace, then
+# replace each one's source with a placeholder before doing the dependency
+# fetch. The real sources are copied in afterwards.
+COPY Cargo.toml Cargo.lock ./
+COPY searchlite-core/Cargo.toml searchlite-core/Cargo.toml
+COPY searchlite-cli/Cargo.toml searchlite-cli/Cargo.toml
+COPY searchlite-http/Cargo.toml searchlite-http/Cargo.toml
+COPY searchlite-ffi/Cargo.toml searchlite-ffi/Cargo.toml
+COPY searchlite-wasm/Cargo.toml searchlite-wasm/Cargo.toml
+COPY searchlite-node/Cargo.toml searchlite-node/Cargo.toml
+COPY searchlite-adapter-elastic/Cargo.toml searchlite-adapter-elastic/Cargo.toml
+COPY integration/Cargo.toml integration/Cargo.toml
+
+RUN mkdir -p \
+      searchlite-core/src searchlite-core/benches \
+      searchlite-cli/src searchlite-http/src searchlite-ffi/src \
+      searchlite-wasm/src searchlite-node/src \
+      searchlite-adapter-elastic/src \
+      integration/src \
+ && echo "fn main() {}" > searchlite-cli/src/main.rs \
+ && echo "fn main() {}" > searchlite-adapter-elastic/src/main.rs \
+ && echo "pub fn placeholder() {}" > searchlite-core/src/lib.rs \
+ && echo "fn main() {}" > searchlite-core/benches/aggs.rs \
+ && echo "fn main() {}" > searchlite-core/benches/end_to_end.rs \
+ && echo "fn main() {}" > searchlite-core/benches/scale.rs \
+ && echo "pub fn placeholder() {}" > searchlite-http/src/lib.rs \
+ && echo "pub fn placeholder() {}" > searchlite-ffi/src/lib.rs \
+ && echo "pub fn placeholder() {}" > searchlite-wasm/src/lib.rs \
+ && echo "pub fn placeholder() {}" > searchlite-node/src/lib.rs \
+ && echo "pub fn placeholder() {}" > searchlite-adapter-elastic/src/lib.rs \
+ && echo "pub fn placeholder() {}" > integration/src/lib.rs
+
+RUN cargo fetch --locked
+
+# Now copy the real sources and build the release binary.
+COPY . .
+RUN cargo build --locked --release -p searchlite-adapter-elastic --bin searchlite-elastic
+
+# Runtime stage: minimal distroless image with only the binary and certificates.
+FROM gcr.io/distroless/cc-debian12 AS runtime
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /workspace/target/release/searchlite-elastic /usr/local/bin/searchlite-elastic
+
+EXPOSE 9200
+ENTRYPOINT ["/usr/local/bin/searchlite-elastic"]

--- a/searchlite-adapter-elastic/README.md
+++ b/searchlite-adapter-elastic/README.md
@@ -119,7 +119,8 @@ For the supported subset of the query DSL and aggregations, see the [compatibili
 - `_refresh`, scroll API, runtime mappings
 - Cross-index search via `POST /_search` (path must specify exactly one index)
 - ES authentication / security plugin / ILM / snapshots / transforms / watcher
-- Painless scripting beyond a small `script_score` whitelist
+- `function_score` and `script_score` queries (rejected in v1 — SearchLite has the underlying query types, the adapter just doesn't translate them yet)
+- Painless scripting
 - `geo_*` queries and aggregations, `more_like_this`, parent/child, nested-as-query
 
 The adapter is intended primarily for **read traffic from existing ES tooling**. Writes still go through the SearchLite native HTTP API on port 8080.

--- a/searchlite-adapter-elastic/README.md
+++ b/searchlite-adapter-elastic/README.md
@@ -1,0 +1,136 @@
+# searchlite-adapter-elastic
+
+A drop-in **Elasticsearch HTTP-API adapter** for [searchlite-http](../searchlite-http). Point your existing Elasticsearch clients — Kibana, the official ES SDKs, query builders, curl — at `http://adapter:9200` and they hit a SearchLite index.
+
+The adapter accepts Elasticsearch-shaped requests, translates them to SearchLite's native API, calls a `searchlite-http` upstream, and translates the response back into the Elasticsearch envelope format. No client changes required.
+
+```
+   ES client (Kibana, SDK, curl)
+            │
+            │ ES query DSL (port 9200)
+            ▼
+   ┌──────────────────────────┐
+   │ searchlite-elastic       │  translates JSON → JSON, both directions
+   └──────────────────────────┘
+            │
+            │ SearchLite API (port 8080)
+            ▼
+   ┌──────────────────────────┐
+   │ searchlite-http          │  the real engine
+   └──────────────────────────┘
+            │
+            ▼
+       on-disk index
+```
+
+## Quick start (Docker Compose)
+
+```yaml
+# docker-compose.yml
+services:
+  searchlite:
+    image: ghcr.io/davidkelley/searchlite:latest
+    command:
+      - http
+      - --index
+      - demo:/data
+      - --bind
+      - 0.0.0.0:8080
+    volumes:
+      - searchlite-data:/data
+
+  elastic:
+    image: ghcr.io/davidkelley/searchlite-elastic:latest
+    depends_on:
+      - searchlite
+    command:
+      - --bind
+      - 0.0.0.0:9200
+      - --upstream-url
+      - http://searchlite:8080
+    ports:
+      - "9200:9200"
+    restart: unless-stopped
+
+volumes:
+  searchlite-data:
+```
+
+```bash
+docker compose up -d
+
+# Smoke-test the adapter
+curl http://localhost:9200/                    # version banner
+curl http://localhost:9200/_cluster/health     # always green; single-node
+```
+
+The adapter is read-only in v1, so initialise indexes and load data through the upstream `searchlite-http` on port 8080. See the [walkthrough](../docs/adapters/elasticsearch.md#initialize-an-index-and-load-data) for a worked example.
+
+For a complete walkthrough including index initialisation, sample data, and connecting Kibana / Python / JS clients, see [docs/adapters/elasticsearch.md](../docs/adapters/elasticsearch.md).
+
+## Quick start (cargo, no Docker)
+
+```bash
+# Terminal 1: upstream searchlite-http
+cargo run -p searchlite-cli -- http --index demo:/tmp/demo --bind 127.0.0.1:8080
+
+# Terminal 2: the adapter
+cargo run -p searchlite-adapter-elastic -- \
+  --bind 127.0.0.1:9200 \
+  --upstream-url http://127.0.0.1:8080
+```
+
+## Configuration
+
+All flags can also be set via the matching `SEARCHLITE_ELASTIC_*` environment variable.
+
+| Flag | Env Var | Default | Purpose |
+|---|---|---|---|
+| `--bind` | `SEARCHLITE_ELASTIC_BIND_ADDR` | `127.0.0.1:9200` | Listen address |
+| `--upstream-url` | `SEARCHLITE_ELASTIC_UPSTREAM_URL` | `http://127.0.0.1:8080` | Base URL of the upstream `searchlite-http`. Trailing slash and path prefix preserved. http/https only. |
+| `--write-key` | `SEARCHLITE_ELASTIC_WRITE_KEY` | -- | Optional write key forwarded to upstream as `x-searchlite-write-key` |
+| `--version-banner` | `SEARCHLITE_ELASTIC_VERSION_BANNER` | `8.11.0` | Version string returned in `GET /` and `_nodes` (some clients pin to a major) |
+| `--request-timeout-secs` | `SEARCHLITE_ELASTIC_REQUEST_TIMEOUT_SECS` | `30` | Per-request timeout for upstream calls |
+| `--max-body-bytes` | `SEARCHLITE_ELASTIC_MAX_BODY_BYTES` | `100 MiB` | Max request body size |
+| `--max-concurrency` | `SEARCHLITE_ELASTIC_MAX_CONCURRENCY` | `64` | Max concurrent in-flight requests |
+| `--shutdown-grace-secs` | `SEARCHLITE_ELASTIC_GRACEFUL_SHUTDOWN_SECS` | `5` | Grace period after SIGTERM/SIGINT before forced shutdown |
+
+> **Note:** The adapter forwards the configured write key to the upstream, but does not authenticate the inbound ES client. Front it with your own proxy if you need access control on the ES side.
+
+## Supported API surface (v1, read-only)
+
+- `GET /` — version banner
+- `GET /_cluster/health`, `GET /_cluster/state`, `GET /_nodes` — single-node stubs
+- `HEAD /{index}`, `GET /{index}` — index existence and metadata
+- `GET /{index}/_mapping`, `GET /_mapping` — mapping read
+- `GET /{index}/_settings` — minimal settings stub
+- `GET /{index}/_aliases`, `GET /{index}/_alias` — index-scoped alias view
+- `POST /{index}/_search`, `GET /{index}/_search` — full-text search with the ES query DSL
+- `POST /{index}/_count` — exact count
+- `POST /{index}/_mget`, `POST /_mget` — multi-get by ID
+- `POST /_msearch`, `POST /{index}/_msearch` — NDJSON multi-search
+
+For the supported subset of the query DSL and aggregations, see the [compatibility matrix](../docs/adapters/elasticsearch.md#compatibility-matrix).
+
+## What's NOT supported (returns `400 not_supported_in_v1`)
+
+- Writes: `_doc`, `_bulk`, `_update`, `_delete_by_query`
+- DDL: `PUT /{index}`, `DELETE /{index}`, `PUT /_mapping`
+- `_refresh`, scroll API, runtime mappings
+- Cross-index search via `POST /_search` (path must specify exactly one index)
+- ES authentication / security plugin / ILM / snapshots / transforms / watcher
+- Painless scripting beyond a small `script_score` whitelist
+- `geo_*` queries and aggregations, `more_like_this`, parent/child, nested-as-query
+
+The adapter is intended primarily for **read traffic from existing ES tooling**. Writes still go through the SearchLite native HTTP API on port 8080.
+
+## See also
+
+- [docs/adapters/elasticsearch.md](../docs/adapters/elasticsearch.md) — full walkthrough with worked examples, Kibana setup, compatibility matrix, and troubleshooting
+- [searchlite-http](../searchlite-http) — the upstream HTTP service
+- [docs/http.md](../docs/http.md) — the SearchLite native HTTP API (used internally and for writes)
+- [docs/queries.md](../docs/queries.md) — the SearchLite query DSL (the translation target)
+
+## License
+
+MIT — same as the rest of the workspace.

--- a/searchlite-adapter-elastic/src/client.rs
+++ b/searchlite-adapter-elastic/src/client.rs
@@ -1,0 +1,205 @@
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::http::StatusCode;
+use reqwest::Url;
+use serde::Deserialize;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::error::ESError;
+use crate::AdapterArgs;
+
+const WRITE_KEY_HEADER: &str = "x-searchlite-write-key";
+
+pub struct SearchliteClient {
+  http: reqwest::Client,
+  base: Url,
+  write_key: Option<String>,
+}
+
+impl SearchliteClient {
+  pub fn new(args: &AdapterArgs) -> Result<Self> {
+    let base = Url::parse(&args.upstream_url)
+      .with_context(|| format!("parsing upstream URL `{}`", args.upstream_url))?;
+    let http = reqwest::Client::builder()
+      .timeout(Duration::from_secs(args.request_timeout_secs))
+      .build()
+      .context("building reqwest client for upstream searchlite-http")?;
+    Ok(Self {
+      http,
+      base,
+      write_key: args.write_key.clone(),
+    })
+  }
+
+  pub async fn search(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
+    self
+      .post_json(&format!("indexes/{index}/search"), body)
+      .await
+  }
+
+  pub async fn mget(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
+    self
+      .post_json(&format!("indexes/{index}/mget"), body)
+      .await
+  }
+
+  pub async fn multi_search(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
+    self
+      .post_json(&format!("indexes/{index}/multi_search"), body)
+      .await
+  }
+
+  pub async fn list_indexes(&self) -> Result<Value, ClientError> {
+    self.get_json("indexes").await
+  }
+
+  pub async fn inspect(&self, index: &str) -> Result<Value, ClientError> {
+    self.get_json(&format!("indexes/{index}/inspect")).await
+  }
+
+  pub async fn healthz(&self) -> Result<Value, ClientError> {
+    self.get_json("healthz").await
+  }
+
+  async fn post_json(&self, path: &str, body: &Value) -> Result<Value, ClientError> {
+    let url = self.url(path)?;
+    let mut req = self.http.post(url).json(body);
+    if let Some(key) = &self.write_key {
+      req = req.header(WRITE_KEY_HEADER, key);
+    }
+    let resp = req.send().await.map_err(ClientError::from_reqwest)?;
+    parse_response(resp).await
+  }
+
+  async fn get_json(&self, path: &str) -> Result<Value, ClientError> {
+    let url = self.url(path)?;
+    let mut req = self.http.get(url);
+    if let Some(key) = &self.write_key {
+      req = req.header(WRITE_KEY_HEADER, key);
+    }
+    let resp = req.send().await.map_err(ClientError::from_reqwest)?;
+    parse_response(resp).await
+  }
+
+  fn url(&self, path: &str) -> Result<Url, ClientError> {
+    self
+      .base
+      .join(path)
+      .map_err(|err| ClientError::InvalidUrl(err.to_string()))
+  }
+}
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+  #[error("upstream returned {status}: {kind} — {reason}")]
+  Upstream {
+    status: StatusCode,
+    kind: String,
+    reason: String,
+  },
+  #[error("upstream connection failed: {0}")]
+  Connection(String),
+  #[error("upstream timeout: {0}")]
+  Timeout(String),
+  #[error("invalid upstream URL: {0}")]
+  InvalidUrl(String),
+  #[error("upstream returned non-JSON body (status {status}): {body}")]
+  Decode { status: StatusCode, body: String },
+}
+
+impl ClientError {
+  fn from_reqwest(err: reqwest::Error) -> Self {
+    if err.is_timeout() {
+      ClientError::Timeout(err.to_string())
+    } else {
+      ClientError::Connection(err.to_string())
+    }
+  }
+}
+
+#[derive(Deserialize)]
+struct UpstreamErrorEnvelope {
+  error: UpstreamErrorBody,
+}
+
+#[derive(Deserialize)]
+struct UpstreamErrorBody {
+  #[serde(rename = "type")]
+  kind: String,
+  reason: String,
+}
+
+async fn parse_response(resp: reqwest::Response) -> Result<Value, ClientError> {
+  let status = resp.status();
+  let bytes = resp
+    .bytes()
+    .await
+    .map_err(|err| ClientError::Connection(err.to_string()))?;
+
+  let status_code = StatusCode::from_u16(status.as_u16())
+    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+
+  if status.is_success() {
+    if bytes.is_empty() {
+      return Ok(Value::Null);
+    }
+    return serde_json::from_slice::<Value>(&bytes).map_err(|_err| ClientError::Decode {
+      status: status_code,
+      body: String::from_utf8_lossy(&bytes).to_string(),
+    });
+  }
+
+  if let Ok(envelope) = serde_json::from_slice::<UpstreamErrorEnvelope>(&bytes) {
+    return Err(ClientError::Upstream {
+      status: status_code,
+      kind: envelope.error.kind,
+      reason: envelope.error.reason,
+    });
+  }
+
+  Err(ClientError::Upstream {
+    status: status_code,
+    kind: "unknown_upstream_error".to_string(),
+    reason: String::from_utf8_lossy(&bytes).to_string(),
+  })
+}
+
+impl From<ClientError> for ESError {
+  fn from(err: ClientError) -> ESError {
+    match err {
+      ClientError::Upstream {
+        status,
+        kind,
+        reason,
+      } => {
+        if status == StatusCode::NOT_FOUND || kind == "unknown_index" {
+          ESError::not_found("index_not_found_exception", reason)
+        } else if status == StatusCode::BAD_REQUEST {
+          ESError::bad_request("x_content_parse_exception", reason)
+        } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+          ESError::new(status, "security_exception", reason)
+        } else {
+          ESError::new(
+            status,
+            "internal_server_error",
+            format!("upstream {kind}: {reason}"),
+          )
+        }
+      }
+      ClientError::Connection(reason) => ESError::bad_gateway("connection_exception", reason),
+      ClientError::Timeout(reason) => ESError::gateway_timeout("timeout_exception", reason),
+      ClientError::InvalidUrl(reason) => ESError::internal("internal_server_error", reason),
+      ClientError::Decode { status, body } => ESError::new(
+        if status.is_success() {
+          StatusCode::BAD_GATEWAY
+        } else {
+          status
+        },
+        "internal_server_error",
+        format!("could not decode upstream response: {body}"),
+      ),
+    }
+  }
+}

--- a/searchlite-adapter-elastic/src/client.rs
+++ b/searchlite-adapter-elastic/src/client.rs
@@ -1,7 +1,8 @@
 use std::time::Duration;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use axum::http::StatusCode;
+use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use reqwest::Url;
 use serde::Deserialize;
 use serde_json::Value;
@@ -11,6 +12,36 @@ use crate::error::ESError;
 use crate::AdapterArgs;
 
 const WRITE_KEY_HEADER: &str = "x-searchlite-write-key";
+
+/// Characters that must be percent-encoded inside a URL path segment.
+/// `/`, `?`, `#` are structural; `%` needs encoding to avoid double-decode;
+/// space and `<`, `>`, `"`, `\\`, `^`, `\`` are unsafe in path syntax. Also
+/// percent-encode all controls. Most legitimate index name characters
+/// (alphanumerics, `-`, `_`, `.`, `:`) pass through unchanged.
+const PATH_SEGMENT: &AsciiSet = &CONTROLS
+  .add(b' ')
+  .add(b'/')
+  .add(b'?')
+  .add(b'#')
+  .add(b'%')
+  .add(b'<')
+  .add(b'>')
+  .add(b'"')
+  .add(b'\\')
+  .add(b'^')
+  .add(b'`')
+  .add(b'{')
+  .add(b'}')
+  .add(b'|');
+
+/// Build a relative path under `indexes/<index>/<suffix>` with the index name
+/// percent-encoded as a single path segment. Without this, an index name
+/// containing `/`, `?`, `#`, or whitespace would be parsed structurally by
+/// `Url::join` and route to the wrong endpoint upstream.
+pub(crate) fn upstream_path(index: &str, suffix: &str) -> String {
+  let encoded = utf8_percent_encode(index, PATH_SEGMENT);
+  format!("indexes/{encoded}/{suffix}")
+}
 
 pub struct SearchliteClient {
   http: reqwest::Client,
@@ -30,6 +61,17 @@ impl SearchliteClient {
     }
     let base =
       Url::parse(&raw).with_context(|| format!("parsing upstream URL `{}`", args.upstream_url))?;
+    // Reject non-HTTP schemes at startup so misconfiguration surfaces as a
+    // clear error instead of a cryptic reqwest failure on the first request.
+    match base.scheme() {
+      "http" | "https" => {}
+      other => {
+        return Err(anyhow!(
+          "upstream URL scheme must be http or https, got `{other}` from `{}`",
+          args.upstream_url
+        ))
+      }
+    }
     let http = reqwest::Client::builder()
       .timeout(Duration::from_secs(args.request_timeout_secs))
       .build()
@@ -42,18 +84,16 @@ impl SearchliteClient {
   }
 
   pub async fn search(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
-    self
-      .post_json(&format!("indexes/{index}/search"), body)
-      .await
+    self.post_json(&upstream_path(index, "search"), body).await
   }
 
   pub async fn mget(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
-    self.post_json(&format!("indexes/{index}/mget"), body).await
+    self.post_json(&upstream_path(index, "mget"), body).await
   }
 
   pub async fn multi_search(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
     self
-      .post_json(&format!("indexes/{index}/multi_search"), body)
+      .post_json(&upstream_path(index, "multi_search"), body)
       .await
   }
 
@@ -62,7 +102,7 @@ impl SearchliteClient {
   }
 
   pub async fn inspect(&self, index: &str) -> Result<Value, ClientError> {
-    self.get_json(&format!("indexes/{index}/inspect")).await
+    self.get_json(&upstream_path(index, "inspect")).await
   }
 
   pub async fn healthz(&self) -> Result<Value, ClientError> {
@@ -207,5 +247,90 @@ impl From<ClientError> for ESError {
         format!("could not decode upstream response: {body}"),
       ),
     }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::AdapterArgs;
+  use clap::Parser;
+
+  fn args(upstream_url: &str) -> AdapterArgs {
+    // Construct AdapterArgs by parsing only the URL flag; clap fills the rest
+    // with defaults. We only care about `upstream_url` here.
+    AdapterArgs::parse_from(["searchlite-elastic", "--upstream-url", upstream_url])
+  }
+
+  #[test]
+  fn upstream_path_passes_through_simple_index_name() {
+    assert_eq!(
+      upstream_path("simple-name.v1", "search"),
+      "indexes/simple-name.v1/search"
+    );
+  }
+
+  #[test]
+  fn upstream_path_encodes_slash_in_index_name() {
+    // Without encoding, `format!("indexes/{index}/search")` with index=`a/b`
+    // would create a 4-segment path that Url::join parses structurally,
+    // routing to the wrong endpoint upstream.
+    assert_eq!(upstream_path("a/b", "search"), "indexes/a%2Fb/search");
+  }
+
+  #[test]
+  fn upstream_path_encodes_query_and_fragment_chars() {
+    assert_eq!(upstream_path("a?b", "search"), "indexes/a%3Fb/search");
+    assert_eq!(upstream_path("a#b", "search"), "indexes/a%23b/search");
+  }
+
+  #[test]
+  fn upstream_path_encodes_whitespace_and_percent() {
+    assert_eq!(upstream_path("a b", "search"), "indexes/a%20b/search");
+    assert_eq!(upstream_path("a%b", "search"), "indexes/a%25b/search");
+  }
+
+  #[test]
+  fn client_new_rejects_file_scheme_url() {
+    // Regression: file:// (or any non-HTTP scheme) used to be accepted at
+    // startup and only fail later at request time with a cryptic reqwest
+    // error. Reject loudly instead.
+    let result = SearchliteClient::new(&args("file:///etc/passwd"));
+    assert!(
+      result.is_err(),
+      "expected file:// to be rejected at startup"
+    );
+    let msg = result.err().unwrap().to_string();
+    assert!(msg.contains("scheme"), "got: {msg}");
+    assert!(msg.contains("file"), "got: {msg}");
+  }
+
+  #[test]
+  fn client_new_accepts_http_and_https() {
+    assert!(SearchliteClient::new(&args("http://127.0.0.1:8080")).is_ok());
+    assert!(SearchliteClient::new(&args("https://example.com")).is_ok());
+  }
+
+  #[test]
+  fn client_new_normalizes_missing_trailing_slash_for_path_prefix() {
+    // Prefix base URLs without a trailing slash would have `Url::join` drop
+    // the prefix segment. Verify we patch the base before parsing.
+    let client =
+      SearchliteClient::new(&args("http://example.com/prefix")).expect("parse with prefix");
+    let url = client
+      .url(&upstream_path("foo", "search"))
+      .expect("build url");
+    assert_eq!(url.path(), "/prefix/indexes/foo/search");
+  }
+
+  #[test]
+  fn client_url_construction_with_encoded_index_name_produces_3_path_segments() {
+    let client = SearchliteClient::new(&args("http://example.com")).expect("parse simple base");
+    let url = client
+      .url(&upstream_path("a/b", "search"))
+      .expect("build url");
+    // Index `a/b` should be a single segment, encoded — total path is
+    // /indexes/a%2Fb/search (3 segments), not /indexes/a/b/search (4).
+    assert_eq!(url.path(), "/indexes/a%2Fb/search");
   }
 }

--- a/searchlite-adapter-elastic/src/client.rs
+++ b/searchlite-adapter-elastic/src/client.rs
@@ -20,8 +20,16 @@ pub struct SearchliteClient {
 
 impl SearchliteClient {
   pub fn new(args: &AdapterArgs) -> Result<Self> {
-    let base = Url::parse(&args.upstream_url)
-      .with_context(|| format!("parsing upstream URL `{}`", args.upstream_url))?;
+    // RFC 3986 `Url::join` drops the last path segment when the base URL has
+    // no trailing slash — so `http://host/prefix` + "indexes/foo" becomes
+    // `http://host/indexes/foo`, silently breaking deployments behind a path
+    // prefix. Force the base to end with `/` so prefixes are preserved.
+    let mut raw = args.upstream_url.clone();
+    if !raw.ends_with('/') {
+      raw.push('/');
+    }
+    let base =
+      Url::parse(&raw).with_context(|| format!("parsing upstream URL `{}`", args.upstream_url))?;
     let http = reqwest::Client::builder()
       .timeout(Duration::from_secs(args.request_timeout_secs))
       .build()
@@ -40,9 +48,7 @@ impl SearchliteClient {
   }
 
   pub async fn mget(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
-    self
-      .post_json(&format!("indexes/{index}/mget"), body)
-      .await
+    self.post_json(&format!("indexes/{index}/mget"), body).await
   }
 
   pub async fn multi_search(&self, index: &str, body: &Value) -> Result<Value, ClientError> {
@@ -138,8 +144,8 @@ async fn parse_response(resp: reqwest::Response) -> Result<Value, ClientError> {
     .await
     .map_err(|err| ClientError::Connection(err.to_string()))?;
 
-  let status_code = StatusCode::from_u16(status.as_u16())
-    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+  let status_code =
+    StatusCode::from_u16(status.as_u16()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
   if status.is_success() {
     if bytes.is_empty() {

--- a/searchlite-adapter-elastic/src/client.rs
+++ b/searchlite-adapter-elastic/src/client.rs
@@ -1,4 +1,5 @@
-use std::time::Duration;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use axum::http::StatusCode;
@@ -7,11 +8,18 @@ use reqwest::Url;
 use serde::Deserialize;
 use serde_json::Value;
 use thiserror::Error;
+use tokio::sync::Mutex;
 
 use crate::error::ESError;
 use crate::AdapterArgs;
 
 const WRITE_KEY_HEADER: &str = "x-searchlite-write-key";
+
+/// TTL for the cached `list_indexes` response. Aliases and index membership
+/// rarely change at high frequency, but every alias-resolving request would
+/// otherwise hit upstream — Kibana / SDKs probe these endpoints repeatedly.
+/// 5 seconds is short enough that a deleted index still surfaces quickly.
+const LIST_INDEXES_TTL: Duration = Duration::from_secs(5);
 
 /// Characters that must be percent-encoded inside a URL path segment.
 /// `/`, `?`, `#` are structural; `%` needs encoding to avoid double-decode;
@@ -47,6 +55,13 @@ pub struct SearchliteClient {
   http: reqwest::Client,
   base: Url,
   write_key: Option<String>,
+  // Cached upstream `list_indexes` response. Every alias-resolving handler
+  // (`_settings`, `_mapping`, `_aliases`, HEAD `/{index}`, `GET /{index}`,
+  // and the alias resolution before search/mget/msearch) hits this once
+  // per request — without the cache that's one upstream round-trip per
+  // call. The cache is read-mostly and protected by a Mutex; on miss we
+  // refetch under the lock.
+  list_cache: Arc<Mutex<Option<(Instant, Value)>>>,
 }
 
 impl SearchliteClient {
@@ -80,6 +95,7 @@ impl SearchliteClient {
       http,
       base,
       write_key: args.write_key.clone(),
+      list_cache: Arc::new(Mutex::new(None)),
     })
   }
 
@@ -98,7 +114,22 @@ impl SearchliteClient {
   }
 
   pub async fn list_indexes(&self) -> Result<Value, ClientError> {
-    self.get_json("indexes").await
+    let mut guard = self.list_cache.lock().await;
+    if let Some((stamped_at, value)) = guard.as_ref() {
+      if stamped_at.elapsed() < LIST_INDEXES_TTL {
+        return Ok(value.clone());
+      }
+    }
+    let fresh = self.get_json("indexes").await?;
+    *guard = Some((Instant::now(), fresh.clone()));
+    Ok(fresh)
+  }
+
+  /// Test/debug helper: drop any cached `list_indexes` response so the next
+  /// call goes upstream. Not used in production code paths.
+  #[cfg(test)]
+  pub async fn invalidate_list_indexes_cache(&self) {
+    *self.list_cache.lock().await = None;
   }
 
   pub async fn inspect(&self, index: &str) -> Result<Value, ClientError> {
@@ -227,11 +258,12 @@ impl From<ClientError> for ESError {
         } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
           ESError::new(status, "security_exception", reason)
         } else {
-          ESError::new(
-            status,
-            "internal_server_error",
-            format!("upstream {kind}: {reason}"),
-          )
+          // Preserve the upstream's `kind` as the ESError type for 5xx so
+          // callers branching on `error.type` keep their discriminator
+          // (e.g. `index_locked_exception`, `vector_dimension_mismatch`).
+          // Previously these collapsed into a generic
+          // `internal_server_error` and the kind was buried in `reason`.
+          ESError::new(status, kind, reason)
         }
       }
       ClientError::Connection(reason) => ESError::bad_gateway("connection_exception", reason),

--- a/searchlite-adapter-elastic/src/compat/mod.rs
+++ b/searchlite-adapter-elastic/src/compat/mod.rs
@@ -1,0 +1,1 @@
+pub mod stub;

--- a/searchlite-adapter-elastic/src/compat/stub.rs
+++ b/searchlite-adapter-elastic/src/compat/stub.rs
@@ -22,17 +22,22 @@ pub fn version_banner(version: &str) -> Value {
   })
 }
 
-/// `GET /_cluster/health` — always green; SearchLite is single-shard.
+/// `GET /_cluster/health` — green when upstream is reachable; advertises one
+/// active primary so the response is internally consistent (Kibana / SDK
+/// probes warn on green-with-zero-shards). When the upstream is unhealthy we
+/// return red and keep the shard counts at zero so callers can distinguish
+/// "fine but empty" from "broken".
 pub fn cluster_health(upstream_healthy: bool) -> Value {
   let status = if upstream_healthy { "green" } else { "red" };
+  let active = if upstream_healthy { 1 } else { 0 };
   json!({
     "cluster_name": "searchlite",
     "status": status,
     "timed_out": false,
     "number_of_nodes": 1,
     "number_of_data_nodes": 1,
-    "active_primary_shards": 0,
-    "active_shards": 0,
+    "active_primary_shards": active,
+    "active_shards": active,
     "relocating_shards": 0,
     "initializing_shards": 0,
     "unassigned_shards": 0,

--- a/searchlite-adapter-elastic/src/compat/stub.rs
+++ b/searchlite-adapter-elastic/src/compat/stub.rs
@@ -1,0 +1,61 @@
+use serde_json::{json, Value};
+
+/// Minimal `GET /` banner mimicking Elasticsearch's root response so that
+/// official ES clients accept the connection.
+pub fn version_banner(version: &str) -> Value {
+  json!({
+    "name": "searchlite-adapter-elastic",
+    "cluster_name": "searchlite",
+    "cluster_uuid": "_na_",
+    "version": {
+      "number": version,
+      "build_flavor": "default",
+      "build_type": "binary",
+      "build_hash": "searchlite",
+      "build_date": "1970-01-01T00:00:00Z",
+      "build_snapshot": false,
+      "lucene_version": "9.0.0",
+      "minimum_wire_compatibility_version": "7.17.0",
+      "minimum_index_compatibility_version": "7.0.0",
+    },
+    "tagline": "You Know, for Search",
+  })
+}
+
+/// `GET /_cluster/health` — always green; SearchLite is single-shard.
+pub fn cluster_health(upstream_healthy: bool) -> Value {
+  let status = if upstream_healthy { "green" } else { "red" };
+  json!({
+    "cluster_name": "searchlite",
+    "status": status,
+    "timed_out": false,
+    "number_of_nodes": 1,
+    "number_of_data_nodes": 1,
+    "active_primary_shards": 0,
+    "active_shards": 0,
+    "relocating_shards": 0,
+    "initializing_shards": 0,
+    "unassigned_shards": 0,
+    "delayed_unassigned_shards": 0,
+    "number_of_pending_tasks": 0,
+    "number_of_in_flight_fetch": 0,
+    "task_max_waiting_in_queue_millis": 0,
+    "active_shards_percent_as_number": 100.0,
+  })
+}
+
+/// `GET /_nodes` — minimal stub so ES clients that probe topology don't crash.
+pub fn nodes_stub(version: &str) -> Value {
+  json!({
+    "_nodes": { "total": 1, "successful": 1, "failed": 0 },
+    "cluster_name": "searchlite",
+    "nodes": {
+      "searchlite": {
+        "name": "searchlite",
+        "version": version,
+        "roles": ["data", "master", "ingest"],
+        "attributes": {},
+      }
+    }
+  })
+}

--- a/searchlite-adapter-elastic/src/error.rs
+++ b/searchlite-adapter-elastic/src/error.rs
@@ -78,6 +78,12 @@ impl ESError {
     )
   }
 
+  /// Override the HTTP status returned to the client. The body's `status`
+  /// field is rebuilt from `self.status` at render time
+  /// (see `IntoResponse for ESError`), so callers always get the new status
+  /// reflected in both the HTTP envelope and the JSON body. The error
+  /// `type`/`reason` strings are NOT rebuilt — set those via the constructor
+  /// before calling `with_status` to keep the body coherent.
   pub fn with_status(mut self, status: StatusCode) -> Self {
     self.status = status;
     self

--- a/searchlite-adapter-elastic/src/error.rs
+++ b/searchlite-adapter-elastic/src/error.rs
@@ -1,0 +1,101 @@
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[error("{reason}")]
+pub struct ESError {
+  pub status: StatusCode,
+  pub error_type: String,
+  pub reason: String,
+  pub root_cause: Vec<RootCause>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RootCause {
+  #[serde(rename = "type")]
+  pub error_type: String,
+  pub reason: String,
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+  error: ErrorPayload<'a>,
+  status: u16,
+}
+
+#[derive(Serialize)]
+struct ErrorPayload<'a> {
+  #[serde(rename = "type")]
+  error_type: &'a str,
+  reason: &'a str,
+  root_cause: &'a [RootCause],
+}
+
+impl ESError {
+  pub fn new(status: StatusCode, error_type: impl Into<String>, reason: impl Into<String>) -> Self {
+    let error_type = error_type.into();
+    let reason = reason.into();
+    let root_cause = vec![RootCause {
+      error_type: error_type.clone(),
+      reason: reason.clone(),
+    }];
+    Self {
+      status,
+      error_type,
+      reason,
+      root_cause,
+    }
+  }
+
+  pub fn bad_request(error_type: impl Into<String>, reason: impl Into<String>) -> Self {
+    Self::new(StatusCode::BAD_REQUEST, error_type, reason)
+  }
+
+  pub fn not_found(error_type: impl Into<String>, reason: impl Into<String>) -> Self {
+    Self::new(StatusCode::NOT_FOUND, error_type, reason)
+  }
+
+  pub fn internal(error_type: impl Into<String>, reason: impl Into<String>) -> Self {
+    Self::new(StatusCode::INTERNAL_SERVER_ERROR, error_type, reason)
+  }
+
+  pub fn bad_gateway(error_type: impl Into<String>, reason: impl Into<String>) -> Self {
+    Self::new(StatusCode::BAD_GATEWAY, error_type, reason)
+  }
+
+  pub fn gateway_timeout(error_type: impl Into<String>, reason: impl Into<String>) -> Self {
+    Self::new(StatusCode::GATEWAY_TIMEOUT, error_type, reason)
+  }
+
+  pub fn unsupported(feature: impl Into<String>) -> Self {
+    let feature = feature.into();
+    Self::bad_request(
+      "x_content_parse_exception",
+      format!("feature `{feature}` not supported by searchlite adapter"),
+    )
+  }
+
+  pub fn with_status(mut self, status: StatusCode) -> Self {
+    self.status = status;
+    self
+  }
+}
+
+impl IntoResponse for ESError {
+  fn into_response(self) -> Response {
+    let body = ErrorBody {
+      error: ErrorPayload {
+        error_type: &self.error_type,
+        reason: &self.reason,
+        root_cause: &self.root_cause,
+      },
+      status: self.status.as_u16(),
+    };
+    (self.status, Json(body)).into_response()
+  }
+}
+
+pub type ESResult<T> = Result<T, ESError>;

--- a/searchlite-adapter-elastic/src/lib.rs
+++ b/searchlite-adapter-elastic/src/lib.rs
@@ -1,0 +1,204 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Context;
+use axum::error_handling::HandleErrorLayer;
+use axum::extract::Request;
+use axum::http::StatusCode;
+use axum::middleware::{self, Next};
+use axum::response::{IntoResponse, Response};
+use axum::Router;
+use clap::{Parser, ValueEnum};
+use tokio::net::TcpListener;
+use tower::limit::ConcurrencyLimitLayer;
+use tower::timeout::TimeoutLayer;
+use tower::{BoxError, ServiceBuilder};
+use tower_http::limit::RequestBodyLimitLayer;
+use tracing::{error, info};
+use tracing_subscriber::{fmt, EnvFilter};
+
+pub mod client;
+pub mod compat;
+pub mod error;
+pub mod routes;
+pub mod state;
+pub mod translate;
+
+pub use client::SearchliteClient;
+pub use error::ESError;
+pub use state::AppState;
+
+#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnsupportedPolicy {
+  /// Reject the request with HTTP 400 when an unsupported feature is encountered.
+  Reject,
+  /// Log a warning and translate as best as possible (may produce empty/partial results).
+  Warn,
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(
+  name = "searchlite-elastic",
+  version,
+  about = "Elasticsearch-compatible HTTP adapter for searchlite-http"
+)]
+pub struct AdapterArgs {
+  /// Bind address for the Elasticsearch-compatible HTTP server.
+  /// WARNING: Binding to 0.0.0.0 or any non-localhost address exposes this
+  /// unauthenticated service to the network; front it with a proxy or firewall.
+  #[arg(long, env = "SEARCHLITE_ELASTIC_BIND_ADDR", default_value = "127.0.0.1:9200")]
+  pub bind: SocketAddr,
+
+  /// Base URL of the upstream searchlite-http instance.
+  #[arg(
+    long,
+    env = "SEARCHLITE_ELASTIC_UPSTREAM_URL",
+    default_value = "http://127.0.0.1:8080"
+  )]
+  pub upstream_url: String,
+
+  /// Optional write key forwarded to upstream as `x-searchlite-write-key`.
+  #[arg(long, env = "SEARCHLITE_ELASTIC_WRITE_KEY")]
+  pub write_key: Option<String>,
+
+  /// Version string returned in the cluster banner (mimic Elasticsearch major version).
+  #[arg(
+    long,
+    env = "SEARCHLITE_ELASTIC_VERSION_BANNER",
+    default_value = "8.11.0"
+  )]
+  pub version_banner: String,
+
+  /// Policy when a request uses an Elasticsearch feature SearchLite cannot model.
+  #[arg(
+    long,
+    value_enum,
+    env = "SEARCHLITE_ELASTIC_ON_UNSUPPORTED",
+    default_value = "reject"
+  )]
+  pub on_unsupported: UnsupportedPolicy,
+
+  /// Per-request timeout in seconds for upstream calls.
+  #[arg(long, env = "SEARCHLITE_ELASTIC_REQUEST_TIMEOUT_SECS", default_value_t = 30)]
+  pub request_timeout_secs: u64,
+
+  /// Maximum allowed request body size in bytes.
+  #[arg(long, env = "SEARCHLITE_ELASTIC_MAX_BODY_BYTES", default_value_t = 100 * 1024 * 1024)]
+  pub max_body_bytes: u64,
+
+  /// Maximum number of in-flight requests.
+  #[arg(long, env = "SEARCHLITE_ELASTIC_MAX_CONCURRENCY", default_value_t = 64)]
+  pub max_concurrency: usize,
+
+  /// Grace period in seconds before forcing shutdown after a signal.
+  #[arg(
+    long,
+    env = "SEARCHLITE_ELASTIC_GRACEFUL_SHUTDOWN_SECS",
+    default_value_t = 5
+  )]
+  pub shutdown_grace_secs: u64,
+}
+
+pub async fn run(args: AdapterArgs) -> anyhow::Result<()> {
+  let client = Arc::new(SearchliteClient::new(&args)?);
+  let state = Arc::new(AppState::new(client, args.clone()));
+
+  let listener = TcpListener::bind(args.bind)
+    .await
+    .with_context(|| format!("binding to {}", args.bind))?;
+  let local_addr = listener
+    .local_addr()
+    .context("reading local listening address")?;
+  info!(
+    address = ?local_addr,
+    upstream = %args.upstream_url,
+    "searchlite elasticsearch adapter listening"
+  );
+
+  let app = router(state, &args);
+  axum::serve(listener, app)
+    .with_graceful_shutdown(shutdown_signal(args.shutdown_grace_secs))
+    .await
+    .context("running HTTP server")
+}
+
+pub fn router(state: Arc<AppState>, args: &AdapterArgs) -> Router {
+  let max_body = args
+    .max_body_bytes
+    .try_into()
+    .expect("configured max_body_bytes does not fit into usize");
+  let middleware = ServiceBuilder::new()
+    .layer(HandleErrorLayer::new(handle_middleware_error))
+    .layer(TimeoutLayer::new(Duration::from_secs(
+      args.request_timeout_secs,
+    )))
+    .layer(ConcurrencyLimitLayer::new(args.max_concurrency))
+    .layer(RequestBodyLimitLayer::new(max_body));
+
+  routes::router(state)
+    .layer(middleware)
+    .layer(middleware::from_fn(move |req, next| {
+      map_413(max_body, req, next)
+    }))
+}
+
+async fn map_413(max_body: usize, req: Request, next: Next) -> Response {
+  let mut res = next.run(req).await;
+  if res.status() == StatusCode::PAYLOAD_TOO_LARGE {
+    res = ESError::bad_request(
+      "request_entity_too_large_exception",
+      format!("request body exceeded configured limit of {max_body} bytes"),
+    )
+    .with_status(StatusCode::PAYLOAD_TOO_LARGE)
+    .into_response();
+  }
+  res
+}
+
+async fn handle_middleware_error(err: BoxError) -> Response {
+  if err.is::<tower::timeout::error::Elapsed>() {
+    return ESError::bad_request("timeout_exception", "request timed out")
+      .with_status(StatusCode::GATEWAY_TIMEOUT)
+      .into_response();
+  }
+  ESError::internal("internal_server_error", err.to_string()).into_response()
+}
+
+async fn shutdown_signal(grace_secs: u64) {
+  let ctrl_c = async {
+    if let Err(err) = tokio::signal::ctrl_c().await {
+      error!(error = ?err, "failed to install ctrl+c handler");
+    }
+  };
+  #[cfg(unix)]
+  let terminate = async {
+    use tokio::signal::unix::{signal, SignalKind};
+    if let Ok(mut sig) = signal(SignalKind::terminate()) {
+      sig.recv().await;
+    }
+  };
+  #[cfg(not(unix))]
+  let terminate = std::future::pending::<()>();
+
+  tokio::select! {
+    _ = ctrl_c => {},
+    _ = terminate => {},
+  }
+
+  info!("shutdown signal received, draining in-flight requests");
+  if grace_secs > 0 {
+    tokio::time::sleep(Duration::from_secs(grace_secs)).await;
+  }
+}
+
+pub fn init_tracing() {
+  let env_filter =
+    EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info,tower_http=info"));
+  fmt()
+    .with_target(false)
+    .with_env_filter(env_filter)
+    .json()
+    .try_init()
+    .ok();
+}

--- a/searchlite-adapter-elastic/src/lib.rs
+++ b/searchlite-adapter-elastic/src/lib.rs
@@ -9,7 +9,7 @@ use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
 use axum::Router;
-use clap::{Parser, ValueEnum};
+use clap::Parser;
 use tokio::net::TcpListener;
 use tower::limit::ConcurrencyLimitLayer;
 use tower::timeout::TimeoutLayer;
@@ -29,14 +29,6 @@ pub use client::SearchliteClient;
 pub use error::ESError;
 pub use state::AppState;
 
-#[derive(ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UnsupportedPolicy {
-  /// Reject the request with HTTP 400 when an unsupported feature is encountered.
-  Reject,
-  /// Log a warning and translate as best as possible (may produce empty/partial results).
-  Warn,
-}
-
 #[derive(Parser, Debug, Clone)]
 #[command(
   name = "searchlite-elastic",
@@ -47,7 +39,11 @@ pub struct AdapterArgs {
   /// Bind address for the Elasticsearch-compatible HTTP server.
   /// WARNING: Binding to 0.0.0.0 or any non-localhost address exposes this
   /// unauthenticated service to the network; front it with a proxy or firewall.
-  #[arg(long, env = "SEARCHLITE_ELASTIC_BIND_ADDR", default_value = "127.0.0.1:9200")]
+  #[arg(
+    long,
+    env = "SEARCHLITE_ELASTIC_BIND_ADDR",
+    default_value = "127.0.0.1:9200"
+  )]
   pub bind: SocketAddr,
 
   /// Base URL of the upstream searchlite-http instance.
@@ -70,17 +66,12 @@ pub struct AdapterArgs {
   )]
   pub version_banner: String,
 
-  /// Policy when a request uses an Elasticsearch feature SearchLite cannot model.
+  /// Per-request timeout in seconds for upstream calls.
   #[arg(
     long,
-    value_enum,
-    env = "SEARCHLITE_ELASTIC_ON_UNSUPPORTED",
-    default_value = "reject"
+    env = "SEARCHLITE_ELASTIC_REQUEST_TIMEOUT_SECS",
+    default_value_t = 30
   )]
-  pub on_unsupported: UnsupportedPolicy,
-
-  /// Per-request timeout in seconds for upstream calls.
-  #[arg(long, env = "SEARCHLITE_ELASTIC_REQUEST_TIMEOUT_SECS", default_value_t = 30)]
   pub request_timeout_secs: u64,
 
   /// Maximum allowed request body size in bytes.

--- a/searchlite-adapter-elastic/src/main.rs
+++ b/searchlite-adapter-elastic/src/main.rs
@@ -1,0 +1,14 @@
+use clap::Parser;
+use searchlite_adapter_elastic::{init_tracing, run, AdapterArgs};
+use tracing::error;
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+  init_tracing();
+  let args = AdapterArgs::parse();
+  if let Err(err) = run(args).await {
+    error!("{err:?}");
+    std::process::exit(1);
+  }
+  Ok(())
+}

--- a/searchlite-adapter-elastic/src/routes/cluster.rs
+++ b/searchlite-adapter-elastic/src/routes/cluster.rs
@@ -1,0 +1,25 @@
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::Json;
+use serde_json::Value;
+
+use crate::compat::stub;
+use crate::state::AppState;
+
+pub async fn root(State(state): State<Arc<AppState>>) -> Json<Value> {
+  Json(stub::version_banner(&state.args().version_banner))
+}
+
+pub async fn cluster_health(State(state): State<Arc<AppState>>) -> Json<Value> {
+  let upstream_healthy = state.client().healthz().await.is_ok();
+  Json(stub::cluster_health(upstream_healthy))
+}
+
+pub async fn cluster_state(State(state): State<Arc<AppState>>) -> Json<Value> {
+  Json(stub::nodes_stub(&state.args().version_banner))
+}
+
+pub async fn nodes(State(state): State<Arc<AppState>>) -> Json<Value> {
+  Json(stub::nodes_stub(&state.args().version_banner))
+}

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -1,0 +1,170 @@
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::Json;
+use serde_json::{json, Value};
+
+use crate::error::{ESError, ESResult};
+use crate::state::AppState;
+use crate::translate::schema_to_es;
+
+pub async fn head_index(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+) -> StatusCode {
+  match index_exists(&state, &index).await {
+    Ok(true) => StatusCode::OK,
+    Ok(false) => StatusCode::NOT_FOUND,
+    Err(_) => StatusCode::SERVICE_UNAVAILABLE,
+  }
+}
+
+pub async fn get_index(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+) -> ESResult<Json<Value>> {
+  let mapping = get_mapping_for(&state, &index).await?;
+  let settings = settings_payload(&index);
+  let mappings = mapping
+    .get(&index)
+    .and_then(|v| v.get("mappings"))
+    .cloned()
+    .unwrap_or_else(|| json!({ "properties": {} }));
+  let settings_value = settings
+    .get(&index)
+    .and_then(|v| v.get("settings"))
+    .cloned()
+    .unwrap_or_else(|| json!({}));
+
+  let mut payload = serde_json::Map::new();
+  payload.insert(
+    index,
+    json!({
+      "aliases": {},
+      "mappings": mappings,
+      "settings": settings_value,
+    }),
+  );
+  Ok(Json(Value::Object(payload)))
+}
+
+pub async fn get_mapping(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+) -> ESResult<Json<Value>> {
+  Ok(Json(get_mapping_for(&state, &index).await?))
+}
+
+pub async fn mapping_all(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>> {
+  let listing = state.client().list_indexes().await?;
+  let names = listing
+    .get("indexes")
+    .and_then(Value::as_array)
+    .map(|items| {
+      items
+        .iter()
+        .filter_map(|item| item.get("name").and_then(Value::as_str).map(str::to_string))
+        .collect::<Vec<_>>()
+    })
+    .unwrap_or_default();
+
+  let mut out = serde_json::Map::new();
+  for name in names {
+    let single = get_mapping_for(&state, &name).await?;
+    if let Some(entry) = single.get(&name) {
+      out.insert(name, entry.clone());
+    }
+  }
+  Ok(Json(Value::Object(out)))
+}
+
+pub async fn get_settings(
+  State(_state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+) -> Json<Value> {
+  Json(settings_payload(&index))
+}
+
+pub async fn aliases(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>> {
+  // Best-effort: resolve aliases from upstream listing if available.
+  let listing = state.client().list_indexes().await?;
+  let aliases = listing
+    .get("aliases")
+    .and_then(Value::as_array)
+    .cloned()
+    .unwrap_or_default();
+  let mut by_index: serde_json::Map<String, Value> = serde_json::Map::new();
+  for alias in aliases {
+    let alias_name = alias.get("alias").and_then(Value::as_str).unwrap_or("").to_string();
+    let target = alias.get("target").and_then(Value::as_str).unwrap_or("").to_string();
+    if alias_name.is_empty() || target.is_empty() {
+      continue;
+    }
+    let entry = by_index
+      .entry(target)
+      .or_insert_with(|| json!({ "aliases": {} }));
+    if let Some(map) = entry.get_mut("aliases").and_then(Value::as_object_mut) {
+      map.insert(alias_name, json!({}));
+    }
+  }
+  Ok(Json(Value::Object(by_index)))
+}
+
+pub fn settings_payload(index: &str) -> Value {
+  json!({
+    index: {
+      "settings": {
+        "index": {
+          "number_of_shards": "1",
+          "number_of_replicas": "0",
+          "provided_name": index,
+          "creation_date": "0",
+          "uuid": "_na_",
+          "version": { "created": "8110000" },
+        }
+      }
+    }
+  })
+}
+
+async fn get_mapping_for(state: &Arc<AppState>, index: &str) -> ESResult<Value> {
+  let inspect = state.client().inspect(index).await?;
+  let schema = inspect
+    .get("manifest")
+    .and_then(|m| m.get("schema"))
+    .ok_or_else(|| {
+      ESError::internal(
+        "internal_server_error",
+        "upstream inspect response missing manifest.schema",
+      )
+    })?;
+  Ok(schema_to_es(index, schema)?)
+}
+
+async fn index_exists(state: &Arc<AppState>, index: &str) -> ESResult<bool> {
+  let listing = state.client().list_indexes().await?;
+  let known = listing
+    .get("indexes")
+    .and_then(Value::as_array)
+    .map(|items| {
+      items
+        .iter()
+        .any(|item| item.get("name").and_then(Value::as_str) == Some(index))
+    })
+    .unwrap_or(false);
+  if known {
+    return Ok(true);
+  }
+  let alias_match = listing
+    .get("aliases")
+    .and_then(Value::as_array)
+    .map(|items| {
+      items
+        .iter()
+        .any(|item| item.get("alias").and_then(Value::as_str) == Some(index))
+    })
+    .unwrap_or(false);
+  Ok(alias_match)
+}
+

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -3,11 +3,18 @@ use std::sync::Arc;
 use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::Json;
+use futures_util::stream::{self, StreamExt};
 use serde_json::{json, Value};
 
 use crate::error::{ESError, ESResult};
 use crate::state::AppState;
 use crate::translate::schema_to_es;
+
+/// Maximum number of concurrent upstream `inspect` calls fired by
+/// `mapping_all`. Bounded so a `_mapping` request against a cluster with
+/// many indexes doesn't open an unbounded number of connections to the
+/// upstream all at once.
+const MAPPING_ALL_CONCURRENCY: usize = 8;
 
 pub async fn head_index(
   State(state): State<Arc<AppState>>,
@@ -69,9 +76,26 @@ pub async fn mapping_all(State(state): State<Arc<AppState>>) -> ESResult<Json<Va
     })
     .unwrap_or_default();
 
+  // Run upstream `inspect` calls concurrently with bounded parallelism.
+  // The previous serialized loop made `_mapping` latency proportional to
+  // the index count and was a real problem on clusters with many indexes
+  // (Kibana, ES SDKs hit it on every connect). `buffer_unordered` keeps
+  // at most MAPPING_ALL_CONCURRENCY in flight at a time.
+  let results: Vec<(String, ESResult<Value>)> = stream::iter(names.into_iter())
+    .map(|name| {
+      let state = state.clone();
+      async move {
+        let result = get_mapping_for(&state, &name).await;
+        (name, result)
+      }
+    })
+    .buffer_unordered(MAPPING_ALL_CONCURRENCY)
+    .collect()
+    .await;
+
   let mut out = serde_json::Map::new();
-  for name in names {
-    let single = get_mapping_for(&state, &name).await?;
+  for (name, result) in results {
+    let single = result?;
     if let Some(entry) = single.get(&name) {
       out.insert(name, entry.clone());
     }
@@ -83,13 +107,19 @@ pub async fn get_settings(
   State(state): State<Arc<AppState>>,
   Path(index): Path<String>,
 ) -> ESResult<Json<Value>> {
-  if !index_exists(&state, &index).await? {
-    return Err(ESError::not_found(
-      "index_not_found_exception",
-      format!("no such index [{index}]"),
-    ));
-  }
-  Ok(Json(settings_payload(&index)))
+  // Resolve the path token through the alias listing so the response is
+  // keyed by the concrete target index, not by the alias name. ES does
+  // the same — alias requests return `{<target>: {settings: ...}}`, never
+  // `{<alias>: ...}`.
+  let resolved = resolve_index_or_alias(&state, &index)
+    .await?
+    .ok_or_else(|| {
+      ESError::not_found(
+        "index_not_found_exception",
+        format!("no such index [{index}]"),
+      )
+    })?;
+  Ok(Json(settings_payload(&resolved)))
 }
 
 pub async fn aliases(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>> {
@@ -205,6 +235,43 @@ async fn get_mapping_for(state: &Arc<AppState>, index: &str) -> ESResult<Value> 
       )
     })?;
   Ok(schema_to_es(index, schema)?)
+}
+
+/// Resolve `name` to the concrete target index it refers to.
+///
+/// - If `name` is a real index, returns `Some(name)`.
+/// - If `name` is an alias, returns `Some(<target index name>)`.
+/// - Otherwise returns `None`.
+async fn resolve_index_or_alias(state: &Arc<AppState>, name: &str) -> ESResult<Option<String>> {
+  let listing = state.client().list_indexes().await?;
+  let is_real_index = listing
+    .get("indexes")
+    .and_then(Value::as_array)
+    .map(|items| {
+      items
+        .iter()
+        .any(|item| item.get("name").and_then(Value::as_str) == Some(name))
+    })
+    .unwrap_or(false);
+  if is_real_index {
+    return Ok(Some(name.to_string()));
+  }
+  let target = listing
+    .get("aliases")
+    .and_then(Value::as_array)
+    .and_then(|items| {
+      items.iter().find_map(|item| {
+        if item.get("alias").and_then(Value::as_str) == Some(name) {
+          item
+            .get("target")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+        } else {
+          None
+        }
+      })
+    });
+  Ok(target)
 }
 
 async fn index_exists(state: &Arc<AppState>, index: &str) -> ESResult<bool> {

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -274,6 +274,16 @@ async fn get_mapping_for(state: &Arc<AppState>, index: &str) -> ESResult<Value> 
 /// - If `name` is a real index, returns `Some(name)`.
 /// - If `name` is an alias, returns `Some(<target index name>)`.
 /// - Otherwise returns `None`.
+///
+/// Returns a single target deliberately. The upstream `searchlite-http`
+/// stores aliases as a `HashMap<String, String>` and rejects duplicate
+/// alias names at startup (`searchlite-http/src/lib.rs::IndexRegistry::from_args`),
+/// so an alias can refer to at most one target index. The `find_map` over
+/// `aliases[*]` below is correct under that contract — at most one entry
+/// can match a given alias name. If the upstream ever loosens to N:1
+/// fan-out (matching real Elasticsearch's alias semantics), `_mapping`,
+/// `_settings`, and `get_index` would need to fan out across all targets
+/// rather than picking one.
 pub(crate) async fn resolve_index_or_alias(
   state: &Arc<AppState>,
   name: &str,

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -31,24 +31,45 @@ pub async fn get_index(
   State(state): State<Arc<AppState>>,
   Path(index): Path<String>,
 ) -> ESResult<Json<Value>> {
-  let mapping = get_mapping_for(&state, &index).await?;
-  let settings = settings_payload(&index);
+  // Resolve aliases up front so the response is keyed by the concrete
+  // target index, matching ES semantics for alias-based requests.
+  let resolved = resolve_index_or_alias(&state, &index)
+    .await?
+    .ok_or_else(|| {
+      ESError::not_found(
+        "index_not_found_exception",
+        format!("no such index [{index}]"),
+      )
+    })?;
+
+  let mapping = get_mapping_for(&state, &resolved).await?;
   let mappings = mapping
-    .get(&index)
+    .get(&resolved)
     .and_then(|v| v.get("mappings"))
     .cloned()
     .unwrap_or_else(|| json!({ "properties": {} }));
+  let settings = settings_payload(&resolved);
   let settings_value = settings
-    .get(&index)
+    .get(&resolved)
     .and_then(|v| v.get("settings"))
+    .cloned()
+    .unwrap_or_else(|| json!({}));
+
+  // Surface the actual aliases pointing at the resolved target instead of
+  // a hard-coded empty object, so management / discovery flows see the
+  // real topology.
+  let aliases_map = aliases_by_index(&state).await?;
+  let aliases_for_target = aliases_map
+    .get(&resolved)
+    .and_then(|entry| entry.get("aliases"))
     .cloned()
     .unwrap_or_else(|| json!({}));
 
   let mut payload = serde_json::Map::new();
   payload.insert(
-    index,
+    resolved,
     json!({
-      "aliases": {},
+      "aliases": aliases_for_target,
       "mappings": mappings,
       "settings": settings_value,
     }),
@@ -60,7 +81,18 @@ pub async fn get_mapping(
   State(state): State<Arc<AppState>>,
   Path(index): Path<String>,
 ) -> ESResult<Json<Value>> {
-  Ok(Json(get_mapping_for(&state, &index).await?))
+  // Resolve aliases here for parity with HEAD /{index} and
+  // GET /{index}/_settings — calling with an alias name should return the
+  // target's mapping keyed by the target.
+  let resolved = resolve_index_or_alias(&state, &index)
+    .await?
+    .ok_or_else(|| {
+      ESError::not_found(
+        "index_not_found_exception",
+        format!("no such index [{index}]"),
+      )
+    })?;
+  Ok(Json(get_mapping_for(&state, &resolved).await?))
 }
 
 pub async fn mapping_all(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>> {

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -274,7 +274,10 @@ async fn get_mapping_for(state: &Arc<AppState>, index: &str) -> ESResult<Value> 
 /// - If `name` is a real index, returns `Some(name)`.
 /// - If `name` is an alias, returns `Some(<target index name>)`.
 /// - Otherwise returns `None`.
-async fn resolve_index_or_alias(state: &Arc<AppState>, name: &str) -> ESResult<Option<String>> {
+pub(crate) async fn resolve_index_or_alias(
+  state: &Arc<AppState>,
+  name: &str,
+) -> ESResult<Option<String>> {
   let listing = state.client().list_indexes().await?;
   let is_real_index = listing
     .get("indexes")

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -96,8 +96,16 @@ pub async fn aliases(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>
     .unwrap_or_default();
   let mut by_index: serde_json::Map<String, Value> = serde_json::Map::new();
   for alias in aliases {
-    let alias_name = alias.get("alias").and_then(Value::as_str).unwrap_or("").to_string();
-    let target = alias.get("target").and_then(Value::as_str).unwrap_or("").to_string();
+    let alias_name = alias
+      .get("alias")
+      .and_then(Value::as_str)
+      .unwrap_or("")
+      .to_string();
+    let target = alias
+      .get("target")
+      .and_then(Value::as_str)
+      .unwrap_or("")
+      .to_string();
     if alias_name.is_empty() || target.is_empty() {
       continue;
     }
@@ -167,4 +175,3 @@ async fn index_exists(state: &Arc<AppState>, index: &str) -> ESResult<bool> {
     .unwrap_or(false);
   Ok(alias_match)
 }
-

--- a/searchlite-adapter-elastic/src/routes/indices.rs
+++ b/searchlite-adapter-elastic/src/routes/indices.rs
@@ -80,14 +80,71 @@ pub async fn mapping_all(State(state): State<Arc<AppState>>) -> ESResult<Json<Va
 }
 
 pub async fn get_settings(
-  State(_state): State<Arc<AppState>>,
+  State(state): State<Arc<AppState>>,
   Path(index): Path<String>,
-) -> Json<Value> {
-  Json(settings_payload(&index))
+) -> ESResult<Json<Value>> {
+  if !index_exists(&state, &index).await? {
+    return Err(ESError::not_found(
+      "index_not_found_exception",
+      format!("no such index [{index}]"),
+    ));
+  }
+  Ok(Json(settings_payload(&index)))
 }
 
 pub async fn aliases(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>> {
-  // Best-effort: resolve aliases from upstream listing if available.
+  Ok(Json(Value::Object(aliases_by_index(&state).await?)))
+}
+
+/// Index-scoped alias endpoint (`GET /{index}/_aliases`,
+/// `GET /{index}/_alias`). Three cases, matching Elasticsearch:
+///
+/// 1. `{index}` is an index with aliases pointing at it → return that entry
+/// 2. `{index}` is an index with no aliases → return `{<index>: {aliases: {}}}`
+/// 3. `{index}` is an alias name → return `{<target>: {aliases: {<index>: {}}}}`
+///
+/// 404 only when `{index}` resolves neither as an index nor as an alias.
+pub async fn aliases_for_index(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+) -> ESResult<Json<Value>> {
+  if !index_exists(&state, &index).await? {
+    return Err(ESError::not_found(
+      "index_not_found_exception",
+      format!("no such index [{index}]"),
+    ));
+  }
+  let all = aliases_by_index(&state).await?;
+  let mut filtered = serde_json::Map::new();
+
+  if let Some(entry) = all.get(&index) {
+    filtered.insert(index.clone(), entry.clone());
+    return Ok(Json(Value::Object(filtered)));
+  }
+
+  // `{index}` may be an alias name itself — find the index it targets.
+  let mut found_as_alias = false;
+  for (target, entry) in &all {
+    if let Some(aliases) = entry.get("aliases").and_then(Value::as_object) {
+      if aliases.contains_key(&index) {
+        let mut narrowed = serde_json::Map::new();
+        narrowed.insert(index.clone(), json!({}));
+        filtered.insert(target.clone(), json!({ "aliases": narrowed }));
+        found_as_alias = true;
+      }
+    }
+  }
+
+  if !found_as_alias {
+    // Index exists but has no aliases — ES returns an empty alias entry.
+    filtered.insert(index.clone(), json!({ "aliases": {} }));
+  }
+  Ok(Json(Value::Object(filtered)))
+}
+
+/// Build the `{ <index>: { aliases: { <alias>: {} } } }` map from upstream's
+/// alias listing. Shared between the global and index-scoped handlers.
+async fn aliases_by_index(state: &Arc<AppState>) -> ESResult<serde_json::Map<String, Value>> {
   let listing = state.client().list_indexes().await?;
   let aliases = listing
     .get("aliases")
@@ -116,7 +173,7 @@ pub async fn aliases(State(state): State<Arc<AppState>>) -> ESResult<Json<Value>
       map.insert(alias_name, json!({}));
     }
   }
-  Ok(Json(Value::Object(by_index)))
+  Ok(by_index)
 }
 
 pub fn settings_payload(index: &str) -> Value {

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -41,6 +41,11 @@ pub async fn mget_global(
     .ok_or_else(|| ESError::bad_request("x_content_parse_exception", "missing `docs` array"))?
     .clone();
 
+  // Honor top-level `_source` so global `_mget` matches the index-scoped
+  // form's behaviour. Without this the upstream always returned stored
+  // fields even when the caller asked for `_source: false`.
+  let return_stored = wants_source(&body);
+
   // Track requested order so we re-emit in the original sequence.
   let mut grouped: BTreeMap<String, Vec<(usize, String)>> = BTreeMap::new();
   for (idx, doc) in docs.iter().enumerate() {
@@ -73,7 +78,10 @@ pub async fn mget_global(
     let ids: Vec<String> = entries.iter().map(|(_, id)| id.clone()).collect();
     let upstream = state
       .client()
-      .mget(&index, &json!({ "ids": &ids, "return_stored": true }))
+      .mget(
+        &index,
+        &json!({ "ids": &ids, "return_stored": return_stored }),
+      )
       .await?;
     let translated = translate_mget_response(&index, &upstream);
     let docs_arr = translated

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -89,6 +89,21 @@ pub async fn mget_global(
       .and_then(Value::as_array)
       .cloned()
       .unwrap_or_default();
+    // Defense-in-depth: ES `_mget` guarantees one response entry per
+    // requested id. If the upstream ever returns a different number we'd
+    // silently drop trailing entries (or extras) when zipping; surface that
+    // as a 502 so clients see the protocol violation instead of a malformed
+    // response. Mirrors the equivalent check in `msearch` upstream-results.
+    if docs_arr.len() != entries.len() {
+      return Err(ESError::bad_gateway(
+        "internal_server_error",
+        format!(
+          "upstream mget for index `{index}` returned {} docs for {} requested ids",
+          docs_arr.len(),
+          entries.len()
+        ),
+      ));
+    }
     for ((position, _), translated_doc) in entries.into_iter().zip(docs_arr.into_iter()) {
       by_position.insert(position, translated_doc);
     }

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -1,0 +1,171 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::{json, Map, Value};
+
+use crate::error::{ESError, ESResult};
+use crate::state::AppState;
+
+/// `POST /{index}/_mget` — accepts `{ ids: [...] }` or `{ docs: [{_id, _source?}] }`.
+pub async fn mget(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+  Json(body): Json<Value>,
+) -> ESResult<Json<Value>> {
+  let ids = collect_ids(&body, &index)?;
+  if ids.is_empty() {
+    return Ok(Json(json!({ "docs": [] })));
+  }
+  let return_stored = wants_source(&body);
+  let upstream = state
+    .client()
+    .mget(
+      &index,
+      &json!({ "ids": ids, "return_stored": return_stored }),
+    )
+    .await?;
+  Ok(Json(translate_mget_response(&index, &upstream)))
+}
+
+/// `POST /_mget` — body has `docs: [{_index, _id}]`. We group by index and
+/// dispatch one upstream call per group, then re-merge in request order.
+pub async fn mget_global(
+  State(state): State<Arc<AppState>>,
+  Json(body): Json<Value>,
+) -> ESResult<Json<Value>> {
+  let docs = body
+    .get("docs")
+    .and_then(Value::as_array)
+    .ok_or_else(|| ESError::bad_request("x_content_parse_exception", "missing `docs` array"))?
+    .clone();
+
+  // Track requested order so we re-emit in the original sequence.
+  let mut grouped: BTreeMap<String, Vec<(usize, String)>> = BTreeMap::new();
+  for (idx, doc) in docs.iter().enumerate() {
+    let map = doc.as_object().ok_or_else(|| {
+      ESError::bad_request("x_content_parse_exception", "each `docs` entry must be an object")
+    })?;
+    let index = map
+      .get("_index")
+      .and_then(Value::as_str)
+      .ok_or_else(|| {
+        ESError::bad_request("x_content_parse_exception", "missing `_index` in docs entry")
+      })?
+      .to_string();
+    let id = map
+      .get("_id")
+      .and_then(Value::as_str)
+      .ok_or_else(|| ESError::bad_request("x_content_parse_exception", "missing `_id`"))?
+      .to_string();
+    grouped.entry(index).or_default().push((idx, id));
+  }
+
+  let mut by_position: BTreeMap<usize, Value> = BTreeMap::new();
+  for (index, entries) in grouped {
+    let ids: Vec<String> = entries.iter().map(|(_, id)| id.clone()).collect();
+    let upstream = state
+      .client()
+      .mget(
+        &index,
+        &json!({ "ids": &ids, "return_stored": true }),
+      )
+      .await?;
+    let translated = translate_mget_response(&index, &upstream);
+    let docs_arr = translated
+      .get("docs")
+      .and_then(Value::as_array)
+      .cloned()
+      .unwrap_or_default();
+    for ((position, _), translated_doc) in entries.into_iter().zip(docs_arr.into_iter()) {
+      by_position.insert(position, translated_doc);
+    }
+  }
+
+  let merged: Vec<Value> = by_position.into_values().collect();
+  Ok(Json(json!({ "docs": merged })))
+}
+
+fn collect_ids(body: &Value, default_index: &str) -> ESResult<Vec<String>> {
+  if let Some(ids) = body.get("ids").and_then(Value::as_array) {
+    return Ok(
+      ids
+        .iter()
+        .filter_map(|v| v.as_str().map(str::to_string))
+        .collect(),
+    );
+  }
+  if let Some(docs) = body.get("docs").and_then(Value::as_array) {
+    let mut ids = Vec::with_capacity(docs.len());
+    for doc in docs {
+      let map = doc.as_object().ok_or_else(|| {
+        ESError::bad_request("x_content_parse_exception", "each `docs` entry must be an object")
+      })?;
+      if let Some(idx) = map.get("_index").and_then(Value::as_str) {
+        if idx != default_index {
+          return Err(ESError::bad_request(
+            "x_content_parse_exception",
+            format!("doc _index `{idx}` does not match request index `{default_index}`"),
+          ));
+        }
+      }
+      let id = map
+        .get("_id")
+        .and_then(Value::as_str)
+        .ok_or_else(|| ESError::bad_request("x_content_parse_exception", "missing `_id`"))?
+        .to_string();
+      ids.push(id);
+    }
+    return Ok(ids);
+  }
+  Err(ESError::bad_request(
+    "x_content_parse_exception",
+    "request must contain `ids` or `docs`",
+  ))
+}
+
+fn wants_source(body: &Value) -> bool {
+  match body.get("_source") {
+    Some(Value::Bool(b)) => *b,
+    Some(Value::Null) => false,
+    Some(_) => true,
+    None => true,
+  }
+}
+
+fn translate_mget_response(index: &str, upstream: &Value) -> Value {
+  let docs = upstream
+    .get("docs")
+    .and_then(Value::as_array)
+    .cloned()
+    .unwrap_or_default();
+  let translated: Vec<Value> = docs
+    .iter()
+    .map(|doc| translate_doc(index, doc))
+    .collect();
+  json!({ "docs": translated })
+}
+
+fn translate_doc(index: &str, doc: &Value) -> Value {
+  let map = doc.as_object();
+  let id = map
+    .and_then(|m| m.get("doc_id"))
+    .and_then(Value::as_str)
+    .unwrap_or("")
+    .to_string();
+  let found = map
+    .and_then(|m| m.get("found"))
+    .and_then(Value::as_bool)
+    .unwrap_or(false);
+  let source = map.and_then(|m| m.get("_source"));
+
+  let mut out = Map::new();
+  out.insert("_index".into(), Value::String(index.to_string()));
+  out.insert("_id".into(), Value::String(id));
+  out.insert("found".into(), Value::Bool(found));
+  if let Some(src) = source {
+    out.insert("_source".into(), src.clone());
+  }
+  Value::Object(out)
+}

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -45,13 +45,19 @@ pub async fn mget_global(
   let mut grouped: BTreeMap<String, Vec<(usize, String)>> = BTreeMap::new();
   for (idx, doc) in docs.iter().enumerate() {
     let map = doc.as_object().ok_or_else(|| {
-      ESError::bad_request("x_content_parse_exception", "each `docs` entry must be an object")
+      ESError::bad_request(
+        "x_content_parse_exception",
+        "each `docs` entry must be an object",
+      )
     })?;
     let index = map
       .get("_index")
       .and_then(Value::as_str)
       .ok_or_else(|| {
-        ESError::bad_request("x_content_parse_exception", "missing `_index` in docs entry")
+        ESError::bad_request(
+          "x_content_parse_exception",
+          "missing `_index` in docs entry",
+        )
       })?
       .to_string();
     let id = map
@@ -67,10 +73,7 @@ pub async fn mget_global(
     let ids: Vec<String> = entries.iter().map(|(_, id)| id.clone()).collect();
     let upstream = state
       .client()
-      .mget(
-        &index,
-        &json!({ "ids": &ids, "return_stored": true }),
-      )
+      .mget(&index, &json!({ "ids": &ids, "return_stored": true }))
       .await?;
     let translated = translate_mget_response(&index, &upstream);
     let docs_arr = translated
@@ -100,7 +103,10 @@ fn collect_ids(body: &Value, default_index: &str) -> ESResult<Vec<String>> {
     let mut ids = Vec::with_capacity(docs.len());
     for doc in docs {
       let map = doc.as_object().ok_or_else(|| {
-        ESError::bad_request("x_content_parse_exception", "each `docs` entry must be an object")
+        ESError::bad_request(
+          "x_content_parse_exception",
+          "each `docs` entry must be an object",
+        )
       })?;
       if let Some(idx) = map.get("_index").and_then(Value::as_str) {
         if idx != default_index {
@@ -140,10 +146,7 @@ fn translate_mget_response(index: &str, upstream: &Value) -> Value {
     .and_then(Value::as_array)
     .cloned()
     .unwrap_or_default();
-  let translated: Vec<Value> = docs
-    .iter()
-    .map(|doc| translate_doc(index, doc))
-    .collect();
+  let translated: Vec<Value> = docs.iter().map(|doc| translate_doc(index, doc)).collect();
   json!({ "docs": translated })
 }
 

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -6,6 +6,7 @@ use axum::Json;
 use serde_json::{json, Map, Value};
 
 use crate::error::{ESError, ESResult};
+use crate::routes::indices::resolve_index_or_alias;
 use crate::state::AppState;
 
 /// `POST /{index}/_mget` — accepts `{ ids: [...] }` or `{ docs: [{_id, _source?}] }`.
@@ -14,6 +15,16 @@ pub async fn mget(
   Path(index): Path<String>,
   Json(body): Json<Value>,
 ) -> ESResult<Json<Value>> {
+  // Resolve aliases so each returned doc carries `_index = <target>`,
+  // matching ES; previously responses echoed the alias path token.
+  let resolved = resolve_index_or_alias(&state, &index)
+    .await?
+    .ok_or_else(|| {
+      ESError::not_found(
+        "index_not_found_exception",
+        format!("no such index [{index}]"),
+      )
+    })?;
   let ids = collect_ids(&body, &index)?;
   if ids.is_empty() {
     return Ok(Json(json!({ "docs": [] })));
@@ -22,11 +33,11 @@ pub async fn mget(
   let upstream = state
     .client()
     .mget(
-      &index,
+      &resolved,
       &json!({ "ids": ids, "return_stored": return_stored }),
     )
     .await?;
-  Ok(Json(translate_mget_response(&index, &upstream)))
+  Ok(Json(translate_mget_response(&resolved, &upstream)))
 }
 
 /// `POST /_mget` — body has `docs: [{_index, _id}]`. We group by index and
@@ -46,7 +57,10 @@ pub async fn mget_global(
   // fields even when the caller asked for `_source: false`.
   let return_stored = wants_source(&body);
 
-  // Track requested order so we re-emit in the original sequence.
+  // Track requested order so we re-emit in the original sequence. Each
+  // doc's `_index` is resolved through the alias table so groups (and the
+  // `_index` stamping in the response) use the concrete target index, not
+  // whatever path token the caller supplied.
   let mut grouped: BTreeMap<String, Vec<(usize, String)>> = BTreeMap::new();
   for (idx, doc) in docs.iter().enumerate() {
     let map = doc.as_object().ok_or_else(|| {
@@ -55,16 +69,20 @@ pub async fn mget_global(
         "each `docs` entry must be an object",
       )
     })?;
-    let index = map
-      .get("_index")
-      .and_then(Value::as_str)
+    let raw_index = map.get("_index").and_then(Value::as_str).ok_or_else(|| {
+      ESError::bad_request(
+        "x_content_parse_exception",
+        "missing `_index` in docs entry",
+      )
+    })?;
+    let index = resolve_index_or_alias(&state, raw_index)
+      .await?
       .ok_or_else(|| {
-        ESError::bad_request(
-          "x_content_parse_exception",
-          "missing `_index` in docs entry",
+        ESError::not_found(
+          "index_not_found_exception",
+          format!("no such index [{raw_index}]"),
         )
-      })?
-      .to_string();
+      })?;
     let id = map
       .get("_id")
       .and_then(Value::as_str)

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -92,12 +92,21 @@ pub async fn mget_global(
 
 fn collect_ids(body: &Value, default_index: &str) -> ESResult<Vec<String>> {
   if let Some(ids) = body.get("ids").and_then(Value::as_array) {
-    return Ok(
-      ids
-        .iter()
-        .filter_map(|v| v.as_str().map(str::to_string))
-        .collect(),
-    );
+    // Reject non-string entries explicitly. Silently filtering them out makes
+    // malformed requests look like partial successes (fewer docs returned
+    // than requested), which violates the one-response-per-id contract that
+    // ES clients rely on.
+    return ids
+      .iter()
+      .map(|v| {
+        v.as_str().map(str::to_string).ok_or_else(|| {
+          ESError::bad_request(
+            "x_content_parse_exception",
+            "every entry in `ids` must be a string",
+          )
+        })
+      })
+      .collect::<Result<Vec<_>, _>>();
   }
   if let Some(docs) = body.get("docs").and_then(Value::as_array) {
     let mut ids = Vec::with_capacity(docs.len());

--- a/searchlite-adapter-elastic/src/routes/mget.rs
+++ b/searchlite-adapter-elastic/src/routes/mget.rs
@@ -107,21 +107,7 @@ pub async fn mget_global(
       .and_then(Value::as_array)
       .cloned()
       .unwrap_or_default();
-    // Defense-in-depth: ES `_mget` guarantees one response entry per
-    // requested id. If the upstream ever returns a different number we'd
-    // silently drop trailing entries (or extras) when zipping; surface that
-    // as a 502 so clients see the protocol violation instead of a malformed
-    // response. Mirrors the equivalent check in `msearch` upstream-results.
-    if docs_arr.len() != entries.len() {
-      return Err(ESError::bad_gateway(
-        "internal_server_error",
-        format!(
-          "upstream mget for index `{index}` returned {} docs for {} requested ids",
-          docs_arr.len(),
-          entries.len()
-        ),
-      ));
-    }
+    validate_mget_order(&index, &entries, &docs_arr)?;
     for ((position, _), translated_doc) in entries.into_iter().zip(docs_arr.into_iter()) {
       by_position.insert(position, translated_doc);
     }
@@ -200,6 +186,48 @@ fn translate_mget_response(index: &str, upstream: &Value) -> Value {
   json!({ "docs": translated })
 }
 
+/// Validate that an upstream mget response lines up with the requested
+/// positional batch.
+///
+/// Two checks, each surfaced as a 502 so callers see a clear protocol
+/// violation rather than receiving a wrong-doc-at-wrong-slot response:
+///
+/// 1. Length parity — ES `_mget` (and our upstream) guarantees one response
+///    entry per requested id; a mismatch would silently zip-truncate.
+/// 2. Per-position `_id` parity — even with matching length, an upstream
+///    that reordered docs would route the wrong source to each slot.
+///    `searchlite-core`'s `Reader::mget` preserves order today (and there's
+///    a regression test for it), but we don't want to bake that contract
+///    into the adapter without a verifier.
+fn validate_mget_order(
+  index: &str,
+  entries: &[(usize, String)],
+  docs_arr: &[Value],
+) -> ESResult<()> {
+  if docs_arr.len() != entries.len() {
+    return Err(ESError::bad_gateway(
+      "internal_server_error",
+      format!(
+        "upstream mget for index `{index}` returned {} docs for {} requested ids",
+        docs_arr.len(),
+        entries.len()
+      ),
+    ));
+  }
+  for (i, ((_, requested_id), doc)) in entries.iter().zip(docs_arr.iter()).enumerate() {
+    let actual = doc.get("_id").and_then(Value::as_str).unwrap_or("");
+    if actual != requested_id {
+      return Err(ESError::bad_gateway(
+        "internal_server_error",
+        format!(
+          "upstream mget for index `{index}` returned out-of-order docs at position {i}: requested `{requested_id}`, got `{actual}`"
+        ),
+      ));
+    }
+  }
+  Ok(())
+}
+
 fn translate_doc(index: &str, doc: &Value) -> Value {
   let map = doc.as_object();
   let id = map
@@ -221,4 +249,81 @@ fn translate_doc(index: &str, doc: &Value) -> Value {
     out.insert("_source".into(), src.clone());
   }
   Value::Object(out)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use axum::http::StatusCode;
+
+  fn entries(ids: &[&str]) -> Vec<(usize, String)> {
+    ids
+      .iter()
+      .enumerate()
+      .map(|(i, id)| (i, (*id).to_string()))
+      .collect()
+  }
+
+  fn doc(id: &str) -> Value {
+    json!({ "_index": "demo", "_id": id, "found": true })
+  }
+
+  #[test]
+  fn validate_mget_order_accepts_matching_length_and_order() {
+    let req = entries(&["a", "b", "c"]);
+    let resp = vec![doc("a"), doc("b"), doc("c")];
+    assert!(validate_mget_order("demo", &req, &resp).is_ok());
+  }
+
+  #[test]
+  fn validate_mget_order_rejects_length_mismatch_with_502() {
+    // Pre-existing length check; pinned here so a refactor of the helper
+    // can't silently regress to a positional zip without parity.
+    let req = entries(&["a", "b", "c"]);
+    let resp = vec![doc("a"), doc("b")];
+    let err = validate_mget_order("demo", &req, &resp).expect_err("should fail");
+    assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+    assert!(
+      err.reason.contains("returned 2 docs for 3 requested"),
+      "reason: {}",
+      err.reason
+    );
+  }
+
+  #[test]
+  fn validate_mget_order_rejects_per_position_id_mismatch_with_502() {
+    // Defense-in-depth: even when lengths match, a reordered upstream
+    // response would route the wrong document into each requested slot.
+    // Surface as a clear 502 so the caller doesn't act on misrouted data.
+    let req = entries(&["a", "b", "c"]);
+    let resp = vec![doc("a"), doc("c"), doc("b")];
+    let err = validate_mget_order("demo", &req, &resp).expect_err("should fail");
+    assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+    assert!(
+      err.reason.contains("position 1"),
+      "reason should pinpoint the slot, got: {}",
+      err.reason
+    );
+    assert!(
+      err.reason.contains("requested `b`"),
+      "reason should name the requested id, got: {}",
+      err.reason
+    );
+    assert!(
+      err.reason.contains("got `c`"),
+      "reason should name the returned id, got: {}",
+      err.reason
+    );
+  }
+
+  #[test]
+  fn validate_mget_order_rejects_doc_with_missing_id_field() {
+    // A doc missing `_id` (e.g. an upstream that drops the field on a
+    // not-found doc) should fail validation — the `_id` is what we use to
+    // verify positional routing, so an absent value can't be trusted.
+    let req = entries(&["a"]);
+    let resp = vec![json!({ "_index": "demo", "found": false })];
+    let err = validate_mget_order("demo", &req, &resp).expect_err("should fail");
+    assert_eq!(err.status, StatusCode::BAD_GATEWAY);
+  }
 }

--- a/searchlite-adapter-elastic/src/routes/mod.rs
+++ b/searchlite-adapter-elastic/src/routes/mod.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use axum::routing::{any, get, head, post, put};
+use axum::Router;
+
+use crate::state::AppState;
+
+pub mod cluster;
+pub mod indices;
+pub mod mget;
+pub mod msearch;
+pub mod reject;
+pub mod search;
+
+pub fn router(state: Arc<AppState>) -> Router {
+  Router::new()
+    .route("/", get(cluster::root))
+    .route("/_cluster/health", get(cluster::cluster_health))
+    .route("/_cluster/state", get(cluster::cluster_state))
+    .route("/_nodes", get(cluster::nodes))
+    .route("/_nodes/stats", get(cluster::nodes))
+    .route("/_mapping", get(indices::mapping_all))
+    .route(
+      "/_search",
+      post(reject::cross_index_search).get(reject::cross_index_search),
+    )
+    .route("/_msearch", post(msearch::msearch))
+    .route("/_mget", post(mget::mget_global))
+    .route("/_bulk", post(reject::write_not_supported))
+    .route(
+      "/_aliases",
+      post(reject::write_not_supported).get(indices::aliases),
+    )
+    .route(
+      "/{index}",
+      head(indices::head_index)
+        .get(indices::get_index)
+        .post(reject::write_not_supported)
+        .put(reject::write_not_supported)
+        .delete(reject::write_not_supported),
+    )
+    .route(
+      "/{index}/_mapping",
+      get(indices::get_mapping).put(reject::write_not_supported),
+    )
+    .route("/{index}/_settings", get(indices::get_settings))
+    .route("/{index}/_aliases", get(indices::aliases))
+    .route("/{index}/_alias", get(indices::aliases))
+    .route(
+      "/{index}/_search",
+      post(search::search).get(search::search),
+    )
+    .route("/{index}/_count", post(search::count).get(search::count))
+    .route("/{index}/_mget", post(mget::mget))
+    .route("/{index}/_msearch", post(msearch::msearch))
+    .route("/{index}/_refresh", any(reject::write_not_supported))
+    .route("/{index}/_bulk", post(reject::write_not_supported))
+    .route(
+      "/{index}/_doc",
+      post(reject::write_not_supported).put(reject::write_not_supported),
+    )
+    .route(
+      "/{index}/_doc/{id}",
+      post(reject::write_not_supported)
+        .put(reject::write_not_supported)
+        .delete(reject::write_not_supported)
+        .get(reject::doc_get_not_supported),
+    )
+    .route("/{index}/_update/{id}", post(reject::write_not_supported))
+    .route(
+      "/{index}/_create/{id}",
+      put(reject::write_not_supported).post(reject::write_not_supported),
+    )
+    .route(
+      "/{index}/_delete_by_query",
+      post(reject::write_not_supported),
+    )
+    .route(
+      "/{index}/_update_by_query",
+      post(reject::write_not_supported),
+    )
+    .with_state(state)
+}

--- a/searchlite-adapter-elastic/src/routes/mod.rs
+++ b/searchlite-adapter-elastic/src/routes/mod.rs
@@ -44,8 +44,8 @@ pub fn router(state: Arc<AppState>) -> Router {
       get(indices::get_mapping).put(reject::write_not_supported),
     )
     .route("/{index}/_settings", get(indices::get_settings))
-    .route("/{index}/_aliases", get(indices::aliases))
-    .route("/{index}/_alias", get(indices::aliases))
+    .route("/{index}/_aliases", get(indices::aliases_for_index))
+    .route("/{index}/_alias", get(indices::aliases_for_index))
     .route("/{index}/_search", post(search::search).get(search::search))
     .route("/{index}/_count", post(search::count).get(search::count))
     .route("/{index}/_mget", post(mget::mget))

--- a/searchlite-adapter-elastic/src/routes/mod.rs
+++ b/searchlite-adapter-elastic/src/routes/mod.rs
@@ -46,10 +46,7 @@ pub fn router(state: Arc<AppState>) -> Router {
     .route("/{index}/_settings", get(indices::get_settings))
     .route("/{index}/_aliases", get(indices::aliases))
     .route("/{index}/_alias", get(indices::aliases))
-    .route(
-      "/{index}/_search",
-      post(search::search).get(search::search),
-    )
+    .route("/{index}/_search", post(search::search).get(search::search))
     .route("/{index}/_count", post(search::count).get(search::count))
     .route("/{index}/_mget", post(mget::mget))
     .route("/{index}/_msearch", post(msearch::msearch))

--- a/searchlite-adapter-elastic/src/routes/msearch.rs
+++ b/searchlite-adapter-elastic/src/routes/msearch.rs
@@ -45,7 +45,10 @@ pub async fn msearch(
       "searches": searches,
       "parallel": true,
     });
-    let upstream = state.client().multi_search(&index, &upstream_request).await?;
+    let upstream = state
+      .client()
+      .multi_search(&index, &upstream_request)
+      .await?;
     let results = upstream
       .get("results")
       .and_then(Value::as_array)
@@ -106,7 +109,10 @@ fn parse_msearch_ndjson(body: &[u8], default_index: Option<&str>) -> ESResult<Ve
       )
     })?;
     let index = pick_index(&header_value, default_index)?;
-    entries.push(MSearchEntry { index, body: body_value });
+    entries.push(MSearchEntry {
+      index,
+      body: body_value,
+    });
   }
   Ok(entries)
 }
@@ -132,7 +138,7 @@ fn pick_index(header: &Value, default_index: Option<&str>) -> ESResult<String> {
       }
     }
   }
-  default_index
-    .map(str::to_string)
-    .ok_or_else(|| ESError::bad_request("x_content_parse_exception", "msearch entry missing `index`"))
+  default_index.map(str::to_string).ok_or_else(|| {
+    ESError::bad_request("x_content_parse_exception", "msearch entry missing `index`")
+  })
 }

--- a/searchlite-adapter-elastic/src/routes/msearch.rs
+++ b/searchlite-adapter-elastic/src/routes/msearch.rs
@@ -64,8 +64,12 @@ pub async fn msearch(
         ),
       ));
     }
-    for ((position, _), result) in group.into_iter().zip(results.into_iter()) {
-      let translated = translate_search_response(&index, &result, 0);
+    for ((position, body), result) in group.into_iter().zip(results.into_iter()) {
+      // Each msearch entry can carry its own track_total_hits. Extract it
+      // from the original ES body so per-response total semantics match
+      // what the caller asked for.
+      let track = extract_track_total_hits(&body);
+      let translated = translate_search_response(&index, &result, 0, track);
       by_position.insert(position, translated);
     }
   }
@@ -81,6 +85,18 @@ pub async fn msearch(
 struct MSearchEntry {
   index: String,
   body: Value,
+}
+
+/// Per-entry equivalent of the search route's helper. Maps the ES request's
+/// `track_total_hits` flag to the Some/None contract used by the response
+/// translator.
+fn extract_track_total_hits(body: &Value) -> Option<bool> {
+  let value = body.as_object()?.get("track_total_hits")?;
+  match value {
+    Value::Bool(b) => Some(*b),
+    Value::Number(n) => n.as_u64().map(|cap| cap > 0),
+    _ => None,
+  }
 }
 
 fn parse_msearch_ndjson(body: &[u8], default_index: Option<&str>) -> ESResult<Vec<MSearchEntry>> {

--- a/searchlite-adapter-elastic/src/routes/msearch.rs
+++ b/searchlite-adapter-elastic/src/routes/msearch.rs
@@ -86,7 +86,11 @@ struct MSearchEntry {
 fn parse_msearch_ndjson(body: &[u8], default_index: Option<&str>) -> ESResult<Vec<MSearchEntry>> {
   let text = std::str::from_utf8(body)
     .map_err(|_| ESError::bad_request("x_content_parse_exception", "msearch body must be UTF-8"))?;
-  let lines: Vec<&str> = text.split('\n').filter(|l| !l.trim().is_empty()).collect();
+  // `str::lines()` strips both `\n` and `\r\n` per line, so CRLF-delimited
+  // NDJSON (common from Windows clients and some HTTP proxies) parses
+  // correctly. Plain `split('\n')` would leave a trailing `\r` that breaks
+  // serde_json::from_str on every line.
+  let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
   if !lines.len().is_multiple_of(2) {
     return Err(ESError::bad_request(
       "x_content_parse_exception",

--- a/searchlite-adapter-elastic/src/routes/msearch.rs
+++ b/searchlite-adapter-elastic/src/routes/msearch.rs
@@ -8,8 +8,11 @@ use axum::Json;
 use serde_json::{json, Value};
 
 use crate::error::{ESError, ESResult};
+use crate::routes::indices::resolve_index_or_alias;
 use crate::state::AppState;
-use crate::translate::{translate_search_body, translate_search_response};
+use crate::translate::{
+  extract_agg_meta, inject_agg_meta, translate_search_body, translate_search_response,
+};
 
 /// `POST /_msearch` (and `POST /{index}/_msearch`) — NDJSON of alternating
 /// header + body lines. Header may include `index` (string or array);
@@ -25,11 +28,21 @@ pub async fn msearch(
     return Ok(Json(json!({ "took": 0, "responses": [] })));
   }
 
-  // Group by index, preserving the original request order.
+  // Group by RESOLVED index name. Each entry's `index` may be an alias —
+  // resolving it here means downstream calls (and the `_index` stamping in
+  // the response via translate_search_response) use the concrete target.
   let mut grouped: BTreeMap<String, Vec<(usize, Value)>> = BTreeMap::new();
   for (idx, entry) in entries.iter().enumerate() {
+    let resolved = resolve_index_or_alias(&state, &entry.index)
+      .await?
+      .ok_or_else(|| {
+        ESError::not_found(
+          "index_not_found_exception",
+          format!("no such index [{}]", entry.index),
+        )
+      })?;
     grouped
-      .entry(entry.index.clone())
+      .entry(resolved)
       .or_default()
       .push((idx, entry.body.clone()));
   }
@@ -65,11 +78,18 @@ pub async fn msearch(
       ));
     }
     for ((position, body), result) in group.into_iter().zip(results.into_iter()) {
-      // Each msearch entry can carry its own track_total_hits. Extract it
-      // from the original ES body so per-response total semantics match
-      // what the caller asked for.
+      // Each msearch entry can carry its own track_total_hits and per-agg
+      // meta. Extract both before translation and re-inject meta after, so
+      // per-response semantics match what the caller asked for.
       let track = extract_track_total_hits(&body);
-      let translated = translate_search_response(&index, &result, 0, track);
+      let agg_meta = body
+        .get("aggs")
+        .or_else(|| body.get("aggregations"))
+        .and_then(Value::as_object)
+        .map(extract_agg_meta)
+        .unwrap_or_default();
+      let mut translated = translate_search_response(&index, &result, 0, track);
+      inject_agg_meta(&mut translated, &agg_meta);
       by_position.insert(position, translated);
     }
   }

--- a/searchlite-adapter-elastic/src/routes/msearch.rs
+++ b/searchlite-adapter-elastic/src/routes/msearch.rs
@@ -1,0 +1,138 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::body::Bytes;
+use axum::extract::{Path, State};
+use axum::Json;
+use serde_json::{json, Value};
+
+use crate::error::{ESError, ESResult};
+use crate::state::AppState;
+use crate::translate::{translate_search_body, translate_search_response};
+
+/// `POST /_msearch` (and `POST /{index}/_msearch`) — NDJSON of alternating
+/// header + body lines. Header may include `index` (string or array);
+/// requests without an explicit index inherit the path index, if any.
+pub async fn msearch(
+  State(state): State<Arc<AppState>>,
+  index: Option<Path<String>>,
+  body: Bytes,
+) -> ESResult<Json<Value>> {
+  let default_index = index.map(|Path(i)| i);
+  let entries = parse_msearch_ndjson(&body, default_index.as_deref())?;
+  if entries.is_empty() {
+    return Ok(Json(json!({ "took": 0, "responses": [] })));
+  }
+
+  // Group by index, preserving the original request order.
+  let mut grouped: BTreeMap<String, Vec<(usize, Value)>> = BTreeMap::new();
+  for (idx, entry) in entries.iter().enumerate() {
+    grouped
+      .entry(entry.index.clone())
+      .or_default()
+      .push((idx, entry.body.clone()));
+  }
+
+  let started = Instant::now();
+  let mut by_position: BTreeMap<usize, Value> = BTreeMap::new();
+  for (index, group) in grouped {
+    let searches: Vec<Value> = group
+      .iter()
+      .map(|(_, body)| translate_search_body(body))
+      .collect::<Result<Vec<_>, _>>()?;
+    let upstream_request = json!({
+      "searches": searches,
+      "parallel": true,
+    });
+    let upstream = state.client().multi_search(&index, &upstream_request).await?;
+    let results = upstream
+      .get("results")
+      .and_then(Value::as_array)
+      .cloned()
+      .unwrap_or_default();
+    if results.len() != group.len() {
+      return Err(ESError::bad_gateway(
+        "internal_server_error",
+        format!(
+          "upstream multi_search returned {} results for {} requested searches",
+          results.len(),
+          group.len()
+        ),
+      ));
+    }
+    for ((position, _), result) in group.into_iter().zip(results.into_iter()) {
+      let translated = translate_search_response(&index, &result, 0);
+      by_position.insert(position, translated);
+    }
+  }
+
+  let took_ms = started.elapsed().as_millis() as u64;
+  let responses: Vec<Value> = by_position.into_values().collect();
+  Ok(Json(json!({
+    "took": took_ms,
+    "responses": responses,
+  })))
+}
+
+struct MSearchEntry {
+  index: String,
+  body: Value,
+}
+
+fn parse_msearch_ndjson(body: &[u8], default_index: Option<&str>) -> ESResult<Vec<MSearchEntry>> {
+  let text = std::str::from_utf8(body)
+    .map_err(|_| ESError::bad_request("x_content_parse_exception", "msearch body must be UTF-8"))?;
+  let lines: Vec<&str> = text.split('\n').filter(|l| !l.trim().is_empty()).collect();
+  if !lines.len().is_multiple_of(2) {
+    return Err(ESError::bad_request(
+      "x_content_parse_exception",
+      "msearch ndjson must contain an even number of non-empty lines (header + body pairs)",
+    ));
+  }
+
+  let mut entries = Vec::with_capacity(lines.len() / 2);
+  for pair in lines.chunks(2) {
+    let header_value: Value = serde_json::from_str(pair[0]).map_err(|err| {
+      ESError::bad_request(
+        "x_content_parse_exception",
+        format!("invalid msearch header JSON: {err}"),
+      )
+    })?;
+    let body_value: Value = serde_json::from_str(pair[1]).map_err(|err| {
+      ESError::bad_request(
+        "x_content_parse_exception",
+        format!("invalid msearch body JSON: {err}"),
+      )
+    })?;
+    let index = pick_index(&header_value, default_index)?;
+    entries.push(MSearchEntry { index, body: body_value });
+  }
+  Ok(entries)
+}
+
+fn pick_index(header: &Value, default_index: Option<&str>) -> ESResult<String> {
+  if let Some(map) = header.as_object() {
+    if let Some(value) = map.get("index") {
+      match value {
+        Value::String(s) => return Ok(s.clone()),
+        Value::Array(items) => {
+          let names: Vec<&str> = items.iter().filter_map(Value::as_str).collect();
+          if names.len() == 1 {
+            return Ok(names[0].to_string());
+          }
+          if names.len() > 1 {
+            return Err(ESError::bad_request(
+              "illegal_argument_exception",
+              "multi-index msearch entries are not supported (single index per request)",
+            ));
+          }
+        }
+        _ => {}
+      }
+    }
+  }
+  default_index
+    .map(str::to_string)
+    .ok_or_else(|| ESError::bad_request("x_content_parse_exception", "msearch entry missing `index`"))
+}

--- a/searchlite-adapter-elastic/src/routes/msearch.rs
+++ b/searchlite-adapter-elastic/src/routes/msearch.rs
@@ -127,9 +127,24 @@ fn pick_index(header: &Value, default_index: Option<&str>) -> ESResult<String> {
       match value {
         Value::String(s) => return Ok(s.clone()),
         Value::Array(items) => {
-          let names: Vec<&str> = items.iter().filter_map(Value::as_str).collect();
+          // Validate every element. Silently dropping non-strings via
+          // filter_map could turn a malformed `["demo", 42]` into a
+          // single-index ("demo") request and route queries to an
+          // unintended index — fail loudly instead.
+          let mut names = Vec::with_capacity(items.len());
+          for item in items {
+            match item.as_str() {
+              Some(s) => names.push(s.to_string()),
+              None => {
+                return Err(ESError::bad_request(
+                  "x_content_parse_exception",
+                  format!("msearch entry `index` array contains non-string element: {item}"),
+                ));
+              }
+            }
+          }
           if names.len() == 1 {
-            return Ok(names[0].to_string());
+            return Ok(names.into_iter().next().unwrap());
           }
           if names.len() > 1 {
             return Err(ESError::bad_request(

--- a/searchlite-adapter-elastic/src/routes/reject.rs
+++ b/searchlite-adapter-elastic/src/routes/reject.rs
@@ -1,0 +1,28 @@
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+
+use crate::error::ESError;
+
+pub async fn write_not_supported() -> impl IntoResponse {
+  ESError::new(
+    StatusCode::BAD_REQUEST,
+    "not_supported_in_v1",
+    "write/DDL operations are not supported by the searchlite elasticsearch adapter (read-only v1)",
+  )
+}
+
+pub async fn doc_get_not_supported() -> impl IntoResponse {
+  ESError::new(
+    StatusCode::BAD_REQUEST,
+    "not_supported_in_v1",
+    "GET /_doc/{id} is not supported in v1; use POST /_search with a term query",
+  )
+}
+
+pub async fn cross_index_search() -> impl IntoResponse {
+  ESError::new(
+    StatusCode::BAD_REQUEST,
+    "illegal_argument_exception",
+    "cross-index search is not supported by the searchlite elasticsearch adapter; specify exactly one index in the path",
+  )
+}

--- a/searchlite-adapter-elastic/src/routes/search.rs
+++ b/searchlite-adapter-elastic/src/routes/search.rs
@@ -7,8 +7,11 @@ use serde::Deserialize;
 use serde_json::{json, Map, Value};
 
 use crate::error::{ESError, ESResult};
+use crate::routes::indices::resolve_index_or_alias;
 use crate::state::AppState;
-use crate::translate::{translate_search_body, translate_search_response};
+use crate::translate::{
+  extract_agg_meta, inject_agg_meta, translate_search_body, translate_search_response,
+};
 
 #[derive(Debug, Deserialize, Default)]
 pub struct SearchParams {
@@ -34,20 +37,37 @@ pub async fn search(
   Query(params): Query<SearchParams>,
   body: Option<Json<Value>>,
 ) -> ESResult<Json<Value>> {
+  // Resolve aliases up front so hits are stamped with the concrete target
+  // index name, matching ES. Without this, `_index` on each hit echoes the
+  // alias the caller used — and ES SDKs round-trip `_index` from search
+  // hits back into write requests, so the wrong-index drift is real.
+  let resolved = resolve_index_or_alias(&state, &index)
+    .await?
+    .ok_or_else(|| {
+      ESError::not_found(
+        "index_not_found_exception",
+        format!("no such index [{index}]"),
+      )
+    })?;
   let merged = merge_query_params_into_body(body.map(|Json(v)| v), &params)?;
   // Capture the caller's track_total_hits intent before translation so the
   // response can report exact-vs-approximate semantics correctly.
   let track = extract_track_total_hits(&merged);
+  // Capture each top-level agg's `meta` blob before translation so we can
+  // re-inject it into the response — SearchLite has no `meta` plumbing.
+  let agg_meta = merged
+    .get("aggs")
+    .or_else(|| merged.get("aggregations"))
+    .and_then(Value::as_object)
+    .map(extract_agg_meta)
+    .unwrap_or_default();
   let sl_body = translate_search_body(&merged)?;
   let started = Instant::now();
-  let sl_response = state.client().search(&index, &sl_body).await?;
+  let sl_response = state.client().search(&resolved, &sl_body).await?;
   let took_ms = started.elapsed().as_millis() as u64;
-  Ok(Json(translate_search_response(
-    &index,
-    &sl_response,
-    took_ms,
-    track,
-  )))
+  let mut response = translate_search_response(&resolved, &sl_response, took_ms, track);
+  inject_agg_meta(&mut response, &agg_meta);
+  Ok(Json(response))
 }
 
 pub async fn count(
@@ -56,13 +76,21 @@ pub async fn count(
   Query(params): Query<SearchParams>,
   body: Option<Json<Value>>,
 ) -> ESResult<Json<Value>> {
+  let resolved = resolve_index_or_alias(&state, &index)
+    .await?
+    .ok_or_else(|| {
+      ESError::not_found(
+        "index_not_found_exception",
+        format!("no such index [{index}]"),
+      )
+    })?;
   let mut merged = merge_query_params_into_body(body.map(|Json(v)| v), &params)?;
   if let Some(map) = merged.as_object_mut() {
     map.insert("size".into(), Value::from(0u64));
     map.insert("track_total_hits".into(), Value::Bool(true));
   }
   let sl_body = translate_search_body(&merged)?;
-  let sl_response = state.client().search(&index, &sl_body).await?;
+  let sl_response = state.client().search(&resolved, &sl_body).await?;
   let total = sl_response
     .get("total_hits_estimate")
     .and_then(Value::as_u64)

--- a/searchlite-adapter-elastic/src/routes/search.rs
+++ b/searchlite-adapter-elastic/src/routes/search.rs
@@ -35,6 +35,9 @@ pub async fn search(
   body: Option<Json<Value>>,
 ) -> ESResult<Json<Value>> {
   let merged = merge_query_params_into_body(body.map(|Json(v)| v), &params)?;
+  // Capture the caller's track_total_hits intent before translation so the
+  // response can report exact-vs-approximate semantics correctly.
+  let track = extract_track_total_hits(&merged);
   let sl_body = translate_search_body(&merged)?;
   let started = Instant::now();
   let sl_response = state.client().search(&index, &sl_body).await?;
@@ -43,6 +46,7 @@ pub async fn search(
     &index,
     &sl_response,
     took_ms,
+    track,
   )))
 }
 
@@ -67,6 +71,20 @@ pub async fn count(
     "count": total,
     "_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 },
   })))
+}
+
+/// Resolve the request's `track_total_hits` to the Some/None contract that
+/// `translate_search_response` expects:
+/// - boolean → that bool
+/// - integer N: > 0 → `Some(true)` (exact totals); 0 → `Some(false)`
+/// - missing or non-numeric/bool → `None` (default lower-bound semantics)
+fn extract_track_total_hits(body: &Value) -> Option<bool> {
+  let value = body.as_object()?.get("track_total_hits")?;
+  match value {
+    Value::Bool(b) => Some(*b),
+    Value::Number(n) => n.as_u64().map(|cap| cap > 0),
+    _ => None,
+  }
 }
 
 fn merge_query_params_into_body(body: Option<Value>, params: &SearchParams) -> ESResult<Value> {

--- a/searchlite-adapter-elastic/src/routes/search.rs
+++ b/searchlite-adapter-elastic/src/routes/search.rs
@@ -35,7 +35,11 @@ pub async fn search(
   let started = Instant::now();
   let sl_response = state.client().search(&index, &sl_body).await?;
   let took_ms = started.elapsed().as_millis() as u64;
-  Ok(Json(translate_search_response(&index, &sl_response, took_ms)))
+  Ok(Json(translate_search_response(
+    &index,
+    &sl_response,
+    took_ms,
+  )))
 }
 
 pub async fn count(
@@ -61,10 +65,7 @@ pub async fn count(
   })))
 }
 
-fn merge_query_params_into_body(
-  body: Option<Value>,
-  params: &SearchParams,
-) -> ESResult<Value> {
+fn merge_query_params_into_body(body: Option<Value>, params: &SearchParams) -> ESResult<Value> {
   let mut map = match body {
     Some(Value::Object(map)) => map,
     Some(Value::Null) | None => Map::new(),
@@ -85,10 +86,14 @@ fn merge_query_params_into_body(
     map.insert("query".into(), json!({ "query_string": Value::Object(qs) }));
   }
   if let Some(from) = params.from {
-    map.entry("from".to_string()).or_insert(Value::from(from as u64));
+    map
+      .entry("from".to_string())
+      .or_insert(Value::from(from as u64));
   }
   if let Some(size) = params.size {
-    map.entry("size".to_string()).or_insert(Value::from(size as u64));
+    map
+      .entry("size".to_string())
+      .or_insert(Value::from(size as u64));
   }
   if let Some(sort) = &params.sort {
     let parts: Vec<Value> = sort
@@ -105,17 +110,40 @@ fn merge_query_params_into_body(
     map.entry("sort".to_string()).or_insert(Value::Array(parts));
   }
   if let Some(track) = params.track_total_hits {
-    map.entry("track_total_hits".to_string())
+    map
+      .entry("track_total_hits".to_string())
       .or_insert(Value::Bool(track));
   }
   if let Some(source) = &params.source {
-    let parts: Vec<Value> = source
-      .split(',')
-      .filter(|s| !s.is_empty())
-      .map(|s| Value::String(s.trim().to_string()))
-      .collect();
-    if !parts.is_empty() {
-      map.entry("_source".to_string()).or_insert(Value::Array(parts));
+    let trimmed = source.trim();
+    // Match Elasticsearch's URL semantics for ?_source: bare booleans
+    // turn the source on/off entirely; otherwise treat as a comma-separated
+    // includes list. Without this, `?_source=false` would be interpreted as
+    // requesting a field literally called `false`.
+    match trimmed.to_ascii_lowercase().as_str() {
+      "true" => {
+        map
+          .entry("_source".to_string())
+          .or_insert(Value::Bool(true));
+      }
+      "false" => {
+        map
+          .entry("_source".to_string())
+          .or_insert(Value::Bool(false));
+      }
+      _ => {
+        let parts: Vec<Value> = trimmed
+          .split(',')
+          .map(str::trim)
+          .filter(|s| !s.is_empty())
+          .map(|s| Value::String(s.to_string()))
+          .collect();
+        if !parts.is_empty() {
+          map
+            .entry("_source".to_string())
+            .or_insert(Value::Array(parts));
+        }
+      }
     }
   }
   Ok(Value::Object(map))

--- a/searchlite-adapter-elastic/src/routes/search.rs
+++ b/searchlite-adapter-elastic/src/routes/search.rs
@@ -20,8 +20,12 @@ pub struct SearchParams {
   default_field: Option<String>,
   #[serde(rename = "_source")]
   source: Option<String>,
+  // String rather than bool so we accept ES's integer-cap form
+  // (e.g. `?track_total_hits=10000`) alongside `true`/`false`. Parsing into
+  // a JSON value happens in `merge_query_params_into_body`; downstream
+  // pagination already handles bool vs integer.
   #[serde(rename = "track_total_hits")]
-  track_total_hits: Option<bool>,
+  track_total_hits: Option<String>,
 }
 
 pub async fn search(
@@ -109,10 +113,24 @@ fn merge_query_params_into_body(body: Option<Value>, params: &SearchParams) -> E
       .collect();
     map.entry("sort".to_string()).or_insert(Value::Array(parts));
   }
-  if let Some(track) = params.track_total_hits {
-    map
-      .entry("track_total_hits".to_string())
-      .or_insert(Value::Bool(track));
+  if let Some(track) = &params.track_total_hits {
+    let trimmed = track.trim();
+    let value = match trimmed.to_ascii_lowercase().as_str() {
+      "true" => Value::Bool(true),
+      "false" => Value::Bool(false),
+      other => match other.parse::<u64>() {
+        Ok(n) => Value::from(n),
+        Err(_) => {
+          return Err(ESError::bad_request(
+            "x_content_parse_exception",
+            format!(
+              "track_total_hits must be `true`, `false`, or a non-negative integer, got `{trimmed}`"
+            ),
+          ));
+        }
+      },
+    };
+    map.entry("track_total_hits".to_string()).or_insert(value);
   }
   if let Some(source) = &params.source {
     let trimmed = source.trim();

--- a/searchlite-adapter-elastic/src/routes/search.rs
+++ b/searchlite-adapter-elastic/src/routes/search.rs
@@ -1,0 +1,122 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::extract::{Path, Query, State};
+use axum::Json;
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+
+use crate::error::{ESError, ESResult};
+use crate::state::AppState;
+use crate::translate::{translate_search_body, translate_search_response};
+
+#[derive(Debug, Deserialize, Default)]
+pub struct SearchParams {
+  q: Option<String>,
+  from: Option<usize>,
+  size: Option<usize>,
+  sort: Option<String>,
+  #[serde(rename = "df")]
+  default_field: Option<String>,
+  #[serde(rename = "_source")]
+  source: Option<String>,
+  #[serde(rename = "track_total_hits")]
+  track_total_hits: Option<bool>,
+}
+
+pub async fn search(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+  Query(params): Query<SearchParams>,
+  body: Option<Json<Value>>,
+) -> ESResult<Json<Value>> {
+  let merged = merge_query_params_into_body(body.map(|Json(v)| v), &params)?;
+  let sl_body = translate_search_body(&merged)?;
+  let started = Instant::now();
+  let sl_response = state.client().search(&index, &sl_body).await?;
+  let took_ms = started.elapsed().as_millis() as u64;
+  Ok(Json(translate_search_response(&index, &sl_response, took_ms)))
+}
+
+pub async fn count(
+  State(state): State<Arc<AppState>>,
+  Path(index): Path<String>,
+  Query(params): Query<SearchParams>,
+  body: Option<Json<Value>>,
+) -> ESResult<Json<Value>> {
+  let mut merged = merge_query_params_into_body(body.map(|Json(v)| v), &params)?;
+  if let Some(map) = merged.as_object_mut() {
+    map.insert("size".into(), Value::from(0u64));
+    map.insert("track_total_hits".into(), Value::Bool(true));
+  }
+  let sl_body = translate_search_body(&merged)?;
+  let sl_response = state.client().search(&index, &sl_body).await?;
+  let total = sl_response
+    .get("total_hits_estimate")
+    .and_then(Value::as_u64)
+    .unwrap_or(0);
+  Ok(Json(json!({
+    "count": total,
+    "_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 },
+  })))
+}
+
+fn merge_query_params_into_body(
+  body: Option<Value>,
+  params: &SearchParams,
+) -> ESResult<Value> {
+  let mut map = match body {
+    Some(Value::Object(map)) => map,
+    Some(Value::Null) | None => Map::new(),
+    Some(_) => {
+      return Err(ESError::bad_request(
+        "x_content_parse_exception",
+        "request body must be a JSON object",
+      ));
+    }
+  };
+
+  if let Some(q) = &params.q {
+    let mut qs = Map::new();
+    qs.insert("query".into(), Value::String(q.clone()));
+    if let Some(df) = &params.default_field {
+      qs.insert("default_field".into(), Value::String(df.clone()));
+    }
+    map.insert("query".into(), json!({ "query_string": Value::Object(qs) }));
+  }
+  if let Some(from) = params.from {
+    map.entry("from".to_string()).or_insert(Value::from(from as u64));
+  }
+  if let Some(size) = params.size {
+    map.entry("size".to_string()).or_insert(Value::from(size as u64));
+  }
+  if let Some(sort) = &params.sort {
+    let parts: Vec<Value> = sort
+      .split(',')
+      .filter(|s| !s.is_empty())
+      .map(|chunk| {
+        if let Some((field, order)) = chunk.split_once(':') {
+          json!({ field: { "order": order } })
+        } else {
+          Value::String(chunk.to_string())
+        }
+      })
+      .collect();
+    map.entry("sort".to_string()).or_insert(Value::Array(parts));
+  }
+  if let Some(track) = params.track_total_hits {
+    map.entry("track_total_hits".to_string())
+      .or_insert(Value::Bool(track));
+  }
+  if let Some(source) = &params.source {
+    let parts: Vec<Value> = source
+      .split(',')
+      .filter(|s| !s.is_empty())
+      .map(|s| Value::String(s.trim().to_string()))
+      .collect();
+    if !parts.is_empty() {
+      map.entry("_source".to_string()).or_insert(Value::Array(parts));
+    }
+  }
+  Ok(Value::Object(map))
+}

--- a/searchlite-adapter-elastic/src/routes/search.rs
+++ b/searchlite-adapter-elastic/src/routes/search.rs
@@ -118,12 +118,22 @@ fn merge_query_params_into_body(body: Option<Value>, params: &SearchParams) -> E
       .or_insert(Value::from(size as u64));
   }
   if let Some(sort) = &params.sort {
+    // Trim each comma-separated chunk, then trim around the optional `:`
+    // separator. Without this, common forms like `?sort=foo:desc, _score`
+    // produce a field literally named " _score" (leading space) and
+    // `?sort=foo : desc` carries trailing/leading whitespace into both
+    // field and order — both round-trip incorrectly to upstream.
     let parts: Vec<Value> = sort
       .split(',')
+      .map(str::trim)
       .filter(|s| !s.is_empty())
       .map(|chunk| {
         if let Some((field, order)) = chunk.split_once(':') {
-          json!({ field: { "order": order } })
+          let field = field.trim();
+          let order = order.trim();
+          let mut obj = serde_json::Map::new();
+          obj.insert(field.to_string(), json!({ "order": order }));
+          Value::Object(obj)
         } else {
           Value::String(chunk.to_string())
         }

--- a/searchlite-adapter-elastic/src/state.rs
+++ b/searchlite-adapter-elastic/src/state.rs
@@ -1,0 +1,24 @@
+use std::sync::Arc;
+
+use crate::client::SearchliteClient;
+use crate::AdapterArgs;
+
+#[derive(Clone)]
+pub struct AppState {
+  client: Arc<SearchliteClient>,
+  args: AdapterArgs,
+}
+
+impl AppState {
+  pub fn new(client: Arc<SearchliteClient>, args: AdapterArgs) -> Self {
+    Self { client, args }
+  }
+
+  pub fn client(&self) -> &SearchliteClient {
+    &self.client
+  }
+
+  pub fn args(&self) -> &AdapterArgs {
+    &self.args
+  }
+}

--- a/searchlite-adapter-elastic/src/translate/aggregation.rs
+++ b/searchlite-adapter-elastic/src/translate/aggregation.rs
@@ -5,6 +5,42 @@ use super::unsupported::Unsupported;
 
 const AGG_KEYS: [&str; 2] = ["aggs", "aggregations"];
 
+/// Walk a top-level ES `aggs`/`aggregations` map and collect each agg's
+/// `meta` blob keyed by the agg name. SearchLite has no `meta` plumbing, so
+/// the route handler stashes these and re-injects them into the response
+/// after translation. Only top-level agg metadata is captured in v1 — nested
+/// aggs would require recursive walking on both sides; tracked as a known
+/// limitation.
+pub fn extract_agg_meta(es_aggs: &Map<String, Value>) -> std::collections::BTreeMap<String, Value> {
+  let mut out = std::collections::BTreeMap::new();
+  for (name, spec) in es_aggs {
+    if let Some(meta) = spec.as_object().and_then(|m| m.get("meta")) {
+      out.insert(name.clone(), meta.clone());
+    }
+  }
+  out
+}
+
+/// Inject collected agg `meta` entries back into a translated ES response.
+/// Mutates `response.aggregations.<name>.meta` for each name in `meta`.
+pub fn inject_agg_meta(response: &mut Value, meta: &std::collections::BTreeMap<String, Value>) {
+  if meta.is_empty() {
+    return;
+  }
+  let Some(aggs) = response
+    .as_object_mut()
+    .and_then(|m| m.get_mut("aggregations"))
+    .and_then(Value::as_object_mut)
+  else {
+    return;
+  };
+  for (name, value) in meta {
+    if let Some(entry) = aggs.get_mut(name).and_then(Value::as_object_mut) {
+      entry.insert("meta".to_string(), value.clone());
+    }
+  }
+}
+
 /// Translate an ES `aggs`/`aggregations` map (name → spec) into SearchLite's
 /// agg map (name → tagged Aggregation JSON). Sub-aggregations recurse.
 pub fn translate_aggs(es_aggs: &Map<String, Value>) -> Result<Map<String, Value>, Unsupported> {

--- a/searchlite-adapter-elastic/src/translate/aggregation.rs
+++ b/searchlite-adapter-elastic/src/translate/aggregation.rs
@@ -68,11 +68,7 @@ fn translate_one_agg(name: &str, spec: &Map<String, Value>) -> Result<Value, Uns
         "use `stats` and read the corresponding field from the response",
       ))
     }
-    other => {
-      return Err(Unsupported::feature(format!(
-        "aggregations.{name}.{other}"
-      )))
-    }
+    other => return Err(Unsupported::feature(format!("aggregations.{name}.{other}"))),
   };
   Ok(translated)
 }
@@ -98,7 +94,10 @@ fn merge_sub(mut out: Map<String, Value>, sub: Option<Value>) -> Map<String, Val
 
 // --- terms ---------------------------------------------------------------
 
-fn translate_terms_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+fn translate_terms_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
   let field = require_field(body, "terms")?;
   let mut out = Map::new();
   out.insert("type".into(), Value::String("terms".into()));
@@ -160,7 +159,10 @@ fn translate_rare_terms_agg(
 
 // --- range / date_range -------------------------------------------------
 
-fn translate_range_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+fn translate_range_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
   let field = require_field(body, "range")?;
   let ranges = body
     .get("ranges")
@@ -195,7 +197,10 @@ fn translate_range_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<
   out.insert("field".into(), Value::String(field));
   out.insert("keyed".into(), Value::Bool(keyed));
   out.insert("ranges".into(), Value::Array(translated_ranges));
-  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "missing".into(),
+    body.get("missing").cloned().unwrap_or(Value::Null),
+  );
   Ok(Value::Object(merge_sub(out, sub)))
 }
 
@@ -215,8 +220,14 @@ fn translate_date_range_agg(
         Unsupported::with_detail("date_range.ranges", "each entry must be an object")
       })?;
       let mut entry = Map::new();
-      entry.insert("key".into(), r_obj.get("key").cloned().unwrap_or(Value::Null));
-      entry.insert("from".into(), r_obj.get("from").cloned().unwrap_or(Value::Null));
+      entry.insert(
+        "key".into(),
+        r_obj.get("key").cloned().unwrap_or(Value::Null),
+      );
+      entry.insert(
+        "from".into(),
+        r_obj.get("from").cloned().unwrap_or(Value::Null),
+      );
       entry.insert("to".into(), r_obj.get("to").cloned().unwrap_or(Value::Null));
       Ok(Value::Object(entry))
     })
@@ -226,9 +237,15 @@ fn translate_date_range_agg(
   out.insert("type".into(), Value::String("date_range".into()));
   out.insert("field".into(), Value::String(field));
   out.insert("keyed".into(), Value::Bool(keyed));
-  out.insert("format".into(), body.get("format").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "format".into(),
+    body.get("format").cloned().unwrap_or(Value::Null),
+  );
   out.insert("ranges".into(), Value::Array(translated_ranges));
-  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "missing".into(),
+    body.get("missing").cloned().unwrap_or(Value::Null),
+  );
   Ok(Value::Object(merge_sub(out, sub)))
 }
 
@@ -247,7 +264,10 @@ fn translate_histogram_agg(
   out.insert("type".into(), Value::String("histogram".into()));
   out.insert("field".into(), Value::String(field));
   out.insert("interval".into(), Value::from(interval));
-  out.insert("offset".into(), body.get("offset").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "offset".into(),
+    body.get("offset").cloned().unwrap_or(Value::Null),
+  );
   out.insert(
     "min_doc_count".into(),
     body.get("min_doc_count").cloned().unwrap_or(Value::Null),
@@ -260,7 +280,10 @@ fn translate_histogram_agg(
     "hard_bounds".into(),
     body.get("hard_bounds").cloned().unwrap_or(Value::Null),
   );
-  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "missing".into(),
+    body.get("missing").cloned().unwrap_or(Value::Null),
+  );
   Ok(Value::Object(merge_sub(out, sub)))
 }
 
@@ -274,14 +297,23 @@ fn translate_date_histogram_agg(
   out.insert("field".into(), Value::String(field));
   out.insert(
     "calendar_interval".into(),
-    body.get("calendar_interval").cloned().unwrap_or(Value::Null),
+    body
+      .get("calendar_interval")
+      .cloned()
+      .unwrap_or(Value::Null),
   );
   out.insert(
     "fixed_interval".into(),
     body.get("fixed_interval").cloned().unwrap_or(Value::Null),
   );
-  out.insert("offset".into(), body.get("offset").cloned().unwrap_or(Value::Null));
-  out.insert("format".into(), body.get("format").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "offset".into(),
+    body.get("offset").cloned().unwrap_or(Value::Null),
+  );
+  out.insert(
+    "format".into(),
+    body.get("format").cloned().unwrap_or(Value::Null),
+  );
   out.insert(
     "min_doc_count".into(),
     body.get("min_doc_count").cloned().unwrap_or(Value::Null),
@@ -294,7 +326,10 @@ fn translate_date_histogram_agg(
     "hard_bounds".into(),
     body.get("hard_bounds").cloned().unwrap_or(Value::Null),
   );
-  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "missing".into(),
+    body.get("missing").cloned().unwrap_or(Value::Null),
+  );
   Ok(Value::Object(merge_sub(out, sub)))
 }
 
@@ -311,7 +346,10 @@ fn translate_metric_agg(body: &Map<String, Value>, kind: &str) -> Result<Value, 
 
 fn translate_cardinality_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
   let field = require_field(body, "cardinality")?;
-  let precision = body.get("precision_threshold").cloned().unwrap_or(Value::Null);
+  let precision = body
+    .get("precision_threshold")
+    .cloned()
+    .unwrap_or(Value::Null);
   Ok(json!({
     "type": "cardinality",
     "field": field,
@@ -321,9 +359,10 @@ fn translate_cardinality_agg(body: &Map<String, Value>) -> Result<Value, Unsuppo
 
 fn translate_percentiles_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
   let field = require_field(body, "percentiles")?;
-  let percents = body.get("percents").cloned().unwrap_or_else(|| {
-    json!([1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0])
-  });
+  let percents = body
+    .get("percents")
+    .cloned()
+    .unwrap_or_else(|| json!([1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0]));
   Ok(json!({
     "type": "percentiles",
     "field": field,
@@ -351,7 +390,10 @@ fn translate_top_hits_agg(body: &Map<String, Value>) -> Result<Value, Unsupporte
   out.insert("type".into(), Value::String("top_hits".into()));
   out.insert("size".into(), Value::from(size));
   out.insert("from".into(), Value::from(from));
-  if let Some(fields) = body.get("_source").and_then(|v| v.as_object().and_then(|o| o.get("includes"))) {
+  if let Some(fields) = body
+    .get("_source")
+    .and_then(|v| v.as_object().and_then(|o| o.get("includes")))
+  {
     out.insert("fields".into(), fields.clone());
   } else if let Some(fields) = body.get("fields") {
     out.insert("fields".into(), fields.clone());
@@ -364,7 +406,10 @@ fn translate_top_hits_agg(body: &Map<String, Value>) -> Result<Value, Unsupporte
 
 // --- structural buckets --------------------------------------------------
 
-fn translate_filter_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+fn translate_filter_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
   let filter = translate_to_filter(&Value::Object(body.clone()))?;
   let mut out = Map::new();
   out.insert("type".into(), Value::String("filter".into()));
@@ -372,7 +417,10 @@ fn translate_filter_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result
   Ok(Value::Object(merge_sub(out, sub)))
 }
 
-fn translate_nested_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+fn translate_nested_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
   let path = body
     .get("path")
     .and_then(Value::as_str)
@@ -452,17 +500,26 @@ fn translate_composite_agg(
 fn translate_bucket_sort_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
   let mut out = Map::new();
   out.insert("type".into(), Value::String("bucket_sort".into()));
-  out.insert("from".into(), body.get("from").cloned().unwrap_or(Value::from(0u64)));
+  out.insert(
+    "from".into(),
+    body.get("from").cloned().unwrap_or(Value::from(0u64)),
+  );
   if let Some(size) = body.get("size") {
     out.insert("size".into(), size.clone());
   }
   if let Some(sort) = body.get("sort") {
-    out.insert("sort".into(), Value::Array(super::sort::translate_sort(sort)?));
+    out.insert(
+      "sort".into(),
+      Value::Array(super::sort::translate_sort(sort)?),
+    );
   }
   Ok(Value::Object(out))
 }
 
-fn translate_bucket_metric_agg(body: &Map<String, Value>, kind: &str) -> Result<Value, Unsupported> {
+fn translate_bucket_metric_agg(
+  body: &Map<String, Value>,
+  kind: &str,
+) -> Result<Value, Unsupported> {
   let buckets_path = body
     .get("buckets_path")
     .and_then(Value::as_str)

--- a/searchlite-adapter-elastic/src/translate/aggregation.rs
+++ b/searchlite-adapter-elastic/src/translate/aggregation.rs
@@ -1,0 +1,528 @@
+use serde_json::{json, Map, Value};
+
+use super::query::translate_to_filter;
+use super::unsupported::Unsupported;
+
+const AGG_KEYS: [&str; 2] = ["aggs", "aggregations"];
+
+/// Translate an ES `aggs`/`aggregations` map (name → spec) into SearchLite's
+/// agg map (name → tagged Aggregation JSON). Sub-aggregations recurse.
+pub fn translate_aggs(es_aggs: &Map<String, Value>) -> Result<Map<String, Value>, Unsupported> {
+  let mut out = Map::new();
+  for (name, spec) in es_aggs {
+    let spec_obj = spec
+      .as_object()
+      .ok_or_else(|| Unsupported::with_detail("aggregations", "each entry must be an object"))?;
+    out.insert(name.clone(), translate_one_agg(name, spec_obj)?);
+  }
+  Ok(out)
+}
+
+fn translate_one_agg(name: &str, spec: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let sub_aggs = collect_sub_aggs(spec)?;
+  let agg_keys: Vec<&String> = spec
+    .keys()
+    .filter(|k| !AGG_KEYS.contains(&k.as_str()) && k.as_str() != "meta")
+    .collect();
+  if agg_keys.len() != 1 {
+    return Err(Unsupported::with_detail(
+      format!("aggregations.{name}"),
+      "expected exactly one aggregation type per entry",
+    ));
+  }
+  let agg_type = agg_keys[0].clone();
+  let body = spec
+    .get(&agg_type)
+    .and_then(Value::as_object)
+    .ok_or_else(|| {
+      Unsupported::with_detail(format!("aggregations.{name}.{agg_type}"), "expected object")
+    })?;
+
+  let translated = match agg_type.as_str() {
+    "terms" => translate_terms_agg(body, sub_aggs)?,
+    "range" => translate_range_agg(body, sub_aggs)?,
+    "date_range" => translate_date_range_agg(body, sub_aggs)?,
+    "histogram" => translate_histogram_agg(body, sub_aggs)?,
+    "date_histogram" => translate_date_histogram_agg(body, sub_aggs)?,
+    "stats" => translate_metric_agg(body, "stats")?,
+    "extended_stats" => translate_metric_agg(body, "extended_stats")?,
+    "value_count" => translate_metric_agg(body, "value_count")?,
+    "cardinality" => translate_cardinality_agg(body)?,
+    "percentiles" => translate_percentiles_agg(body)?,
+    "percentile_ranks" => translate_percentile_ranks_agg(body)?,
+    "top_hits" => translate_top_hits_agg(body)?,
+    "filter" => translate_filter_agg(body, sub_aggs)?,
+    "nested" => translate_nested_agg(body, sub_aggs)?,
+    "composite" => translate_composite_agg(body, sub_aggs)?,
+    "bucket_sort" => translate_bucket_sort_agg(body)?,
+    "avg_bucket" => translate_bucket_metric_agg(body, "avg_bucket")?,
+    "sum_bucket" => translate_bucket_metric_agg(body, "sum_bucket")?,
+    "derivative" => translate_derivative_agg(body)?,
+    "moving_avg" => translate_moving_avg_agg(body)?,
+    "bucket_script" => translate_bucket_script_agg(body)?,
+    "significant_terms" => translate_significant_terms_agg(body, sub_aggs)?,
+    "rare_terms" => translate_rare_terms_agg(body, sub_aggs)?,
+    "avg" | "sum" | "min" | "max" => {
+      return Err(Unsupported::with_detail(
+        format!("aggregations.{name}.{agg_type}"),
+        "use `stats` and read the corresponding field from the response",
+      ))
+    }
+    other => {
+      return Err(Unsupported::feature(format!(
+        "aggregations.{name}.{other}"
+      )))
+    }
+  };
+  Ok(translated)
+}
+
+fn collect_sub_aggs(spec: &Map<String, Value>) -> Result<Option<Value>, Unsupported> {
+  let raw = spec.get("aggs").or_else(|| spec.get("aggregations"));
+  let Some(raw) = raw else {
+    return Ok(None);
+  };
+  let map = raw
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("aggregations.aggs", "must be an object"))?;
+  let translated = translate_aggs(map)?;
+  Ok(Some(Value::Object(translated)))
+}
+
+fn merge_sub(mut out: Map<String, Value>, sub: Option<Value>) -> Map<String, Value> {
+  if let Some(sub) = sub {
+    out.insert("aggs".to_string(), sub);
+  }
+  out
+}
+
+// --- terms ---------------------------------------------------------------
+
+fn translate_terms_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+  let field = require_field(body, "terms")?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("terms".into()));
+  out.insert("field".into(), Value::String(field));
+  if let Some(size) = body.get("size") {
+    out.insert("size".into(), size.clone());
+  }
+  if let Some(shard_size) = body.get("shard_size") {
+    out.insert("shard_size".into(), shard_size.clone());
+  }
+  if let Some(min_doc) = body.get("min_doc_count") {
+    out.insert("min_doc_count".into(), min_doc.clone());
+  }
+  if let Some(missing) = body.get("missing") {
+    out.insert("missing".into(), missing.clone());
+  }
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+fn translate_significant_terms_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
+  let field = require_field(body, "significant_terms")?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("significant_terms".into()));
+  out.insert("field".into(), Value::String(field));
+  if let Some(size) = body.get("size") {
+    out.insert("size".into(), size.clone());
+  }
+  if let Some(min_doc) = body.get("min_doc_count") {
+    out.insert("min_doc_count".into(), min_doc.clone());
+  }
+  if body.contains_key("background_filter") {
+    return Err(Unsupported::with_detail(
+      "significant_terms.background_filter",
+      "not supported in v1 — pass via filter aggregation instead",
+    ));
+  }
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+fn translate_rare_terms_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
+  let field = require_field(body, "rare_terms")?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("rare_terms".into()));
+  out.insert("field".into(), Value::String(field));
+  if let Some(max) = body.get("max_doc_count") {
+    out.insert("max_doc_count".into(), max.clone());
+  }
+  if let Some(size) = body.get("size") {
+    out.insert("size".into(), size.clone());
+  }
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+// --- range / date_range -------------------------------------------------
+
+fn translate_range_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+  let field = require_field(body, "range")?;
+  let ranges = body
+    .get("ranges")
+    .and_then(Value::as_array)
+    .ok_or_else(|| Unsupported::with_detail("range", "missing `ranges` array"))?;
+  let mut translated_ranges = Vec::with_capacity(ranges.len());
+  for r in ranges {
+    let r_obj = r
+      .as_object()
+      .ok_or_else(|| Unsupported::with_detail("range.ranges", "each entry must be an object"))?;
+    let mut entry = Map::new();
+    if let Some(key) = r_obj.get("key") {
+      entry.insert("key".into(), key.clone());
+    } else {
+      entry.insert("key".into(), Value::Null);
+    }
+    if let Some(from) = r_obj.get("from") {
+      entry.insert("from".into(), from.clone());
+    } else {
+      entry.insert("from".into(), Value::Null);
+    }
+    if let Some(to) = r_obj.get("to") {
+      entry.insert("to".into(), to.clone());
+    } else {
+      entry.insert("to".into(), Value::Null);
+    }
+    translated_ranges.push(Value::Object(entry));
+  }
+  let keyed = body.get("keyed").and_then(Value::as_bool).unwrap_or(false);
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("range".into()));
+  out.insert("field".into(), Value::String(field));
+  out.insert("keyed".into(), Value::Bool(keyed));
+  out.insert("ranges".into(), Value::Array(translated_ranges));
+  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+fn translate_date_range_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
+  let field = require_field(body, "date_range")?;
+  let ranges = body
+    .get("ranges")
+    .and_then(Value::as_array)
+    .ok_or_else(|| Unsupported::with_detail("date_range", "missing `ranges` array"))?;
+  let translated_ranges: Vec<Value> = ranges
+    .iter()
+    .map(|r| {
+      let r_obj = r.as_object().ok_or_else(|| {
+        Unsupported::with_detail("date_range.ranges", "each entry must be an object")
+      })?;
+      let mut entry = Map::new();
+      entry.insert("key".into(), r_obj.get("key").cloned().unwrap_or(Value::Null));
+      entry.insert("from".into(), r_obj.get("from").cloned().unwrap_or(Value::Null));
+      entry.insert("to".into(), r_obj.get("to").cloned().unwrap_or(Value::Null));
+      Ok(Value::Object(entry))
+    })
+    .collect::<Result<Vec<_>, Unsupported>>()?;
+  let keyed = body.get("keyed").and_then(Value::as_bool).unwrap_or(false);
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("date_range".into()));
+  out.insert("field".into(), Value::String(field));
+  out.insert("keyed".into(), Value::Bool(keyed));
+  out.insert("format".into(), body.get("format").cloned().unwrap_or(Value::Null));
+  out.insert("ranges".into(), Value::Array(translated_ranges));
+  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+// --- histogram / date_histogram -----------------------------------------
+
+fn translate_histogram_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
+  let field = require_field(body, "histogram")?;
+  let interval = body
+    .get("interval")
+    .and_then(Value::as_f64)
+    .ok_or_else(|| Unsupported::with_detail("histogram.interval", "must be a number"))?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("histogram".into()));
+  out.insert("field".into(), Value::String(field));
+  out.insert("interval".into(), Value::from(interval));
+  out.insert("offset".into(), body.get("offset").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "min_doc_count".into(),
+    body.get("min_doc_count").cloned().unwrap_or(Value::Null),
+  );
+  out.insert(
+    "extended_bounds".into(),
+    body.get("extended_bounds").cloned().unwrap_or(Value::Null),
+  );
+  out.insert(
+    "hard_bounds".into(),
+    body.get("hard_bounds").cloned().unwrap_or(Value::Null),
+  );
+  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+fn translate_date_histogram_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
+  let field = require_field(body, "date_histogram")?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("date_histogram".into()));
+  out.insert("field".into(), Value::String(field));
+  out.insert(
+    "calendar_interval".into(),
+    body.get("calendar_interval").cloned().unwrap_or(Value::Null),
+  );
+  out.insert(
+    "fixed_interval".into(),
+    body.get("fixed_interval").cloned().unwrap_or(Value::Null),
+  );
+  out.insert("offset".into(), body.get("offset").cloned().unwrap_or(Value::Null));
+  out.insert("format".into(), body.get("format").cloned().unwrap_or(Value::Null));
+  out.insert(
+    "min_doc_count".into(),
+    body.get("min_doc_count").cloned().unwrap_or(Value::Null),
+  );
+  out.insert(
+    "extended_bounds".into(),
+    body.get("extended_bounds").cloned().unwrap_or(Value::Null),
+  );
+  out.insert(
+    "hard_bounds".into(),
+    body.get("hard_bounds").cloned().unwrap_or(Value::Null),
+  );
+  out.insert("missing".into(), body.get("missing").cloned().unwrap_or(Value::Null));
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+// --- metric aggregations -------------------------------------------------
+
+fn translate_metric_agg(body: &Map<String, Value>, kind: &str) -> Result<Value, Unsupported> {
+  let field = require_field(body, kind)?;
+  Ok(json!({
+    "type": kind,
+    "field": field,
+    "missing": body.get("missing").cloned().unwrap_or(Value::Null),
+  }))
+}
+
+fn translate_cardinality_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let field = require_field(body, "cardinality")?;
+  let precision = body.get("precision_threshold").cloned().unwrap_or(Value::Null);
+  Ok(json!({
+    "type": "cardinality",
+    "field": field,
+    "precision_threshold": precision,
+  }))
+}
+
+fn translate_percentiles_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let field = require_field(body, "percentiles")?;
+  let percents = body.get("percents").cloned().unwrap_or_else(|| {
+    json!([1.0, 5.0, 25.0, 50.0, 75.0, 95.0, 99.0])
+  });
+  Ok(json!({
+    "type": "percentiles",
+    "field": field,
+    "percents": percents,
+  }))
+}
+
+fn translate_percentile_ranks_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let field = require_field(body, "percentile_ranks")?;
+  let values = body
+    .get("values")
+    .cloned()
+    .ok_or_else(|| Unsupported::with_detail("percentile_ranks.values", "missing array"))?;
+  Ok(json!({
+    "type": "percentile_ranks",
+    "field": field,
+    "values": values,
+  }))
+}
+
+fn translate_top_hits_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let size = body.get("size").and_then(Value::as_u64).unwrap_or(3);
+  let from = body.get("from").and_then(Value::as_u64).unwrap_or(0);
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("top_hits".into()));
+  out.insert("size".into(), Value::from(size));
+  out.insert("from".into(), Value::from(from));
+  if let Some(fields) = body.get("_source").and_then(|v| v.as_object().and_then(|o| o.get("includes"))) {
+    out.insert("fields".into(), fields.clone());
+  } else if let Some(fields) = body.get("fields") {
+    out.insert("fields".into(), fields.clone());
+  }
+  if let Some(sort) = body.get("sort") {
+    out.insert("sort".into(), super::sort::translate_sort(sort)?.into());
+  }
+  Ok(Value::Object(out))
+}
+
+// --- structural buckets --------------------------------------------------
+
+fn translate_filter_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+  let filter = translate_to_filter(&Value::Object(body.clone()))?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("filter".into()));
+  out.insert("filter".into(), filter);
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+fn translate_nested_agg(body: &Map<String, Value>, sub: Option<Value>) -> Result<Value, Unsupported> {
+  let path = body
+    .get("path")
+    .and_then(Value::as_str)
+    .ok_or_else(|| Unsupported::with_detail("nested.path", "missing string"))?
+    .to_string();
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("nested".into()));
+  out.insert("path".into(), Value::String(path));
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+fn translate_composite_agg(
+  body: &Map<String, Value>,
+  sub: Option<Value>,
+) -> Result<Value, Unsupported> {
+  let sources = body
+    .get("sources")
+    .and_then(Value::as_array)
+    .ok_or_else(|| Unsupported::with_detail("composite.sources", "missing array"))?;
+  let translated_sources: Vec<Value> = sources
+    .iter()
+    .map(|src| {
+      let src_obj = src.as_object().ok_or_else(|| {
+        Unsupported::with_detail("composite.sources", "each source must be an object")
+      })?;
+      if src_obj.len() != 1 {
+        return Err(Unsupported::with_detail(
+          "composite.sources",
+          "each source must contain exactly one named entry",
+        ));
+      }
+      let (name, body) = src_obj.iter().next().unwrap();
+      let body = body.as_object().ok_or_else(|| {
+        Unsupported::with_detail("composite.sources", "source spec must be object")
+      })?;
+      if body.len() != 1 {
+        return Err(Unsupported::with_detail(
+          "composite.sources",
+          "source spec must contain exactly one type",
+        ));
+      }
+      let (kind, spec) = body.iter().next().unwrap();
+      let spec = spec
+        .as_object()
+        .ok_or_else(|| Unsupported::with_detail("composite.sources", "type spec must be object"))?;
+      let field = spec
+        .get("field")
+        .and_then(Value::as_str)
+        .ok_or_else(|| Unsupported::with_detail("composite.sources.field", "missing"))?
+        .to_string();
+      match kind.as_str() {
+        "terms" => Ok(json!({ "type": "terms", "name": name, "field": field })),
+        "histogram" => {
+          let interval = spec
+            .get("interval")
+            .and_then(Value::as_f64)
+            .ok_or_else(|| Unsupported::with_detail("composite.histogram.interval", "missing"))?;
+          Ok(json!({ "type": "histogram", "name": name, "field": field, "interval": interval }))
+        }
+        other => Err(Unsupported::feature(format!("composite.sources.{other}"))),
+      }
+    })
+    .collect::<Result<Vec<_>, Unsupported>>()?;
+  let size = body.get("size").and_then(Value::as_u64).unwrap_or(10) as usize;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("composite".into()));
+  out.insert("sources".into(), Value::Array(translated_sources));
+  out.insert("size".into(), Value::from(size));
+  if let Some(after) = body.get("after") {
+    out.insert("after".into(), after.clone());
+  }
+  Ok(Value::Object(merge_sub(out, sub)))
+}
+
+// --- pipeline aggregations ----------------------------------------------
+
+fn translate_bucket_sort_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("bucket_sort".into()));
+  out.insert("from".into(), body.get("from").cloned().unwrap_or(Value::from(0u64)));
+  if let Some(size) = body.get("size") {
+    out.insert("size".into(), size.clone());
+  }
+  if let Some(sort) = body.get("sort") {
+    out.insert("sort".into(), Value::Array(super::sort::translate_sort(sort)?));
+  }
+  Ok(Value::Object(out))
+}
+
+fn translate_bucket_metric_agg(body: &Map<String, Value>, kind: &str) -> Result<Value, Unsupported> {
+  let buckets_path = body
+    .get("buckets_path")
+    .and_then(Value::as_str)
+    .ok_or_else(|| Unsupported::with_detail(format!("{kind}.buckets_path"), "missing"))?
+    .to_string();
+  Ok(json!({ "type": kind, "buckets_path": buckets_path }))
+}
+
+fn translate_derivative_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let buckets_path = body
+    .get("buckets_path")
+    .and_then(Value::as_str)
+    .ok_or_else(|| Unsupported::with_detail("derivative.buckets_path", "missing"))?
+    .to_string();
+  Ok(json!({ "type": "derivative", "buckets_path": buckets_path }))
+}
+
+fn translate_moving_avg_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let buckets_path = body
+    .get("buckets_path")
+    .and_then(Value::as_str)
+    .ok_or_else(|| Unsupported::with_detail("moving_avg.buckets_path", "missing"))?
+    .to_string();
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("moving_avg".into()));
+  out.insert("buckets_path".into(), Value::String(buckets_path));
+  if let Some(window) = body.get("window") {
+    out.insert("window".into(), window.clone());
+  }
+  if let Some(model) = body.get("model") {
+    out.insert("model".into(), model.clone());
+  }
+  if let Some(predict) = body.get("predict") {
+    out.insert("predict".into(), predict.clone());
+  }
+  Ok(Value::Object(out))
+}
+
+fn translate_bucket_script_agg(body: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let buckets_path = body
+    .get("buckets_path")
+    .cloned()
+    .ok_or_else(|| Unsupported::with_detail("bucket_script.buckets_path", "missing"))?;
+  let script = body
+    .get("script")
+    .cloned()
+    .ok_or_else(|| Unsupported::with_detail("bucket_script.script", "missing"))?;
+  Ok(json!({
+    "type": "bucket_script",
+    "buckets_path": buckets_path,
+    "script": script,
+  }))
+}
+
+// --- helpers -------------------------------------------------------------
+
+fn require_field(body: &Map<String, Value>, kind: &str) -> Result<String, Unsupported> {
+  body
+    .get("field")
+    .and_then(Value::as_str)
+    .map(str::to_string)
+    .ok_or_else(|| Unsupported::with_detail(format!("{kind}.field"), "missing string"))
+}

--- a/searchlite-adapter-elastic/src/translate/highlight.rs
+++ b/searchlite-adapter-elastic/src/translate/highlight.rs
@@ -1,0 +1,61 @@
+use serde_json::{json, Map, Value};
+
+use super::unsupported::Unsupported;
+
+/// Translate ES highlight spec into SearchLite's HighlightRequest JSON.
+///
+/// SearchLite uses singular `pre_tag`/`post_tag`; ES allows arrays. We pick the
+/// first element if a list is supplied.
+pub fn translate_highlight(es_highlight: &Value) -> Result<Value, Unsupported> {
+  let map = es_highlight.as_object().ok_or_else(|| {
+    Unsupported::with_detail("highlight", "expected an object with `fields`")
+  })?;
+  let global_pre = pick_first_tag(map.get("pre_tags"));
+  let global_post = pick_first_tag(map.get("post_tags"));
+  let fields_in = map
+    .get("fields")
+    .and_then(Value::as_object)
+    .ok_or_else(|| Unsupported::with_detail("highlight.fields", "expected an object"))?;
+
+  let mut fields_out = Map::new();
+  for (field, spec) in fields_in {
+    let field_obj = spec.as_object();
+    let pre_tag = field_obj
+      .and_then(|m| pick_first_tag(m.get("pre_tags")))
+      .or_else(|| global_pre.clone());
+    let post_tag = field_obj
+      .and_then(|m| pick_first_tag(m.get("post_tags")))
+      .or_else(|| global_post.clone());
+    let fragment_size = field_obj
+      .and_then(|m| m.get("fragment_size"))
+      .and_then(Value::as_u64);
+    let number_of_fragments = field_obj
+      .and_then(|m| m.get("number_of_fragments"))
+      .and_then(Value::as_u64);
+
+    let mut entry = Map::new();
+    if let Some(tag) = pre_tag {
+      entry.insert("pre_tag".to_string(), Value::String(tag));
+    }
+    if let Some(tag) = post_tag {
+      entry.insert("post_tag".to_string(), Value::String(tag));
+    }
+    if let Some(size) = fragment_size {
+      entry.insert("fragment_size".to_string(), Value::from(size));
+    }
+    if let Some(n) = number_of_fragments {
+      entry.insert("number_of_fragments".to_string(), Value::from(n));
+    }
+    fields_out.insert(field.clone(), Value::Object(entry));
+  }
+
+  Ok(json!({ "fields": Value::Object(fields_out) }))
+}
+
+fn pick_first_tag(value: Option<&Value>) -> Option<String> {
+  match value? {
+    Value::String(s) => Some(s.clone()),
+    Value::Array(items) => items.first().and_then(Value::as_str).map(str::to_string),
+    _ => None,
+  }
+}

--- a/searchlite-adapter-elastic/src/translate/highlight.rs
+++ b/searchlite-adapter-elastic/src/translate/highlight.rs
@@ -7,9 +7,9 @@ use super::unsupported::Unsupported;
 /// SearchLite uses singular `pre_tag`/`post_tag`; ES allows arrays. We pick the
 /// first element if a list is supplied.
 pub fn translate_highlight(es_highlight: &Value) -> Result<Value, Unsupported> {
-  let map = es_highlight.as_object().ok_or_else(|| {
-    Unsupported::with_detail("highlight", "expected an object with `fields`")
-  })?;
+  let map = es_highlight
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("highlight", "expected an object with `fields`"))?;
   let global_pre = pick_first_tag(map.get("pre_tags"));
   let global_post = pick_first_tag(map.get("post_tags"));
   let fields_in = map

--- a/searchlite-adapter-elastic/src/translate/mapping.rs
+++ b/searchlite-adapter-elastic/src/translate/mapping.rs
@@ -29,9 +29,9 @@ pub fn schema_to_es(index: &str, schema: &Value) -> Result<Value, Unsupported> {
 fn translate_properties(props: &Map<String, Value>) -> Result<Map<String, Value>, Unsupported> {
   let mut out = Map::new();
   for (name, value) in props {
-    let prop = value
-      .as_object()
-      .ok_or_else(|| Unsupported::with_detail("mapping", format!("property `{name}` must be an object")))?;
+    let prop = value.as_object().ok_or_else(|| {
+      Unsupported::with_detail("mapping", format!("property `{name}` must be an object"))
+    })?;
     out.insert(name.clone(), translate_field(prop)?);
   }
   Ok(out)
@@ -55,8 +55,9 @@ fn translate_field(prop: &Map<String, Value>) -> Result<Value, Unsupported> {
         if let Some(analyzer) = prop.get("searchlite:analyzer").and_then(Value::as_str) {
           out.insert("analyzer".into(), Value::String(analyzer.to_string()));
         }
-        if let Some(search_analyzer) =
-          prop.get("searchlite:searchAnalyzer").and_then(Value::as_str)
+        if let Some(search_analyzer) = prop
+          .get("searchlite:searchAnalyzer")
+          .and_then(Value::as_str)
         {
           out.insert(
             "search_analyzer".into(),

--- a/searchlite-adapter-elastic/src/translate/mapping.rs
+++ b/searchlite-adapter-elastic/src/translate/mapping.rs
@@ -1,0 +1,169 @@
+use serde_json::{json, Map, Value};
+
+use super::unsupported::Unsupported;
+
+/// Convert a SearchLite JSON Schema (with `searchlite:*` extensions) into an
+/// Elasticsearch mapping JSON of the form:
+///
+/// ```json
+/// { "<index>": { "mappings": { "properties": { ... } } } }
+/// ```
+pub fn schema_to_es(index: &str, schema: &Value) -> Result<Value, Unsupported> {
+  let properties = schema
+    .as_object()
+    .and_then(|m| m.get("properties"))
+    .and_then(Value::as_object);
+  let mapping_props = match properties {
+    Some(map) => translate_properties(map)?,
+    None => Map::new(),
+  };
+  Ok(json!({
+    index: {
+      "mappings": {
+        "properties": Value::Object(mapping_props),
+      }
+    }
+  }))
+}
+
+fn translate_properties(props: &Map<String, Value>) -> Result<Map<String, Value>, Unsupported> {
+  let mut out = Map::new();
+  for (name, value) in props {
+    let prop = value
+      .as_object()
+      .ok_or_else(|| Unsupported::with_detail("mapping", format!("property `{name}` must be an object")))?;
+    out.insert(name.clone(), translate_field(prop)?);
+  }
+  Ok(out)
+}
+
+fn translate_field(prop: &Map<String, Value>) -> Result<Value, Unsupported> {
+  let raw_type = prop
+    .get("type")
+    .ok_or_else(|| Unsupported::with_detail("mapping", "property missing `type`"))?;
+  let base_type = primary_type(raw_type)?;
+  let kind = prop.get("searchlite:kind").and_then(Value::as_str);
+
+  let mut out = Map::new();
+  match base_type {
+    "string" => match kind {
+      Some("keyword") => {
+        out.insert("type".into(), Value::String("keyword".into()));
+      }
+      _ => {
+        out.insert("type".into(), Value::String("text".into()));
+        if let Some(analyzer) = prop.get("searchlite:analyzer").and_then(Value::as_str) {
+          out.insert("analyzer".into(), Value::String(analyzer.to_string()));
+        }
+        if let Some(search_analyzer) =
+          prop.get("searchlite:searchAnalyzer").and_then(Value::as_str)
+        {
+          out.insert(
+            "search_analyzer".into(),
+            Value::String(search_analyzer.to_string()),
+          );
+        }
+      }
+    },
+    "integer" => {
+      out.insert("type".into(), Value::String("long".into()));
+    }
+    "number" => {
+      out.insert("type".into(), Value::String("double".into()));
+    }
+    "boolean" => {
+      out.insert("type".into(), Value::String("boolean".into()));
+    }
+    "array" => {
+      // Nested fields are emitted as JSON Schema arrays of objects.
+      let items = prop
+        .get("items")
+        .and_then(Value::as_object)
+        .ok_or_else(|| Unsupported::with_detail("mapping", "array property missing `items`"))?;
+      let item_type = items
+        .get("type")
+        .and_then(Value::as_str)
+        .unwrap_or("object");
+      if item_type != "object" {
+        return Err(Unsupported::with_detail(
+          "mapping",
+          "array fields must have items.type=object (nested)",
+        ));
+      }
+      out.insert("type".into(), Value::String("nested".into()));
+      if let Some(child_props) = items.get("properties").and_then(Value::as_object) {
+        out.insert(
+          "properties".into(),
+          Value::Object(translate_properties(child_props)?),
+        );
+      }
+    }
+    "object" => {
+      // Vector fields and other object-typed extensions are surfaced as
+      // dense_vector when the marker is present.
+      if let Some(vec_cfg) = prop.get("searchlite:vector").and_then(Value::as_object) {
+        out.insert("type".into(), Value::String("dense_vector".into()));
+        if let Some(dim) = vec_cfg.get("dim") {
+          out.insert("dims".into(), dim.clone());
+        }
+        if let Some(metric) = vec_cfg.get("metric").and_then(Value::as_str) {
+          let similarity = match metric {
+            "Cosine" | "cosine" => "cosine",
+            "L2" | "l2" => "l2_norm",
+            other => {
+              return Err(Unsupported::with_detail(
+                "mapping.vector.metric",
+                format!("unknown metric `{other}`"),
+              ))
+            }
+          };
+          out.insert("similarity".into(), Value::String(similarity.into()));
+        }
+      } else {
+        out.insert("type".into(), Value::String("object".into()));
+      }
+    }
+    other => {
+      return Err(Unsupported::with_detail(
+        "mapping",
+        format!("type `{other}` not supported"),
+      ));
+    }
+  }
+  Ok(Value::Object(out))
+}
+
+fn primary_type(value: &Value) -> Result<&str, Unsupported> {
+  match value {
+    Value::String(s) => Ok(primary_str(s)),
+    Value::Array(items) => {
+      for v in items {
+        if let Some(s) = v.as_str() {
+          if s != "null" {
+            return Ok(primary_str(s));
+          }
+        }
+      }
+      Err(Unsupported::with_detail(
+        "mapping",
+        "type array contained no concrete type",
+      ))
+    }
+    _ => Err(Unsupported::with_detail(
+      "mapping",
+      "`type` must be a string or array of strings",
+    )),
+  }
+}
+
+fn primary_str(s: &str) -> &str {
+  match s {
+    "string" => "string",
+    "integer" => "integer",
+    "number" => "number",
+    "boolean" => "boolean",
+    "array" => "array",
+    "object" => "object",
+    _ => s,
+  }
+}

--- a/searchlite-adapter-elastic/src/translate/mod.rs
+++ b/searchlite-adapter-elastic/src/translate/mod.rs
@@ -8,7 +8,7 @@ pub mod response;
 pub mod sort;
 pub mod unsupported;
 
-pub use aggregation::translate_aggs;
+pub use aggregation::{extract_agg_meta, inject_agg_meta, translate_aggs};
 pub use highlight::translate_highlight;
 pub use mapping::schema_to_es;
 pub use pagination::apply_pagination;

--- a/searchlite-adapter-elastic/src/translate/mod.rs
+++ b/searchlite-adapter-elastic/src/translate/mod.rs
@@ -1,0 +1,19 @@
+pub mod aggregation;
+pub mod highlight;
+pub mod mapping;
+pub mod pagination;
+pub mod query;
+pub mod request;
+pub mod response;
+pub mod sort;
+pub mod unsupported;
+
+pub use aggregation::translate_aggs;
+pub use highlight::translate_highlight;
+pub use mapping::schema_to_es;
+pub use pagination::apply_pagination;
+pub use query::translate_query;
+pub use request::translate_search_body;
+pub use response::translate_search_response;
+pub use sort::translate_sort;
+pub use unsupported::Unsupported;

--- a/searchlite-adapter-elastic/src/translate/pagination.rs
+++ b/searchlite-adapter-elastic/src/translate/pagination.rs
@@ -23,10 +23,38 @@ pub fn apply_pagination(
   if let Some(search_after) = es_body.get("search_after") {
     out.insert("search_after".to_string(), search_after.clone());
   }
-  if let Some(track_total_hits) = es_body.get("track_total_hits") {
-    // SearchLite always returns total_hits_estimate; the request flag is
-    // accepted but informational only.
-    let _ = track_total_hits;
+  if let Some(track) = es_body.get("track_total_hits") {
+    // SearchLite's `track_total_hits` (Option<bool>) actually changes
+    // execution: when true it disables WAND/BMW pruning so `total_hits` is
+    // exact rather than an estimate. Forward it so `_count` and clients that
+    // explicitly request exact totals get them.
+    let normalized = match track {
+      Value::Bool(b) => Value::Bool(*b),
+      Value::Number(n) => {
+        // ES allows an integer cap (track up to N exactly, then return a
+        // lower bound). SearchLite has no lower-bound mode, so map any
+        // positive cap to `true` and 0 to `false` — closer to user intent
+        // than silently dropping it.
+        let positive = n
+          .as_i64()
+          .map(|i| i > 0)
+          .or_else(|| n.as_u64().map(|u| u > 0))
+          .ok_or_else(|| {
+            Unsupported::with_detail(
+              "track_total_hits",
+              "must be a boolean or non-negative integer",
+            )
+          })?;
+        Value::Bool(positive)
+      }
+      _ => {
+        return Err(Unsupported::with_detail(
+          "track_total_hits",
+          "must be a boolean or non-negative integer",
+        ))
+      }
+    };
+    out.insert("track_total_hits".to_string(), normalized);
   }
   Ok(())
 }

--- a/searchlite-adapter-elastic/src/translate/pagination.rs
+++ b/searchlite-adapter-elastic/src/translate/pagination.rs
@@ -1,0 +1,32 @@
+use serde_json::{Map, Value};
+
+use super::unsupported::Unsupported;
+
+/// Copy ES `from`, `size`, and `search_after` onto the SearchLite request body.
+/// `scroll` is rejected — recommend `search_after` migration.
+pub fn apply_pagination(
+  es_body: &Map<String, Value>,
+  out: &mut Map<String, Value>,
+) -> Result<(), Unsupported> {
+  if es_body.contains_key("scroll") || es_body.contains_key("scroll_id") {
+    return Err(Unsupported::with_detail(
+      "scroll",
+      "use `search_after` for cursor-style pagination",
+    ));
+  }
+  if let Some(from) = es_body.get("from") {
+    out.insert("from".to_string(), from.clone());
+  }
+  if let Some(size) = es_body.get("size") {
+    out.insert("limit".to_string(), size.clone());
+  }
+  if let Some(search_after) = es_body.get("search_after") {
+    out.insert("search_after".to_string(), search_after.clone());
+  }
+  if let Some(track_total_hits) = es_body.get("track_total_hits") {
+    // SearchLite always returns total_hits_estimate; the request flag is
+    // accepted but informational only.
+    let _ = track_total_hits;
+  }
+  Ok(())
+}

--- a/searchlite-adapter-elastic/src/translate/pagination.rs
+++ b/searchlite-adapter-elastic/src/translate/pagination.rs
@@ -30,22 +30,20 @@ pub fn apply_pagination(
     // explicitly request exact totals get them.
     let normalized = match track {
       Value::Bool(b) => Value::Bool(*b),
+      // ES allows an integer cap (track up to N exactly, then return a
+      // lower bound). SearchLite has no lower-bound mode, so map any
+      // positive cap to `true` and 0 to `false` — closer to user intent
+      // than silently dropping it. `as_u64` returns `None` for negative
+      // integers and floats, so both classes get rejected here instead of
+      // being silently coerced to `false`.
       Value::Number(n) => {
-        // ES allows an integer cap (track up to N exactly, then return a
-        // lower bound). SearchLite has no lower-bound mode, so map any
-        // positive cap to `true` and 0 to `false` — closer to user intent
-        // than silently dropping it.
-        let positive = n
-          .as_i64()
-          .map(|i| i > 0)
-          .or_else(|| n.as_u64().map(|u| u > 0))
-          .ok_or_else(|| {
-            Unsupported::with_detail(
-              "track_total_hits",
-              "must be a boolean or non-negative integer",
-            )
-          })?;
-        Value::Bool(positive)
+        let cap = n.as_u64().ok_or_else(|| {
+          Unsupported::with_detail(
+            "track_total_hits",
+            "must be a boolean or non-negative integer",
+          )
+        })?;
+        Value::Bool(cap > 0)
       }
       _ => {
         return Err(Unsupported::with_detail(

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -1,0 +1,827 @@
+use serde_json::{json, Map, Value};
+
+use super::unsupported::Unsupported;
+
+/// Translate a single ES query clause into SearchLite's tagged QueryNode JSON.
+///
+/// The input is the value of the `query` key from the ES `_search` body — i.e.
+/// an object containing exactly one top-level clause name (e.g. `{"match_all": {}}`).
+pub fn translate_query(es: &Value) -> Result<Value, Unsupported> {
+  let map = es
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("query", "expected an object"))?;
+  if map.is_empty() {
+    return Ok(json!({ "type": "match_all" }));
+  }
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "query",
+      "expected exactly one top-level clause",
+    ));
+  }
+  let (clause, body) = map.iter().next().unwrap();
+  translate_clause(clause, body)
+}
+
+fn translate_clause(clause: &str, body: &Value) -> Result<Value, Unsupported> {
+  match clause {
+    "match_all" => translate_match_all(body),
+    "match_none" => Err(Unsupported::feature("match_none")),
+    "match" => translate_match(body),
+    "match_phrase" => translate_match_phrase(body, false),
+    "match_phrase_prefix" => Err(Unsupported::feature("match_phrase_prefix")),
+    "multi_match" => translate_multi_match(body),
+    "term" => translate_term(body),
+    "terms" => translate_terms(body),
+    "prefix" => translate_prefix(body),
+    "wildcard" => translate_wildcard(body),
+    "regexp" => translate_regexp(body),
+    "range" => translate_range_clause(body),
+    "exists" => translate_exists(body),
+    "bool" => translate_bool(body),
+    "constant_score" => translate_constant_score(body),
+    "dis_max" => translate_dis_max(body),
+    "query_string" => translate_query_string(body),
+    "simple_query_string" => translate_query_string(body),
+    other => Err(Unsupported::feature(other)),
+  }
+}
+
+// --- match_all -----------------------------------------------------------
+
+fn translate_match_all(body: &Value) -> Result<Value, Unsupported> {
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("match_all".into()));
+  if let Some(boost) = body.as_object().and_then(|m| m.get("boost")) {
+    out.insert("boost".into(), boost.clone());
+  }
+  Ok(Value::Object(out))
+}
+
+// --- match ---------------------------------------------------------------
+
+fn translate_match(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("match", "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "match",
+      "expected exactly one field",
+    ));
+  }
+  let (field, spec) = map.iter().next().unwrap();
+  let parsed = parse_match_spec(spec)?;
+
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("query_string".into()));
+  out.insert("query".into(), Value::String(parsed.query));
+  out.insert(
+    "fields".into(),
+    Value::Array(vec![Value::String(field.clone())]),
+  );
+  if let Some(b) = parsed.boost {
+    out.insert("boost".into(), Value::from(b));
+  }
+  if parsed.fuzziness.is_some() {
+    return Err(Unsupported::with_detail(
+      "match.fuzziness",
+      "use multi_match for fuzziness",
+    ));
+  }
+  if let Some(op) = parsed.operator {
+    let upper = op.to_ascii_lowercase();
+    if upper != "or" {
+      return Err(Unsupported::with_detail(
+        "match.operator",
+        "only `or` is supported for `match`",
+      ));
+    }
+  }
+  Ok(Value::Object(out))
+}
+
+struct MatchSpec {
+  query: String,
+  boost: Option<f64>,
+  fuzziness: Option<String>,
+  operator: Option<String>,
+}
+
+fn parse_match_spec(spec: &Value) -> Result<MatchSpec, Unsupported> {
+  match spec {
+    Value::String(s) => Ok(MatchSpec {
+      query: s.clone(),
+      boost: None,
+      fuzziness: None,
+      operator: None,
+    }),
+    Value::Number(n) => Ok(MatchSpec {
+      query: n.to_string(),
+      boost: None,
+      fuzziness: None,
+      operator: None,
+    }),
+    Value::Bool(b) => Ok(MatchSpec {
+      query: b.to_string(),
+      boost: None,
+      fuzziness: None,
+      operator: None,
+    }),
+    Value::Object(map) => {
+      let query = map
+        .get("query")
+        .and_then(|v| match v {
+          Value::String(s) => Some(s.clone()),
+          Value::Number(n) => Some(n.to_string()),
+          Value::Bool(b) => Some(b.to_string()),
+          _ => None,
+        })
+        .ok_or_else(|| Unsupported::with_detail("match", "missing string `query`"))?;
+      Ok(MatchSpec {
+        query,
+        boost: map.get("boost").and_then(Value::as_f64),
+        fuzziness: map.get("fuzziness").and_then(Value::as_str).map(str::to_string),
+        operator: map.get("operator").and_then(Value::as_str).map(str::to_string),
+      })
+    }
+    _ => Err(Unsupported::with_detail(
+      "match",
+      "spec must be string or object",
+    )),
+  }
+}
+
+// --- match_phrase --------------------------------------------------------
+
+fn translate_match_phrase(body: &Value, _prefix: bool) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("match_phrase", "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "match_phrase",
+      "expected exactly one field",
+    ));
+  }
+  let (field, spec) = map.iter().next().unwrap();
+  let (text, slop, boost) = match spec {
+    Value::String(s) => (s.clone(), None, None),
+    Value::Object(opts) => {
+      let q = opts
+        .get("query")
+        .and_then(Value::as_str)
+        .ok_or_else(|| Unsupported::with_detail("match_phrase", "missing string `query`"))?
+        .to_string();
+      let slop = opts.get("slop").and_then(Value::as_u64);
+      let boost = opts.get("boost").and_then(Value::as_f64);
+      (q, slop, boost)
+    }
+    _ => {
+      return Err(Unsupported::with_detail(
+        "match_phrase",
+        "spec must be string or object",
+      ))
+    }
+  };
+
+  let terms: Vec<Value> = text.split_whitespace().map(|t| Value::String(t.to_string())).collect();
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("phrase".into()));
+  out.insert("field".into(), Value::String(field.clone()));
+  out.insert("terms".into(), Value::Array(terms));
+  if let Some(s) = slop {
+    out.insert("slop".into(), Value::from(s));
+  }
+  if let Some(b) = boost {
+    out.insert("boost".into(), Value::from(b));
+  }
+  Ok(Value::Object(out))
+}
+
+// --- multi_match ---------------------------------------------------------
+
+fn translate_multi_match(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("multi_match", "expected an object"))?;
+  let query = map
+    .get("query")
+    .and_then(Value::as_str)
+    .ok_or_else(|| Unsupported::with_detail("multi_match", "missing string `query`"))?
+    .to_string();
+  let fields = map
+    .get("fields")
+    .and_then(Value::as_array)
+    .ok_or_else(|| Unsupported::with_detail("multi_match", "missing `fields` array"))?
+    .iter()
+    .map(translate_field_spec)
+    .collect::<Result<Vec<_>, _>>()?;
+
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("multi_match".into()));
+  out.insert("query".into(), Value::String(query));
+  out.insert("fields".into(), Value::Array(fields));
+
+  if let Some(t) = map.get("type").and_then(Value::as_str) {
+    let t_norm = match t {
+      "best_fields" | "most_fields" | "cross_fields" => t.to_string(),
+      "phrase" | "phrase_prefix" | "bool_prefix" => {
+        return Err(Unsupported::with_detail(
+          "multi_match.type",
+          format!("`{t}` not supported; use best_fields/most_fields/cross_fields"),
+        ))
+      }
+      other => {
+        return Err(Unsupported::with_detail(
+          "multi_match.type",
+          format!("unknown match_type `{other}`"),
+        ))
+      }
+    };
+    out.insert("match_type".into(), Value::String(t_norm));
+  }
+
+  if let Some(fz) = map.get("fuzziness") {
+    out.insert("fuzziness".into(), translate_fuzziness(fz)?);
+  }
+  if let Some(tb) = map.get("tie_breaker") {
+    out.insert("tie_breaker".into(), tb.clone());
+  }
+  if let Some(op) = map.get("operator").and_then(Value::as_str) {
+    out.insert("operator".into(), Value::String(op.to_ascii_lowercase()));
+  }
+  if let Some(msm) = map.get("minimum_should_match") {
+    out.insert("minimum_should_match".into(), msm.clone());
+  }
+  if let Some(boost) = map.get("boost") {
+    out.insert("boost".into(), boost.clone());
+  }
+  Ok(Value::Object(out))
+}
+
+fn translate_field_spec(spec: &Value) -> Result<Value, Unsupported> {
+  match spec {
+    Value::String(s) => {
+      if let Some((name, boost)) = s.split_once('^') {
+        let boost: f64 = boost.parse().map_err(|_| {
+          Unsupported::with_detail("fields", format!("invalid boost in `{s}`"))
+        })?;
+        Ok(json!({ "field": name, "boost": boost }))
+      } else {
+        Ok(json!({ "field": s }))
+      }
+    }
+    Value::Object(_) => Ok(spec.clone()),
+    _ => Err(Unsupported::with_detail(
+      "fields",
+      "must be string or object",
+    )),
+  }
+}
+
+fn translate_fuzziness(value: &Value) -> Result<Value, Unsupported> {
+  // SearchLite expects MultiMatchFuzziness shape — accept ES "AUTO" or numeric 0/1/2.
+  match value {
+    Value::String(s) => match s.to_ascii_uppercase().as_str() {
+      "AUTO" => Ok(json!({ "max_edits": 2 })),
+      "0" => Ok(json!({ "max_edits": 0 })),
+      "1" => Ok(json!({ "max_edits": 1 })),
+      "2" => Ok(json!({ "max_edits": 2 })),
+      other => Err(Unsupported::with_detail(
+        "fuzziness",
+        format!("unknown value `{other}`"),
+      )),
+    },
+    Value::Number(n) => {
+      let edits = n.as_u64().ok_or_else(|| {
+        Unsupported::with_detail("fuzziness", "must be a non-negative integer")
+      })?;
+      if edits > 2 {
+        return Err(Unsupported::with_detail(
+          "fuzziness",
+          "max_edits must be 0, 1, or 2",
+        ));
+      }
+      Ok(json!({ "max_edits": edits }))
+    }
+    _ => Err(Unsupported::with_detail("fuzziness", "must be string or number")),
+  }
+}
+
+// --- term / terms --------------------------------------------------------
+
+fn translate_term(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("term", "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "term",
+      "expected exactly one field",
+    ));
+  }
+  let (field, spec) = map.iter().next().unwrap();
+  let (value, boost) = parse_value_or_object(spec, "term")?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("term".into()));
+  out.insert("field".into(), Value::String(field.clone()));
+  out.insert("value".into(), Value::String(value));
+  if let Some(b) = boost {
+    out.insert("boost".into(), Value::from(b));
+  }
+  Ok(Value::Object(out))
+}
+
+fn translate_terms(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("terms", "expected an object"))?;
+  let mut field_iter = map.iter().filter(|(k, _)| *k != "boost");
+  let (field, spec) = field_iter
+    .next()
+    .ok_or_else(|| Unsupported::with_detail("terms", "missing field entry"))?;
+  if field_iter.next().is_some() {
+    return Err(Unsupported::with_detail(
+      "terms",
+      "expected exactly one field entry",
+    ));
+  }
+  let values = spec
+    .as_array()
+    .ok_or_else(|| Unsupported::with_detail("terms", "field value must be an array"))?;
+  let shoulds: Vec<Value> = values
+    .iter()
+    .map(|v| {
+      let term = v
+        .as_str()
+        .map(str::to_string)
+        .or_else(|| v.as_i64().map(|n| n.to_string()))
+        .or_else(|| v.as_u64().map(|n| n.to_string()))
+        .or_else(|| v.as_f64().map(|n| n.to_string()))
+        .ok_or_else(|| Unsupported::with_detail("terms", "values must be primitives"))?;
+      Ok(json!({ "type": "term", "field": field, "value": term }))
+    })
+    .collect::<Result<Vec<_>, Unsupported>>()?;
+
+  Ok(json!({
+    "type": "bool",
+    "should": shoulds,
+    "minimum_should_match": 1,
+  }))
+}
+
+fn parse_value_or_object(spec: &Value, clause: &str) -> Result<(String, Option<f64>), Unsupported> {
+  match spec {
+    Value::String(s) => Ok((s.clone(), None)),
+    Value::Number(n) => Ok((n.to_string(), None)),
+    Value::Bool(b) => Ok((b.to_string(), None)),
+    Value::Object(opts) => {
+      let v = opts
+        .get("value")
+        .or_else(|| opts.get("query"))
+        .ok_or_else(|| Unsupported::with_detail(clause, "missing `value`"))?;
+      let primitive = match v {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n.to_string(),
+        Value::Bool(b) => b.to_string(),
+        _ => {
+          return Err(Unsupported::with_detail(
+            clause,
+            "value must be a primitive",
+          ))
+        }
+      };
+      let boost = opts.get("boost").and_then(Value::as_f64);
+      Ok((primitive, boost))
+    }
+    _ => Err(Unsupported::with_detail(clause, "spec must be primitive or object")),
+  }
+}
+
+// --- prefix / wildcard / regexp -----------------------------------------
+
+fn translate_prefix(body: &Value) -> Result<Value, Unsupported> {
+  field_value_clause(body, "prefix", "prefix")
+}
+
+fn translate_wildcard(body: &Value) -> Result<Value, Unsupported> {
+  field_value_clause(body, "wildcard", "wildcard")
+}
+
+fn translate_regexp(body: &Value) -> Result<Value, Unsupported> {
+  field_value_clause(body, "regexp", "regex")
+}
+
+fn field_value_clause(body: &Value, es_clause: &str, sl_type: &str) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail(es_clause, "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      es_clause,
+      "expected exactly one field",
+    ));
+  }
+  let (field, spec) = map.iter().next().unwrap();
+  let (value, boost) = parse_value_or_object(spec, es_clause)?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String(sl_type.into()));
+  out.insert("field".into(), Value::String(field.clone()));
+  out.insert("value".into(), Value::String(value));
+  if let Some(b) = boost {
+    out.insert("boost".into(), Value::from(b));
+  }
+  Ok(Value::Object(out))
+}
+
+// --- range ---------------------------------------------------------------
+
+/// `range` is rendered as a SearchLite `constant_score` wrapping a Filter so
+/// it can be used in any query position. When used inside `bool.filter` we
+/// translate to a raw filter via [`translate_range_to_filter`].
+fn translate_range_clause(body: &Value) -> Result<Value, Unsupported> {
+  let filter = translate_range_to_filter(body)?;
+  Ok(json!({ "type": "constant_score", "filter": filter }))
+}
+
+pub fn translate_range_to_filter(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("range", "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "range",
+      "expected exactly one field",
+    ));
+  }
+  let (field, spec) = map.iter().next().unwrap();
+  let opts = spec
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("range", "spec must be an object"))?;
+
+  let gte = opts.get("gte");
+  let gt = opts.get("gt");
+  let lte = opts.get("lte");
+  let lt = opts.get("lt");
+
+  if opts.get("format").is_some() {
+    return Err(Unsupported::with_detail(
+      "range.format",
+      "date format strings not supported; supply numeric or epoch_ms values",
+    ));
+  }
+  if opts.get("time_zone").is_some() {
+    return Err(Unsupported::with_detail("range.time_zone", "not supported"));
+  }
+  if opts.get("relation").is_some() {
+    return Err(Unsupported::with_detail("range.relation", "not supported"));
+  }
+
+  // Determine numeric kind from any provided bound.
+  let any = gte.or(gt).or(lte).or(lt).ok_or_else(|| {
+    Unsupported::with_detail("range", "must specify at least one of gte/gt/lte/lt")
+  })?;
+
+  let is_int = is_integer_value(any)
+    && [gte, gt, lte, lt]
+      .iter()
+      .all(|b| b.map(is_integer_value).unwrap_or(true));
+
+  if is_int {
+    let min = i64_lower(gte, gt)?;
+    let max = i64_upper(lte, lt)?;
+    Ok(json!({ "I64Range": { "field": field, "min": min, "max": max } }))
+  } else {
+    let min = f64_lower(gte, gt)?;
+    let max = f64_upper(lte, lt)?;
+    Ok(json!({ "F64Range": { "field": field, "min": min, "max": max } }))
+  }
+}
+
+fn is_integer_value(v: &Value) -> bool {
+  match v {
+    Value::Number(n) => n.is_i64() || n.is_u64(),
+    _ => false,
+  }
+}
+
+fn i64_lower(gte: Option<&Value>, gt: Option<&Value>) -> Result<i64, Unsupported> {
+  if let Some(v) = gte {
+    return v
+      .as_i64()
+      .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
+      .ok_or_else(|| Unsupported::with_detail("range.gte", "must fit in i64"));
+  }
+  if let Some(v) = gt {
+    let n = v
+      .as_i64()
+      .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
+      .ok_or_else(|| Unsupported::with_detail("range.gt", "must fit in i64"))?;
+    return Ok(n.saturating_add(1));
+  }
+  Ok(i64::MIN)
+}
+
+fn i64_upper(lte: Option<&Value>, lt: Option<&Value>) -> Result<i64, Unsupported> {
+  if let Some(v) = lte {
+    return v
+      .as_i64()
+      .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
+      .ok_or_else(|| Unsupported::with_detail("range.lte", "must fit in i64"));
+  }
+  if let Some(v) = lt {
+    let n = v
+      .as_i64()
+      .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
+      .ok_or_else(|| Unsupported::with_detail("range.lt", "must fit in i64"))?;
+    return Ok(n.saturating_sub(1));
+  }
+  Ok(i64::MAX)
+}
+
+fn f64_lower(gte: Option<&Value>, gt: Option<&Value>) -> Result<f64, Unsupported> {
+  if let Some(v) = gte {
+    return v
+      .as_f64()
+      .ok_or_else(|| Unsupported::with_detail("range.gte", "must be numeric"));
+  }
+  if let Some(v) = gt {
+    let n = v
+      .as_f64()
+      .ok_or_else(|| Unsupported::with_detail("range.gt", "must be numeric"))?;
+    // SearchLite F64Range is inclusive; nudge upward by next-representable.
+    return Ok(next_up(n));
+  }
+  Ok(f64::NEG_INFINITY)
+}
+
+fn f64_upper(lte: Option<&Value>, lt: Option<&Value>) -> Result<f64, Unsupported> {
+  if let Some(v) = lte {
+    return v
+      .as_f64()
+      .ok_or_else(|| Unsupported::with_detail("range.lte", "must be numeric"));
+  }
+  if let Some(v) = lt {
+    let n = v
+      .as_f64()
+      .ok_or_else(|| Unsupported::with_detail("range.lt", "must be numeric"))?;
+    return Ok(next_down(n));
+  }
+  Ok(f64::INFINITY)
+}
+
+fn next_up(x: f64) -> f64 {
+  if x.is_nan() || x == f64::INFINITY {
+    return x;
+  }
+  let bits = x.to_bits();
+  let next = if x >= 0.0 { bits + 1 } else { bits - 1 };
+  f64::from_bits(next)
+}
+
+fn next_down(x: f64) -> f64 {
+  if x.is_nan() || x == f64::NEG_INFINITY {
+    return x;
+  }
+  let bits = x.to_bits();
+  let next = if x > 0.0 { bits - 1 } else { bits + 1 };
+  f64::from_bits(next)
+}
+
+// --- exists --------------------------------------------------------------
+
+fn translate_exists(_body: &Value) -> Result<Value, Unsupported> {
+  Err(Unsupported::with_detail(
+    "exists",
+    "no equivalent in searchlite; reject for v1",
+  ))
+}
+
+// --- bool ----------------------------------------------------------------
+
+fn translate_bool(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("bool", "expected an object"))?;
+
+  let must = collect_clause_array(map.get("must"))?;
+  let should = collect_clause_array(map.get("should"))?;
+  let must_not = collect_clause_array(map.get("must_not"))?;
+  let filter_clauses = collect_clause_array(map.get("filter"))?;
+
+  let must_translated = must
+    .iter()
+    .map(translate_query)
+    .collect::<Result<Vec<_>, _>>()?;
+  let should_translated = should
+    .iter()
+    .map(translate_query)
+    .collect::<Result<Vec<_>, _>>()?;
+  let must_not_translated = must_not
+    .iter()
+    .map(translate_query)
+    .collect::<Result<Vec<_>, _>>()?;
+  let filter_translated = filter_clauses
+    .iter()
+    .map(translate_to_filter)
+    .collect::<Result<Vec<_>, _>>()?;
+
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("bool".into()));
+  out.insert("must".into(), Value::Array(must_translated));
+  out.insert("should".into(), Value::Array(should_translated));
+  out.insert("must_not".into(), Value::Array(must_not_translated));
+  out.insert("filter".into(), Value::Array(filter_translated));
+
+  if let Some(msm) = map.get("minimum_should_match") {
+    let n = msm
+      .as_u64()
+      .ok_or_else(|| Unsupported::with_detail("bool.minimum_should_match", "must be unsigned int"))?;
+    out.insert("minimum_should_match".into(), Value::from(n));
+  }
+  if let Some(boost) = map.get("boost") {
+    out.insert("boost".into(), boost.clone());
+  }
+  Ok(Value::Object(out))
+}
+
+fn collect_clause_array(value: Option<&Value>) -> Result<Vec<Value>, Unsupported> {
+  match value {
+    None => Ok(Vec::new()),
+    Some(Value::Array(items)) => Ok(items.clone()),
+    Some(other) => Ok(vec![other.clone()]),
+  }
+}
+
+/// Translate an ES query clause that appears in a filter context into a
+/// SearchLite Filter (externally-tagged JSON).
+pub fn translate_to_filter(es: &Value) -> Result<Value, Unsupported> {
+  let map = es
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("filter", "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "filter",
+      "expected exactly one clause",
+    ));
+  }
+  let (clause, body) = map.iter().next().unwrap();
+  match clause.as_str() {
+    "term" => term_to_filter(body),
+    "terms" => terms_to_filter(body),
+    "range" => translate_range_to_filter(body),
+    "bool" => bool_to_filter(body),
+    "match_all" => Ok(json!({ "And": [] })),
+    other => Err(Unsupported::with_detail(
+      format!("filter.{other}"),
+      "not all query clauses are valid in filter context",
+    )),
+  }
+}
+
+fn term_to_filter(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("term", "expected an object"))?;
+  if map.len() != 1 {
+    return Err(Unsupported::with_detail(
+      "term",
+      "expected exactly one field",
+    ));
+  }
+  let (field, spec) = map.iter().next().unwrap();
+  let (value, _boost) = parse_value_or_object(spec, "term")?;
+  Ok(json!({ "KeywordEq": { "field": field, "value": value } }))
+}
+
+fn terms_to_filter(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("terms", "expected an object"))?;
+  let mut field_iter = map.iter().filter(|(k, _)| *k != "boost");
+  let (field, spec) = field_iter
+    .next()
+    .ok_or_else(|| Unsupported::with_detail("terms", "missing field entry"))?;
+  let values: Vec<String> = spec
+    .as_array()
+    .ok_or_else(|| Unsupported::with_detail("terms", "field value must be array"))?
+    .iter()
+    .map(|v| {
+      v.as_str()
+        .map(str::to_string)
+        .or_else(|| v.as_i64().map(|n| n.to_string()))
+        .or_else(|| v.as_u64().map(|n| n.to_string()))
+        .or_else(|| v.as_f64().map(|n| n.to_string()))
+        .ok_or_else(|| Unsupported::with_detail("terms", "values must be primitives"))
+    })
+    .collect::<Result<Vec<_>, _>>()?;
+  Ok(json!({ "KeywordIn": { "field": field, "values": values } }))
+}
+
+fn bool_to_filter(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("bool", "expected an object"))?;
+  let must = collect_clause_array(map.get("must"))?;
+  let must_not = collect_clause_array(map.get("must_not"))?;
+  let filter = collect_clause_array(map.get("filter"))?;
+  let should = collect_clause_array(map.get("should"))?;
+  if !should.is_empty() {
+    return Err(Unsupported::with_detail(
+      "filter.bool.should",
+      "should clauses cannot appear inside filter context",
+    ));
+  }
+
+  let mut and_parts: Vec<Value> = Vec::new();
+  for clause in must.iter().chain(filter.iter()) {
+    and_parts.push(translate_to_filter(clause)?);
+  }
+  for clause in must_not {
+    let inner = translate_to_filter(&clause)?;
+    and_parts.push(json!({ "Not": inner }));
+  }
+  if and_parts.len() == 1 {
+    Ok(and_parts.into_iter().next().unwrap())
+  } else {
+    Ok(json!({ "And": and_parts }))
+  }
+}
+
+// --- constant_score / dis_max -------------------------------------------
+
+fn translate_constant_score(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("constant_score", "expected an object"))?;
+  let filter_node = map
+    .get("filter")
+    .ok_or_else(|| Unsupported::with_detail("constant_score.filter", "missing"))?;
+  let filter = translate_to_filter(filter_node)?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("constant_score".into()));
+  out.insert("filter".into(), filter);
+  if let Some(boost) = map.get("boost") {
+    out.insert("boost".into(), boost.clone());
+  }
+  Ok(Value::Object(out))
+}
+
+fn translate_dis_max(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("dis_max", "expected an object"))?;
+  let queries = map
+    .get("queries")
+    .and_then(Value::as_array)
+    .ok_or_else(|| Unsupported::with_detail("dis_max.queries", "missing array"))?
+    .iter()
+    .map(translate_query)
+    .collect::<Result<Vec<_>, _>>()?;
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("dis_max".into()));
+  out.insert("queries".into(), Value::Array(queries));
+  if let Some(tb) = map.get("tie_breaker") {
+    out.insert("tie_breaker".into(), tb.clone());
+  }
+  if let Some(boost) = map.get("boost") {
+    out.insert("boost".into(), boost.clone());
+  }
+  Ok(Value::Object(out))
+}
+
+// --- query_string --------------------------------------------------------
+
+fn translate_query_string(body: &Value) -> Result<Value, Unsupported> {
+  let map = body
+    .as_object()
+    .ok_or_else(|| Unsupported::with_detail("query_string", "expected an object"))?;
+  let query = map
+    .get("query")
+    .and_then(Value::as_str)
+    .ok_or_else(|| Unsupported::with_detail("query_string", "missing string `query`"))?
+    .to_string();
+  let mut out = Map::new();
+  out.insert("type".into(), Value::String("query_string".into()));
+  out.insert("query".into(), Value::String(query));
+
+  if let Some(fields) = map.get("fields").and_then(Value::as_array) {
+    let translated = fields
+      .iter()
+      .map(translate_field_spec)
+      .collect::<Result<Vec<_>, _>>()?;
+    out.insert("fields".into(), Value::Array(translated));
+  } else if let Some(default_field) = map.get("default_field").and_then(Value::as_str) {
+    out.insert(
+      "fields".into(),
+      Value::Array(vec![translate_field_spec(&Value::String(
+        default_field.to_string(),
+      ))?]),
+    );
+  }
+  if let Some(boost) = map.get("boost") {
+    out.insert("boost".into(), boost.clone());
+  }
+  Ok(Value::Object(out))
+}

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -655,6 +655,14 @@ pub fn translate_range_to_filter(body: &Value) -> Result<Value, Unsupported> {
   if is_int {
     let min = i64_lower(gte, gt)?;
     let max = i64_upper(lte, lt)?;
+    // `gt: i64::MAX` and `lt: i64::MIN` are exclusive bounds with no
+    // representable integer satisfying them; either bound returning `None`
+    // means the range is impossible. Emit a deliberately-empty range
+    // (`min > max`) so the upstream filter matches zero documents.
+    let (min, max) = match (min, max) {
+      (Some(min), Some(max)) => (min, max),
+      _ => (i64::MAX, i64::MIN),
+    };
     Ok(json!({ "I64Range": { "field": field, "min": min, "max": max } }))
   } else {
     let min = f64_lower(gte, gt)?;
@@ -670,38 +678,46 @@ fn is_integer_value(v: &Value) -> bool {
   }
 }
 
-fn i64_lower(gte: Option<&Value>, gt: Option<&Value>) -> Result<i64, Unsupported> {
+/// Returns the inclusive lower bound, or `None` when the bound is
+/// representable in input but unrepresentable in i64 after the exclusive
+/// adjustment (e.g. `gt: i64::MAX` has no integer satisfying it).
+fn i64_lower(gte: Option<&Value>, gt: Option<&Value>) -> Result<Option<i64>, Unsupported> {
   if let Some(v) = gte {
-    return v
+    let n = v
       .as_i64()
       .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
-      .ok_or_else(|| Unsupported::with_detail("range.gte", "must fit in i64"));
+      .ok_or_else(|| Unsupported::with_detail("range.gte", "must fit in i64"))?;
+    return Ok(Some(n));
   }
   if let Some(v) = gt {
     let n = v
       .as_i64()
       .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
       .ok_or_else(|| Unsupported::with_detail("range.gt", "must fit in i64"))?;
-    return Ok(n.saturating_add(1));
+    // checked_add returns None for `gt: i64::MAX` since no integer is > i64::MAX.
+    return Ok(n.checked_add(1));
   }
-  Ok(i64::MIN)
+  Ok(Some(i64::MIN))
 }
 
-fn i64_upper(lte: Option<&Value>, lt: Option<&Value>) -> Result<i64, Unsupported> {
+/// Returns the inclusive upper bound, or `None` when `lt` is set to
+/// `i64::MIN` (no integer satisfies the predicate).
+fn i64_upper(lte: Option<&Value>, lt: Option<&Value>) -> Result<Option<i64>, Unsupported> {
   if let Some(v) = lte {
-    return v
+    let n = v
       .as_i64()
       .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
-      .ok_or_else(|| Unsupported::with_detail("range.lte", "must fit in i64"));
+      .ok_or_else(|| Unsupported::with_detail("range.lte", "must fit in i64"))?;
+    return Ok(Some(n));
   }
   if let Some(v) = lt {
     let n = v
       .as_i64()
       .or_else(|| v.as_u64().and_then(|n| i64::try_from(n).ok()))
       .ok_or_else(|| Unsupported::with_detail("range.lt", "must fit in i64"))?;
-    return Ok(n.saturating_sub(1));
+    return Ok(n.checked_sub(1));
   }
-  Ok(i64::MAX)
+  Ok(Some(i64::MAX))
 }
 
 fn f64_lower(gte: Option<&Value>, gt: Option<&Value>) -> Result<f64, Unsupported> {

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -71,6 +71,26 @@ fn translate_match(body: &Value) -> Result<Value, Unsupported> {
     ));
   }
   let (field, spec) = map.iter().next().unwrap();
+  // Reject ES `match` options that change matching semantics in ways
+  // SearchLite has no equivalent for. Silent drops would let a request
+  // succeed but diverge from caller intent without any signal — match the
+  // project pattern of rejecting loudly.
+  if let Some(opts) = spec.as_object() {
+    for opt in [
+      "zero_terms_query",
+      "lenient",
+      "cutoff_frequency",
+      "analyzer",
+      "auto_generate_synonyms_phrase_query",
+    ] {
+      if opts.contains_key(opt) {
+        return Err(Unsupported::with_detail(
+          format!("match.{opt}"),
+          "no SearchLite equivalent",
+        ));
+      }
+    }
+  }
   let parsed = parse_match_spec(spec)?;
 
   let mut out = Map::new();
@@ -250,6 +270,25 @@ fn translate_multi_match(body: &Value) -> Result<Value, Unsupported> {
   let map = body
     .as_object()
     .ok_or_else(|| Unsupported::with_detail("multi_match", "expected an object"))?;
+  // Same loud-rejection policy as `match` for options that change matching
+  // semantics with no SearchLite equivalent.
+  for opt in [
+    "zero_terms_query",
+    "lenient",
+    "cutoff_frequency",
+    "analyzer",
+    "slop",
+    "prefix_length",
+    "max_expansions",
+    "auto_generate_synonyms_phrase_query",
+  ] {
+    if map.contains_key(opt) {
+      return Err(Unsupported::with_detail(
+        format!("multi_match.{opt}"),
+        "no SearchLite equivalent",
+      ));
+    }
+  }
   let query = map
     .get("query")
     .and_then(Value::as_str)

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -141,8 +141,14 @@ fn parse_match_spec(spec: &Value) -> Result<MatchSpec, Unsupported> {
       Ok(MatchSpec {
         query,
         boost: map.get("boost").and_then(Value::as_f64),
-        fuzziness: map.get("fuzziness").and_then(Value::as_str).map(str::to_string),
-        operator: map.get("operator").and_then(Value::as_str).map(str::to_string),
+        fuzziness: map
+          .get("fuzziness")
+          .and_then(Value::as_str)
+          .map(str::to_string),
+        operator: map
+          .get("operator")
+          .and_then(Value::as_str)
+          .map(str::to_string),
       })
     }
     _ => Err(Unsupported::with_detail(
@@ -185,7 +191,10 @@ fn translate_match_phrase(body: &Value, _prefix: bool) -> Result<Value, Unsuppor
     }
   };
 
-  let terms: Vec<Value> = text.split_whitespace().map(|t| Value::String(t.to_string())).collect();
+  let terms: Vec<Value> = text
+    .split_whitespace()
+    .map(|t| Value::String(t.to_string()))
+    .collect();
   let mut out = Map::new();
   out.insert("type".into(), Value::String("phrase".into()));
   out.insert("field".into(), Value::String(field.clone()));
@@ -264,9 +273,9 @@ fn translate_field_spec(spec: &Value) -> Result<Value, Unsupported> {
   match spec {
     Value::String(s) => {
       if let Some((name, boost)) = s.split_once('^') {
-        let boost: f64 = boost.parse().map_err(|_| {
-          Unsupported::with_detail("fields", format!("invalid boost in `{s}`"))
-        })?;
+        let boost: f64 = boost
+          .parse()
+          .map_err(|_| Unsupported::with_detail("fields", format!("invalid boost in `{s}`")))?;
         Ok(json!({ "field": name, "boost": boost }))
       } else {
         Ok(json!({ "field": s }))
@@ -294,9 +303,9 @@ fn translate_fuzziness(value: &Value) -> Result<Value, Unsupported> {
       )),
     },
     Value::Number(n) => {
-      let edits = n.as_u64().ok_or_else(|| {
-        Unsupported::with_detail("fuzziness", "must be a non-negative integer")
-      })?;
+      let edits = n
+        .as_u64()
+        .ok_or_else(|| Unsupported::with_detail("fuzziness", "must be a non-negative integer"))?;
       if edits > 2 {
         return Err(Unsupported::with_detail(
           "fuzziness",
@@ -305,11 +314,69 @@ fn translate_fuzziness(value: &Value) -> Result<Value, Unsupported> {
       }
       Ok(json!({ "max_edits": edits }))
     }
-    _ => Err(Unsupported::with_detail("fuzziness", "must be string or number")),
+    _ => Err(Unsupported::with_detail(
+      "fuzziness",
+      "must be string or number",
+    )),
   }
 }
 
 // --- term / terms --------------------------------------------------------
+
+/// Classified ES `term`/`terms` value, preserving numeric type so we can route
+/// integer/float terms to SearchLite's I64Range/F64Range filters instead of
+/// stringifying them as keywords (which never matches a numeric field).
+enum TermValue {
+  Keyword(String),
+  I64(i64),
+  F64(f64),
+}
+
+fn classify_term_value(
+  spec: &Value,
+  clause: &str,
+) -> Result<(TermValue, Option<f64>), Unsupported> {
+  match spec {
+    Value::String(s) => Ok((TermValue::Keyword(s.clone()), None)),
+    Value::Bool(b) => Ok((TermValue::Keyword(b.to_string()), None)),
+    Value::Number(n) => {
+      let value = numeric_term(n, clause)?;
+      Ok((value, None))
+    }
+    Value::Object(opts) => {
+      let inner = opts
+        .get("value")
+        .or_else(|| opts.get("query"))
+        .ok_or_else(|| Unsupported::with_detail(clause, "missing `value`"))?;
+      let (value, _) = classify_term_value(inner, clause)?;
+      let boost = opts.get("boost").and_then(Value::as_f64);
+      Ok((value, boost))
+    }
+    _ => Err(Unsupported::with_detail(
+      clause,
+      "spec must be primitive or object",
+    )),
+  }
+}
+
+fn numeric_term(n: &serde_json::Number, clause: &str) -> Result<TermValue, Unsupported> {
+  if let Some(i) = n.as_i64() {
+    return Ok(TermValue::I64(i));
+  }
+  if let Some(u) = n.as_u64() {
+    return match i64::try_from(u) {
+      Ok(i) => Ok(TermValue::I64(i)),
+      Err(_) => Ok(TermValue::F64(u as f64)),
+    };
+  }
+  if let Some(f) = n.as_f64() {
+    return Ok(TermValue::F64(f));
+  }
+  Err(Unsupported::with_detail(
+    clause,
+    "numeric value not representable as i64 or f64",
+  ))
+}
 
 fn translate_term(body: &Value) -> Result<Value, Unsupported> {
   let map = body
@@ -322,15 +389,42 @@ fn translate_term(body: &Value) -> Result<Value, Unsupported> {
     ));
   }
   let (field, spec) = map.iter().next().unwrap();
-  let (value, boost) = parse_value_or_object(spec, "term")?;
+  let (value, boost) = classify_term_value(spec, "term")?;
+  match value {
+    TermValue::Keyword(s) => {
+      let mut out = Map::new();
+      out.insert("type".into(), Value::String("term".into()));
+      out.insert("field".into(), Value::String(field.clone()));
+      out.insert("value".into(), Value::String(s));
+      if let Some(b) = boost {
+        out.insert("boost".into(), Value::from(b));
+      }
+      Ok(Value::Object(out))
+    }
+    TermValue::I64(n) => Ok(numeric_term_query(
+      field,
+      json!({ "I64Range": { "field": field, "min": n, "max": n } }),
+      boost,
+    )),
+    TermValue::F64(f) => Ok(numeric_term_query(
+      field,
+      json!({ "F64Range": { "field": field, "min": f, "max": f } }),
+      boost,
+    )),
+  }
+}
+
+/// ES `term` against a numeric field is constant-score scoping to a single
+/// value. SearchLite has no native numeric `term`, so wrap an equality range
+/// (min == max) in `constant_score` to preserve scoring semantics.
+fn numeric_term_query(_field: &str, filter: Value, boost: Option<f64>) -> Value {
   let mut out = Map::new();
-  out.insert("type".into(), Value::String("term".into()));
-  out.insert("field".into(), Value::String(field.clone()));
-  out.insert("value".into(), Value::String(value));
+  out.insert("type".into(), Value::String("constant_score".into()));
+  out.insert("filter".into(), filter);
   if let Some(b) = boost {
     out.insert("boost".into(), Value::from(b));
   }
-  Ok(Value::Object(out))
+  Value::Object(out)
 }
 
 fn translate_terms(body: &Value) -> Result<Value, Unsupported> {
@@ -395,7 +489,10 @@ fn parse_value_or_object(spec: &Value, clause: &str) -> Result<(String, Option<f
       let boost = opts.get("boost").and_then(Value::as_f64);
       Ok((primitive, boost))
     }
-    _ => Err(Unsupported::with_detail(clause, "spec must be primitive or object")),
+    _ => Err(Unsupported::with_detail(
+      clause,
+      "spec must be primitive or object",
+    )),
   }
 }
 
@@ -571,22 +668,15 @@ fn f64_upper(lte: Option<&Value>, lt: Option<&Value>) -> Result<f64, Unsupported
   Ok(f64::INFINITY)
 }
 
+// Use the standard library's IEEE-754 next/prev helpers (stable since Rust 1.86).
+// These handle ±0.0, subnormals, and infinities correctly, unlike the previous
+// hand-rolled bit-twiddling.
 fn next_up(x: f64) -> f64 {
-  if x.is_nan() || x == f64::INFINITY {
-    return x;
-  }
-  let bits = x.to_bits();
-  let next = if x >= 0.0 { bits + 1 } else { bits - 1 };
-  f64::from_bits(next)
+  f64::next_up(x)
 }
 
 fn next_down(x: f64) -> f64 {
-  if x.is_nan() || x == f64::NEG_INFINITY {
-    return x;
-  }
-  let bits = x.to_bits();
-  let next = if x > 0.0 { bits - 1 } else { bits + 1 };
-  f64::from_bits(next)
+  f64::next_down(x)
 }
 
 // --- exists --------------------------------------------------------------
@@ -635,9 +725,9 @@ fn translate_bool(body: &Value) -> Result<Value, Unsupported> {
   out.insert("filter".into(), Value::Array(filter_translated));
 
   if let Some(msm) = map.get("minimum_should_match") {
-    let n = msm
-      .as_u64()
-      .ok_or_else(|| Unsupported::with_detail("bool.minimum_should_match", "must be unsigned int"))?;
+    let n = msm.as_u64().ok_or_else(|| {
+      Unsupported::with_detail("bool.minimum_should_match", "must be unsigned int")
+    })?;
     out.insert("minimum_should_match".into(), Value::from(n));
   }
   if let Some(boost) = map.get("boost") {
@@ -691,8 +781,12 @@ fn term_to_filter(body: &Value) -> Result<Value, Unsupported> {
     ));
   }
   let (field, spec) = map.iter().next().unwrap();
-  let (value, _boost) = parse_value_or_object(spec, "term")?;
-  Ok(json!({ "KeywordEq": { "field": field, "value": value } }))
+  let (value, _boost) = classify_term_value(spec, "term")?;
+  match value {
+    TermValue::Keyword(s) => Ok(json!({ "KeywordEq": { "field": field, "value": s } })),
+    TermValue::I64(n) => Ok(json!({ "I64Range": { "field": field, "min": n, "max": n } })),
+    TermValue::F64(f) => Ok(json!({ "F64Range": { "field": field, "min": f, "max": f } })),
+  }
 }
 
 fn terms_to_filter(body: &Value) -> Result<Value, Unsupported> {
@@ -703,6 +797,12 @@ fn terms_to_filter(body: &Value) -> Result<Value, Unsupported> {
   let (field, spec) = field_iter
     .next()
     .ok_or_else(|| Unsupported::with_detail("terms", "missing field entry"))?;
+  if field_iter.next().is_some() {
+    return Err(Unsupported::with_detail(
+      "terms",
+      "expected exactly one field entry",
+    ));
+  }
   let values: Vec<String> = spec
     .as_array()
     .ok_or_else(|| Unsupported::with_detail("terms", "field value must be array"))?

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -444,18 +444,12 @@ fn translate_terms(body: &Value) -> Result<Value, Unsupported> {
   let values = spec
     .as_array()
     .ok_or_else(|| Unsupported::with_detail("terms", "field value must be an array"))?;
+  // Per-value dispatch by type so numeric inputs route to range filters
+  // (which match numeric fields upstream) instead of being stringified into
+  // keyword `term` queries that never match.
   let shoulds: Vec<Value> = values
     .iter()
-    .map(|v| {
-      let term = v
-        .as_str()
-        .map(str::to_string)
-        .or_else(|| v.as_i64().map(|n| n.to_string()))
-        .or_else(|| v.as_u64().map(|n| n.to_string()))
-        .or_else(|| v.as_f64().map(|n| n.to_string()))
-        .ok_or_else(|| Unsupported::with_detail("terms", "values must be primitives"))?;
-      Ok(json!({ "type": "term", "field": field, "value": term }))
-    })
+    .map(|v| terms_value_to_query_node(field, v))
     .collect::<Result<Vec<_>, Unsupported>>()?;
 
   Ok(json!({
@@ -463,6 +457,32 @@ fn translate_terms(body: &Value) -> Result<Value, Unsupported> {
     "should": shoulds,
     "minimum_should_match": 1,
   }))
+}
+
+fn terms_value_to_query_node(field: &str, value: &Value) -> Result<Value, Unsupported> {
+  match classify_terms_element(value)? {
+    TermValue::Keyword(s) => Ok(json!({ "type": "term", "field": field, "value": s })),
+    TermValue::I64(n) => Ok(json!({
+      "type": "constant_score",
+      "filter": { "I64Range": { "field": field, "min": n, "max": n } },
+    })),
+    TermValue::F64(f) => Ok(json!({
+      "type": "constant_score",
+      "filter": { "F64Range": { "field": field, "min": f, "max": f } },
+    })),
+  }
+}
+
+fn classify_terms_element(value: &Value) -> Result<TermValue, Unsupported> {
+  match value {
+    Value::String(s) => Ok(TermValue::Keyword(s.clone())),
+    Value::Bool(b) => Ok(TermValue::Keyword(b.to_string())),
+    Value::Number(n) => numeric_term(n, "terms"),
+    _ => Err(Unsupported::with_detail(
+      "terms",
+      "values must be primitives (string, boolean, or number)",
+    )),
+  }
 }
 
 fn parse_value_or_object(spec: &Value, clause: &str) -> Result<(String, Option<f64>), Unsupported> {
@@ -803,20 +823,47 @@ fn terms_to_filter(body: &Value) -> Result<Value, Unsupported> {
       "expected exactly one field entry",
     ));
   }
-  let values: Vec<String> = spec
+  let array = spec
     .as_array()
-    .ok_or_else(|| Unsupported::with_detail("terms", "field value must be array"))?
+    .ok_or_else(|| Unsupported::with_detail("terms", "field value must be array"))?;
+  let classified: Vec<TermValue> = array
     .iter()
-    .map(|v| {
-      v.as_str()
-        .map(str::to_string)
-        .or_else(|| v.as_i64().map(|n| n.to_string()))
-        .or_else(|| v.as_u64().map(|n| n.to_string()))
-        .or_else(|| v.as_f64().map(|n| n.to_string()))
-        .ok_or_else(|| Unsupported::with_detail("terms", "values must be primitives"))
-    })
+    .map(classify_terms_element)
     .collect::<Result<Vec<_>, _>>()?;
-  Ok(json!({ "KeywordIn": { "field": field, "values": values } }))
+
+  // All-string fast path keeps the more compact `KeywordIn` filter shape.
+  // Mixed or numeric values fall through to per-value equality filters
+  // wrapped in `Or`, since SearchLite has no native "numeric in" filter.
+  if classified
+    .iter()
+    .all(|v| matches!(v, TermValue::Keyword(_)))
+  {
+    let values: Vec<String> = classified
+      .into_iter()
+      .map(|v| match v {
+        TermValue::Keyword(s) => s,
+        _ => unreachable!(),
+      })
+      .collect();
+    return Ok(json!({ "KeywordIn": { "field": field, "values": values } }));
+  }
+
+  let filters: Vec<Value> = classified
+    .into_iter()
+    .map(|v| match v {
+      TermValue::Keyword(s) => json!({ "KeywordEq": { "field": field, "value": s } }),
+      TermValue::I64(n) => json!({ "I64Range": { "field": field, "min": n, "max": n } }),
+      TermValue::F64(f) => json!({ "F64Range": { "field": field, "min": f, "max": f } }),
+    })
+    .collect();
+  match filters.len() {
+    0 => Err(Unsupported::with_detail(
+      "terms",
+      "values array must be non-empty",
+    )),
+    1 => Ok(filters.into_iter().next().unwrap()),
+    _ => Ok(json!({ "Or": filters })),
+  }
 }
 
 fn bool_to_filter(body: &Value) -> Result<Value, Unsupported> {

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -110,8 +110,8 @@ fn translate_match(body: &Value) -> Result<Value, Unsupported> {
     ));
   }
   if let Some(op) = parsed.operator {
-    let upper = op.to_ascii_lowercase();
-    if upper != "or" {
+    let normalized = op.to_ascii_lowercase();
+    if normalized != "or" {
       return Err(Unsupported::with_detail(
         "match.operator",
         "only `or` is supported for `match`",

--- a/searchlite-adapter-elastic/src/translate/query.rs
+++ b/searchlite-adapter-elastic/src/translate/query.rs
@@ -191,6 +191,29 @@ fn translate_match_phrase(body: &Value, _prefix: bool) -> Result<Value, Unsuppor
     }
   };
 
+  // Slop=0 (the default) → emit a `query_string` with a quoted phrase so
+  // tokenization runs through the field's analyzer (matching ES behaviour
+  // for punctuation, contractions, non-ASCII). For slop > 0 we fall back
+  // to the literal-token `phrase` translation since `query_string` quoted
+  // phrases don't model token proximity.
+  let slop_value = slop.unwrap_or(0);
+  if slop_value == 0 {
+    let mut out = Map::new();
+    out.insert("type".into(), Value::String("query_string".into()));
+    out.insert(
+      "query".into(),
+      Value::String(quote_phrase_for_query_string(&text)),
+    );
+    out.insert(
+      "fields".into(),
+      Value::Array(vec![Value::String(field.clone())]),
+    );
+    if let Some(b) = boost {
+      out.insert("boost".into(), Value::from(b));
+    }
+    return Ok(Value::Object(out));
+  }
+
   let terms: Vec<Value> = text
     .split_whitespace()
     .map(|t| Value::String(t.to_string()))
@@ -199,13 +222,26 @@ fn translate_match_phrase(body: &Value, _prefix: bool) -> Result<Value, Unsuppor
   out.insert("type".into(), Value::String("phrase".into()));
   out.insert("field".into(), Value::String(field.clone()));
   out.insert("terms".into(), Value::Array(terms));
-  if let Some(s) = slop {
-    out.insert("slop".into(), Value::from(s));
-  }
+  out.insert("slop".into(), Value::from(slop_value));
   if let Some(b) = boost {
     out.insert("boost".into(), Value::from(b));
   }
   Ok(Value::Object(out))
+}
+
+/// Wrap text in quotes for `query_string` syntax, escaping the only two
+/// characters that have meaning inside a quoted phrase: `\` and `"`.
+fn quote_phrase_for_query_string(text: &str) -> String {
+  let mut out = String::with_capacity(text.len() + 2);
+  out.push('"');
+  for ch in text.chars() {
+    if ch == '"' || ch == '\\' {
+      out.push('\\');
+    }
+    out.push(ch);
+  }
+  out.push('"');
+  out
 }
 
 // --- multi_match ---------------------------------------------------------
@@ -236,10 +272,16 @@ fn translate_multi_match(body: &Value) -> Result<Value, Unsupported> {
     let t_norm = match t {
       "best_fields" | "most_fields" | "cross_fields" => t.to_string(),
       "phrase" | "phrase_prefix" | "bool_prefix" => {
+        // Don't recommend best_fields/most_fields/cross_fields here — they
+        // are bag-of-words modes with different matching semantics. Phrase
+        // intent is closer to `match_phrase` per field; we surface that
+        // hint without claiming an exact equivalent.
         return Err(Unsupported::with_detail(
           "multi_match.type",
-          format!("`{t}` not supported; use best_fields/most_fields/cross_fields"),
-        ))
+          format!(
+            "`{t}` not supported in v1; consider issuing `match_phrase` per field combined under `dis_max`"
+          ),
+        ));
       }
       other => {
         return Err(Unsupported::with_detail(
@@ -431,7 +473,12 @@ fn translate_terms(body: &Value) -> Result<Value, Unsupported> {
   let map = body
     .as_object()
     .ok_or_else(|| Unsupported::with_detail("terms", "expected an object"))?;
-  let mut field_iter = map.iter().filter(|(k, _)| *k != "boost");
+  // Only treat `boost` as the meta-key when its value is numeric (the only
+  // shape ES documents). Otherwise it's a legitimate field name — silently
+  // filtering it would make any schema with a `boost` column unqueryable.
+  let mut field_iter = map
+    .iter()
+    .filter(|(k, v)| !(*k == "boost" && v.is_number()));
   let (field, spec) = field_iter
     .next()
     .ok_or_else(|| Unsupported::with_detail("terms", "missing field entry"))?;
@@ -737,6 +784,9 @@ fn translate_bool(body: &Value) -> Result<Value, Unsupported> {
     .map(translate_to_filter)
     .collect::<Result<Vec<_>, _>>()?;
 
+  // Capture the should-clause count before moving `should_translated` into
+  // the output, since `resolve_bool_msm` needs it for percentage resolution.
+  let should_count = should_translated.len();
   let mut out = Map::new();
   out.insert("type".into(), Value::String("bool".into()));
   out.insert("must".into(), Value::Array(must_translated));
@@ -745,15 +795,87 @@ fn translate_bool(body: &Value) -> Result<Value, Unsupported> {
   out.insert("filter".into(), Value::Array(filter_translated));
 
   if let Some(msm) = map.get("minimum_should_match") {
-    let n = msm.as_u64().ok_or_else(|| {
-      Unsupported::with_detail("bool.minimum_should_match", "must be unsigned int")
-    })?;
-    out.insert("minimum_should_match".into(), Value::from(n));
+    // Core's `Bool.minimum_should_match` is `Option<usize>` only — it doesn't
+    // accept ES's `"75%"` percentage form like `multi_match` does. Resolve
+    // the percentage adapter-side against the should-clause count so the
+    // common Kibana shape works.
+    let resolved = resolve_bool_msm(msm, should_count)?;
+    out.insert("minimum_should_match".into(), Value::from(resolved as u64));
   }
   if let Some(boost) = map.get("boost") {
     out.insert("boost".into(), boost.clone());
   }
   Ok(Value::Object(out))
+}
+
+/// Resolve a `bool.minimum_should_match` value against the count of `should`
+/// clauses. Accepts:
+///
+/// - non-negative integer (`3`)
+/// - integer-as-string (`"3"`)
+/// - whole or fractional percentage (`"75%"`) → `floor(should_count * pct / 100)`
+///
+/// Rejects negatives, ES's combinator syntax (`"3<90%"`, `"-25%"`), and any
+/// other shape with a clear error.
+fn resolve_bool_msm(value: &Value, should_count: usize) -> Result<usize, Unsupported> {
+  match value {
+    Value::Number(n) => n
+      .as_u64()
+      .map(|n| (n as usize).min(should_count))
+      .ok_or_else(|| {
+        Unsupported::with_detail(
+          "bool.minimum_should_match",
+          "must be a non-negative integer",
+        )
+      }),
+    Value::String(s) => parse_msm_string(s.trim(), should_count),
+    _ => Err(Unsupported::with_detail(
+      "bool.minimum_should_match",
+      "must be an integer or a percentage string like \"75%\"",
+    )),
+  }
+}
+
+fn parse_msm_string(s: &str, should_count: usize) -> Result<usize, Unsupported> {
+  if let Some(stripped) = s.strip_suffix('%') {
+    // Reject combinator syntax (`3<90%`) and signed forms — supporting them
+    // properly is non-trivial and silently mis-translating is worse than
+    // returning a clear error.
+    if stripped.contains('<') || stripped.starts_with('-') || stripped.starts_with('+') {
+      return Err(Unsupported::with_detail(
+        "bool.minimum_should_match",
+        "combinator and signed percentage syntax (e.g. `3<90%`, `-25%`) is not supported",
+      ));
+    }
+    let pct: f64 = stripped.parse().map_err(|_| {
+      Unsupported::with_detail(
+        "bool.minimum_should_match",
+        format!("invalid percentage `{s}`"),
+      )
+    })?;
+    if !(0.0..=100.0).contains(&pct) {
+      return Err(Unsupported::with_detail(
+        "bool.minimum_should_match",
+        "percentage must be between 0 and 100",
+      ));
+    }
+    let resolved = ((should_count as f64) * pct / 100.0).floor() as usize;
+    return Ok(resolved.min(should_count));
+  }
+  // Bare integer string — accept defensively (some ES clients send "3").
+  let n: i64 = s.parse().map_err(|_| {
+    Unsupported::with_detail(
+      "bool.minimum_should_match",
+      format!("must be an integer or percentage, got `{s}`"),
+    )
+  })?;
+  if n < 0 {
+    return Err(Unsupported::with_detail(
+      "bool.minimum_should_match",
+      "negative integers are not supported (use a percentage instead)",
+    ));
+  }
+  Ok((n as usize).min(should_count))
 }
 
 fn collect_clause_array(value: Option<&Value>) -> Result<Vec<Value>, Unsupported> {
@@ -813,7 +935,12 @@ fn terms_to_filter(body: &Value) -> Result<Value, Unsupported> {
   let map = body
     .as_object()
     .ok_or_else(|| Unsupported::with_detail("terms", "expected an object"))?;
-  let mut field_iter = map.iter().filter(|(k, _)| *k != "boost");
+  // Only treat `boost` as the meta-key when its value is numeric (the only
+  // shape ES documents). Otherwise it's a legitimate field name — silently
+  // filtering it would make any schema with a `boost` column unqueryable.
+  let mut field_iter = map
+    .iter()
+    .filter(|(k, v)| !(*k == "boost" && v.is_number()));
   let (field, spec) = field_iter
     .next()
     .ok_or_else(|| Unsupported::with_detail("terms", "missing field entry"))?;

--- a/searchlite-adapter-elastic/src/translate/request.rs
+++ b/searchlite-adapter-elastic/src/translate/request.rs
@@ -11,7 +11,21 @@ use super::unsupported::Unsupported;
 /// `SearchRequest` body. Always sets `return_stored: true` so callers see
 /// `_source` in hits.
 pub fn translate_search_body(es_body: &Value) -> Result<Value, Unsupported> {
-  let map = es_body.as_object().cloned().unwrap_or_default();
+  // Accept only an object body or a literal `null`. Previously any non-object
+  // value was silently coerced into an empty map and run as `match_all` —
+  // for `_msearch` that meant a malformed body line scanned the whole index
+  // instead of returning a parse error. ES treats a missing/null body as
+  // match-all, so we keep that behaviour for `null` only.
+  let map = match es_body {
+    Value::Object(map) => map.clone(),
+    Value::Null => Map::new(),
+    _ => {
+      return Err(Unsupported::with_detail(
+        "body",
+        "search body must be a JSON object",
+      ))
+    }
+  };
 
   if map.contains_key("script_fields") {
     return Err(Unsupported::feature("script_fields"));

--- a/searchlite-adapter-elastic/src/translate/request.rs
+++ b/searchlite-adapter-elastic/src/translate/request.rs
@@ -1,0 +1,142 @@
+use serde_json::{Map, Value};
+
+use super::aggregation::translate_aggs;
+use super::highlight::translate_highlight;
+use super::pagination::apply_pagination;
+use super::query::translate_query;
+use super::sort::translate_sort;
+use super::unsupported::Unsupported;
+
+/// Translate an Elasticsearch `_search` request body into a SearchLite
+/// `SearchRequest` body. Always sets `return_stored: true` so callers see
+/// `_source` in hits.
+pub fn translate_search_body(es_body: &Value) -> Result<Value, Unsupported> {
+  let map = es_body
+    .as_object()
+    .cloned()
+    .unwrap_or_default();
+
+  if map.contains_key("script_fields") {
+    return Err(Unsupported::feature("script_fields"));
+  }
+  if map.contains_key("docvalue_fields") {
+    return Err(Unsupported::feature("docvalue_fields"));
+  }
+  if map.contains_key("stored_fields") {
+    return Err(Unsupported::feature("stored_fields"));
+  }
+  if map.contains_key("post_filter") {
+    return Err(Unsupported::feature("post_filter"));
+  }
+  if map.contains_key("min_score") {
+    return Err(Unsupported::feature("min_score"));
+  }
+  if map.contains_key("indices_boost") {
+    return Err(Unsupported::feature("indices_boost"));
+  }
+  if map.contains_key("collapse") {
+    return Err(Unsupported::feature("collapse"));
+  }
+  if map.contains_key("rescore") {
+    return Err(Unsupported::feature("rescore"));
+  }
+  if map.contains_key("suggest") {
+    return Err(Unsupported::feature("suggest"));
+  }
+  if map.contains_key("pit") {
+    return Err(Unsupported::feature("point_in_time"));
+  }
+
+  let mut out = Map::new();
+
+  let query = match map.get("query") {
+    Some(q) => translate_query(q)?,
+    None => translate_query(&Value::Object(Map::new()))?,
+  };
+  out.insert("query".into(), query);
+
+  apply_pagination(&map, &mut out)?;
+
+  if let Some(sort) = map.get("sort") {
+    out.insert("sort".into(), Value::Array(translate_sort(sort)?));
+  }
+
+  if let Some(highlight) = map.get("highlight") {
+    out.insert("highlight".into(), translate_highlight(highlight)?);
+  }
+
+  if let Some(source) = map.get("_source") {
+    apply_source(source, &mut out)?;
+  } else {
+    out.insert("return_stored".into(), Value::Bool(true));
+  }
+
+  let aggs_value = map
+    .get("aggs")
+    .or_else(|| map.get("aggregations"))
+    .cloned();
+  if let Some(aggs_value) = aggs_value {
+    let aggs_map = aggs_value
+      .as_object()
+      .ok_or_else(|| Unsupported::with_detail("aggs", "must be an object"))?;
+    let translated = translate_aggs(aggs_map)?;
+    out.insert("aggs".into(), Value::Object(translated));
+  }
+
+  if let Some(explain) = map.get("explain") {
+    out.insert("explain".into(), explain.clone());
+  }
+  if let Some(profile) = map.get("profile") {
+    out.insert("profile".into(), profile.clone());
+  }
+
+  Ok(Value::Object(out))
+}
+
+fn apply_source(source: &Value, out: &mut Map<String, Value>) -> Result<(), Unsupported> {
+  match source {
+    Value::Bool(false) => {
+      out.insert("return_stored".into(), Value::Bool(false));
+      out.insert("return_hits".into(), Value::Bool(true));
+    }
+    Value::Bool(true) => {
+      out.insert("return_stored".into(), Value::Bool(true));
+    }
+    Value::Array(items) => {
+      let fields: Vec<Value> = items
+        .iter()
+        .filter_map(Value::as_str)
+        .map(|s| Value::String(s.to_string()))
+        .collect();
+      if !fields.is_empty() {
+        out.insert("fields".into(), Value::Array(fields));
+      }
+      out.insert("return_stored".into(), Value::Bool(true));
+    }
+    Value::String(field) => {
+      out.insert(
+        "fields".into(),
+        Value::Array(vec![Value::String(field.clone())]),
+      );
+      out.insert("return_stored".into(), Value::Bool(true));
+    }
+    Value::Object(opts) => {
+      if let Some(includes) = opts.get("includes").and_then(Value::as_array) {
+        let fields: Vec<Value> = includes
+          .iter()
+          .filter_map(Value::as_str)
+          .map(|s| Value::String(s.to_string()))
+          .collect();
+        if !fields.is_empty() {
+          out.insert("fields".into(), Value::Array(fields));
+        }
+      }
+      if opts.get("excludes").is_some() {
+        return Err(Unsupported::feature("_source.excludes"));
+      }
+      out.insert("return_stored".into(), Value::Bool(true));
+    }
+    _ => return Err(Unsupported::feature("_source")),
+  }
+  Ok(())
+}

--- a/searchlite-adapter-elastic/src/translate/request.rs
+++ b/searchlite-adapter-elastic/src/translate/request.rs
@@ -11,10 +11,7 @@ use super::unsupported::Unsupported;
 /// `SearchRequest` body. Always sets `return_stored: true` so callers see
 /// `_source` in hits.
 pub fn translate_search_body(es_body: &Value) -> Result<Value, Unsupported> {
-  let map = es_body
-    .as_object()
-    .cloned()
-    .unwrap_or_default();
+  let map = es_body.as_object().cloned().unwrap_or_default();
 
   if map.contains_key("script_fields") {
     return Err(Unsupported::feature("script_fields"));
@@ -71,10 +68,7 @@ pub fn translate_search_body(es_body: &Value) -> Result<Value, Unsupported> {
     out.insert("return_stored".into(), Value::Bool(true));
   }
 
-  let aggs_value = map
-    .get("aggs")
-    .or_else(|| map.get("aggregations"))
-    .cloned();
+  let aggs_value = map.get("aggs").or_else(|| map.get("aggregations")).cloned();
   if let Some(aggs_value) = aggs_value {
     let aggs_map = aggs_value
       .as_object()

--- a/searchlite-adapter-elastic/src/translate/request.rs
+++ b/searchlite-adapter-elastic/src/translate/request.rs
@@ -129,12 +129,37 @@ fn apply_source(source: &Value, out: &mut Map<String, Value>) -> Result<(), Unsu
       out.insert("return_stored".into(), Value::Bool(true));
     }
     Value::Object(opts) => {
-      if let Some(includes) = opts.get("includes").and_then(Value::as_array) {
-        let fields: Vec<Value> = includes
-          .iter()
-          .filter_map(Value::as_str)
-          .map(|s| Value::String(s.to_string()))
-          .collect();
+      if let Some(includes) = opts.get("includes") {
+        // ES accepts both the single-string form (`"includes": "title"`) and
+        // the array form (`"includes": ["title", "category"]`). Previously
+        // we only handled the array case via `filter_map(Value::as_str)`,
+        // which silently dropped non-string entries (widening the payload)
+        // and ignored the string form entirely (also widening). Validate
+        // both shapes and reject invalid elements with a clear error.
+        let fields = match includes {
+          Value::String(s) => vec![Value::String(s.clone())],
+          Value::Array(items) => {
+            let mut fields = Vec::with_capacity(items.len());
+            for item in items {
+              match item.as_str() {
+                Some(s) => fields.push(Value::String(s.to_string())),
+                None => {
+                  return Err(Unsupported::with_detail(
+                    "_source.includes",
+                    format!("array element must be a string, got {item}"),
+                  ));
+                }
+              }
+            }
+            fields
+          }
+          _ => {
+            return Err(Unsupported::with_detail(
+              "_source.includes",
+              "must be a string or array of strings",
+            ));
+          }
+        };
         if !fields.is_empty() {
           out.insert("fields".into(), Value::Array(fields));
         }

--- a/searchlite-adapter-elastic/src/translate/response.rs
+++ b/searchlite-adapter-elastic/src/translate/response.rs
@@ -112,6 +112,34 @@ fn translate_aggregation(agg: &Value) -> Value {
   };
   let kind = map.get("type").and_then(Value::as_str).unwrap_or("");
   match kind {
+    // Range / date_range honor the `keyed` flag on the SL response. ES
+    // returns an object map (key → bucket) when keyed, an array otherwise.
+    // Other bucket types (terms, histogram, etc.) always emit arrays.
+    "range" | "date_range" if map.get("keyed").and_then(Value::as_bool) == Some(true) => {
+      let mut out = Map::new();
+      if let Some(buckets) = map.get("buckets").and_then(Value::as_array) {
+        let mut keyed = Map::new();
+        for bucket in buckets {
+          let key = bucket
+            .get("key")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| bucket.get("key").map(|v| v.to_string()).unwrap_or_default());
+          if key.is_empty() {
+            continue;
+          }
+          // Drop `key`/`key_as_string` from the inner value — the outer map
+          // key IS the key in ES's keyed shape.
+          let translated = translate_bucket(bucket);
+          let mut entry = translated.as_object().cloned().unwrap_or_default();
+          entry.remove("key");
+          entry.remove("key_as_string");
+          keyed.insert(key, Value::Object(entry));
+        }
+        out.insert("buckets".into(), Value::Object(keyed));
+      }
+      Value::Object(out)
+    }
     "terms" | "rare_terms" | "range" | "date_range" | "histogram" | "date_histogram"
     | "composite" | "significant_terms" => {
       let mut out = Map::new();

--- a/searchlite-adapter-elastic/src/translate/response.rs
+++ b/searchlite-adapter-elastic/src/translate/response.rs
@@ -11,7 +11,10 @@ pub fn translate_search_response(index: &str, sl: &Value, took_ms: u64) -> Value
     json!({ "total": 1, "successful": 1, "skipped": 0, "failed": 0 }),
   );
 
-  let total = sl.get("total_hits_estimate").and_then(Value::as_u64).unwrap_or(0);
+  let total = sl
+    .get("total_hits_estimate")
+    .and_then(Value::as_u64)
+    .unwrap_or(0);
   let hits_arr = sl
     .get("hits")
     .and_then(Value::as_array)
@@ -69,10 +72,7 @@ fn translate_hit(index: &str, hit: &Value) -> Value {
     out.insert("_source".into(), f.clone());
   }
   if let Some(snippet) = map.and_then(|m| m.get("snippet")) {
-    out.insert(
-      "highlight".into(),
-      json!({ "_snippet": [snippet] }),
-    );
+    out.insert("highlight".into(), json!({ "_snippet": [snippet] }));
   }
   if let Some(highlights) = map.and_then(|m| m.get("highlights")) {
     out.insert("highlight".into(), highlights.clone());
@@ -172,8 +172,7 @@ fn translate_aggregation(agg: &Value) -> Value {
         }
       })
     }
-    "bucket_sort" | "avg_bucket" | "sum_bucket" | "derivative" | "moving_avg"
-    | "bucket_script" => {
+    "bucket_sort" | "avg_bucket" | "sum_bucket" | "derivative" | "moving_avg" | "bucket_script" => {
       let mut out = Map::new();
       copy_field(map, "value", &mut out);
       copy_field(map, "from", &mut out);

--- a/searchlite-adapter-elastic/src/translate/response.rs
+++ b/searchlite-adapter-elastic/src/translate/response.rs
@@ -2,7 +2,20 @@ use serde_json::{json, Map, Value};
 
 /// Translate a SearchLite SearchResult into an Elasticsearch search response
 /// envelope. `took_ms` is computed by the route handler.
-pub fn translate_search_response(index: &str, sl: &Value, took_ms: u64) -> Value {
+///
+/// `track_total_hits` reflects the original ES request's flag so the response
+/// reports total semantics correctly:
+///   * `Some(true)`  → emit `hits.total = { value, relation: "eq" }` (exact)
+///   * `Some(false)` → omit `hits.total` entirely (matches ES behaviour when
+///     totals are explicitly disabled)
+///   * `None`        → emit `hits.total = { value, relation: "gte" }` (lower
+///     bound — historical default for callers that don't set the flag)
+pub fn translate_search_response(
+  index: &str,
+  sl: &Value,
+  took_ms: u64,
+  track_total_hits: Option<bool>,
+) -> Value {
   let mut env = Map::new();
   env.insert("took".into(), Value::from(took_ms));
   env.insert("timed_out".into(), Value::Bool(false));
@@ -32,14 +45,25 @@ pub fn translate_search_response(index: &str, sl: &Value, took_ms: u64) -> Value
     })
     .collect();
 
-  env.insert(
-    "hits".into(),
-    json!({
-      "total": { "value": total, "relation": "gte" },
-      "max_score": max_score.map(Value::from).unwrap_or(Value::Null),
-      "hits": translated_hits,
-    }),
+  let mut hits = Map::new();
+  match track_total_hits {
+    Some(true) => {
+      hits.insert("total".into(), json!({ "value": total, "relation": "eq" }));
+    }
+    Some(false) => {
+      // Omit `total` entirely — matches ES, which signals "totals disabled"
+      // by not emitting the field rather than fabricating a value.
+    }
+    None => {
+      hits.insert("total".into(), json!({ "value": total, "relation": "gte" }));
+    }
+  }
+  hits.insert(
+    "max_score".into(),
+    max_score.map(Value::from).unwrap_or(Value::Null),
   );
+  hits.insert("hits".into(), Value::Array(translated_hits));
+  env.insert("hits".into(), Value::Object(hits));
 
   if let Some(aggs) = sl.get("aggregations").and_then(Value::as_object) {
     if !aggs.is_empty() {

--- a/searchlite-adapter-elastic/src/translate/response.rs
+++ b/searchlite-adapter-elastic/src/translate/response.rs
@@ -71,11 +71,26 @@ fn translate_hit(index: &str, hit: &Value) -> Value {
   if let Some(f) = fields {
     out.insert("_source".into(), f.clone());
   }
-  if let Some(snippet) = map.and_then(|m| m.get("snippet")) {
-    out.insert("highlight".into(), json!({ "_snippet": [snippet] }));
-  }
-  if let Some(highlights) = map.and_then(|m| m.get("highlights")) {
-    out.insert("highlight".into(), highlights.clone());
+  // Precedence: prefer structured `highlights` (per-field map) over the legacy
+  // single-field `snippet`. When both are present we keep `highlights` as the
+  // primary payload but surface the snippet under `_snippet` so neither field
+  // is silently dropped — the previous unconditional double-insert overwrote
+  // the snippet.
+  let snippet = map.and_then(|m| m.get("snippet")).cloned();
+  let highlights = map.and_then(|m| m.get("highlights")).cloned();
+  match (highlights, snippet) {
+    (Some(h), Some(s)) => {
+      let mut merged = h.as_object().cloned().unwrap_or_default();
+      merged.insert("_snippet".to_string(), json!([s]));
+      out.insert("highlight".into(), Value::Object(merged));
+    }
+    (Some(h), None) => {
+      out.insert("highlight".into(), h);
+    }
+    (None, Some(s)) => {
+      out.insert("highlight".into(), json!({ "_snippet": [s] }));
+    }
+    (None, None) => {}
   }
   if let Some(sort_key) = map.and_then(|m| m.get("sort_key")) {
     out.insert("sort".into(), sort_key.clone());

--- a/searchlite-adapter-elastic/src/translate/response.rs
+++ b/searchlite-adapter-elastic/src/translate/response.rs
@@ -1,0 +1,242 @@
+use serde_json::{json, Map, Value};
+
+/// Translate a SearchLite SearchResult into an Elasticsearch search response
+/// envelope. `took_ms` is computed by the route handler.
+pub fn translate_search_response(index: &str, sl: &Value, took_ms: u64) -> Value {
+  let mut env = Map::new();
+  env.insert("took".into(), Value::from(took_ms));
+  env.insert("timed_out".into(), Value::Bool(false));
+  env.insert(
+    "_shards".into(),
+    json!({ "total": 1, "successful": 1, "skipped": 0, "failed": 0 }),
+  );
+
+  let total = sl.get("total_hits_estimate").and_then(Value::as_u64).unwrap_or(0);
+  let hits_arr = sl
+    .get("hits")
+    .and_then(Value::as_array)
+    .cloned()
+    .unwrap_or_default();
+  let mut max_score: Option<f64> = None;
+  let translated_hits: Vec<Value> = hits_arr
+    .iter()
+    .map(|hit| {
+      let translated = translate_hit(index, hit);
+      if let Some(score) = translated.get("_score").and_then(Value::as_f64) {
+        max_score = Some(max_score.map_or(score, |m| m.max(score)));
+      }
+      translated
+    })
+    .collect();
+
+  env.insert(
+    "hits".into(),
+    json!({
+      "total": { "value": total, "relation": "gte" },
+      "max_score": max_score.map(Value::from).unwrap_or(Value::Null),
+      "hits": translated_hits,
+    }),
+  );
+
+  if let Some(aggs) = sl.get("aggregations").and_then(Value::as_object) {
+    if !aggs.is_empty() {
+      env.insert("aggregations".into(), translate_aggregations(aggs));
+    }
+  }
+
+  Value::Object(env)
+}
+
+fn translate_hit(index: &str, hit: &Value) -> Value {
+  let map = hit.as_object();
+  let id = map
+    .and_then(|m| m.get("doc_id"))
+    .and_then(Value::as_str)
+    .unwrap_or("")
+    .to_string();
+  let score = map.and_then(|m| m.get("score"));
+  let fields = map.and_then(|m| m.get("fields"));
+
+  let mut out = Map::new();
+  out.insert("_index".into(), Value::String(index.to_string()));
+  out.insert("_id".into(), Value::String(id));
+  if let Some(s) = score {
+    out.insert("_score".into(), s.clone());
+  } else {
+    out.insert("_score".into(), Value::Null);
+  }
+  if let Some(f) = fields {
+    out.insert("_source".into(), f.clone());
+  }
+  if let Some(snippet) = map.and_then(|m| m.get("snippet")) {
+    out.insert(
+      "highlight".into(),
+      json!({ "_snippet": [snippet] }),
+    );
+  }
+  if let Some(highlights) = map.and_then(|m| m.get("highlights")) {
+    out.insert("highlight".into(), highlights.clone());
+  }
+  if let Some(sort_key) = map.and_then(|m| m.get("sort_key")) {
+    out.insert("sort".into(), sort_key.clone());
+  }
+  Value::Object(out)
+}
+
+fn translate_aggregations(sl_aggs: &Map<String, Value>) -> Value {
+  let mut out = Map::new();
+  for (name, agg) in sl_aggs {
+    out.insert(name.clone(), translate_aggregation(agg));
+  }
+  Value::Object(out)
+}
+
+fn translate_aggregation(agg: &Value) -> Value {
+  let Some(map) = agg.as_object() else {
+    return agg.clone();
+  };
+  let kind = map.get("type").and_then(Value::as_str).unwrap_or("");
+  match kind {
+    "terms" | "rare_terms" | "range" | "date_range" | "histogram" | "date_histogram"
+    | "composite" | "significant_terms" => {
+      let mut out = Map::new();
+      if let Some(buckets) = map.get("buckets").and_then(Value::as_array) {
+        let translated_buckets: Vec<Value> = buckets.iter().map(translate_bucket).collect();
+        out.insert("buckets".into(), Value::Array(translated_buckets));
+      }
+      if let Some(after_key) = map.get("after_key") {
+        out.insert("after_key".into(), after_key.clone());
+      }
+      if let Some(doc_count) = map.get("doc_count") {
+        out.insert("doc_count".into(), doc_count.clone());
+      }
+      Value::Object(out)
+    }
+    "filter" | "nested" => {
+      let mut out = Map::new();
+      if let Some(doc_count) = map.get("doc_count") {
+        out.insert("doc_count".into(), doc_count.clone());
+      }
+      if let Some(sub) = map.get("aggregations").and_then(Value::as_object) {
+        for (name, value) in sub {
+          out.insert(name.clone(), translate_aggregation(value));
+        }
+      }
+      Value::Object(out)
+    }
+    "stats" => {
+      let mut out = Map::new();
+      copy_field(map, "count", &mut out);
+      copy_field(map, "min", &mut out);
+      copy_field(map, "max", &mut out);
+      copy_field(map, "sum", &mut out);
+      copy_field(map, "avg", &mut out);
+      Value::Object(out)
+    }
+    "extended_stats" => {
+      let mut out = Map::new();
+      copy_field(map, "count", &mut out);
+      copy_field(map, "min", &mut out);
+      copy_field(map, "max", &mut out);
+      copy_field(map, "sum", &mut out);
+      copy_field(map, "avg", &mut out);
+      copy_field(map, "variance", &mut out);
+      copy_field(map, "std_deviation", &mut out);
+      Value::Object(out)
+    }
+    "value_count" | "cardinality" => {
+      let mut out = Map::new();
+      copy_field(map, "value", &mut out);
+      Value::Object(out)
+    }
+    "percentiles" | "percentile_ranks" => {
+      let mut out = Map::new();
+      if let Some(values) = map.get("values") {
+        out.insert("values".into(), values.clone());
+      }
+      Value::Object(out)
+    }
+    "top_hits" => {
+      let total = map.get("total").and_then(Value::as_u64).unwrap_or(0);
+      let hits = map
+        .get("hits")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+      let translated_hits: Vec<Value> = hits.iter().map(top_hit_to_es).collect();
+      json!({
+        "hits": {
+          "total": { "value": total, "relation": "eq" },
+          "max_score": Value::Null,
+          "hits": translated_hits,
+        }
+      })
+    }
+    "bucket_sort" | "avg_bucket" | "sum_bucket" | "derivative" | "moving_avg"
+    | "bucket_script" => {
+      let mut out = Map::new();
+      copy_field(map, "value", &mut out);
+      copy_field(map, "from", &mut out);
+      copy_field(map, "size", &mut out);
+      copy_field(map, "predictions", &mut out);
+      Value::Object(out)
+    }
+    _ => agg.clone(),
+  }
+}
+
+fn translate_bucket(bucket: &Value) -> Value {
+  let Some(map) = bucket.as_object() else {
+    return bucket.clone();
+  };
+  let mut out = Map::new();
+  if let Some(key) = map.get("key") {
+    out.insert("key".into(), key.clone());
+    if let Some(s) = key.as_str() {
+      out.insert("key_as_string".into(), Value::String(s.to_string()));
+    }
+  }
+  if let Some(doc_count) = map.get("doc_count") {
+    out.insert("doc_count".into(), doc_count.clone());
+  }
+  if let Some(bg_count) = map.get("bg_count") {
+    out.insert("bg_count".into(), bg_count.clone());
+  }
+  if let Some(score) = map.get("score") {
+    out.insert("score".into(), score.clone());
+  }
+  if let Some(sub) = map.get("aggregations").and_then(Value::as_object) {
+    for (name, value) in sub {
+      out.insert(name.clone(), translate_aggregation(value));
+    }
+  }
+  Value::Object(out)
+}
+
+fn top_hit_to_es(hit: &Value) -> Value {
+  let Some(map) = hit.as_object() else {
+    return hit.clone();
+  };
+  let mut out = Map::new();
+  if let Some(id) = map.get("doc_id") {
+    out.insert("_id".into(), id.clone());
+  }
+  if let Some(score) = map.get("score") {
+    out.insert("_score".into(), score.clone());
+  } else {
+    out.insert("_score".into(), Value::Null);
+  }
+  if let Some(fields) = map.get("fields") {
+    out.insert("_source".into(), fields.clone());
+  }
+  if let Some(snippet) = map.get("snippet") {
+    out.insert("highlight".into(), json!({ "_snippet": [snippet] }));
+  }
+  Value::Object(out)
+}
+
+fn copy_field(src: &Map<String, Value>, key: &str, dst: &mut Map<String, Value>) {
+  if let Some(v) = src.get(key) {
+    dst.insert(key.to_string(), v.clone());
+  }
+}

--- a/searchlite-adapter-elastic/src/translate/response.rs
+++ b/searchlite-adapter-elastic/src/translate/response.rs
@@ -231,10 +231,22 @@ fn translate_aggregation(agg: &Value) -> Value {
         .cloned()
         .unwrap_or_default();
       let translated_hits: Vec<Value> = hits.iter().map(top_hit_to_es).collect();
+      // Compute max_score from inner hits — ES populates this with the largest
+      // `_score` across the bucket's hits (or null when there are none / none
+      // carry a score). Previously hard-coded to null, which made SDKs that
+      // branch on this signal think every bucket was empty.
+      let max_score = translated_hits
+        .iter()
+        .filter_map(|hit| hit.get("_score").and_then(Value::as_f64))
+        .fold(None, |acc: Option<f64>, score| {
+          Some(acc.map_or(score, |m| m.max(score)))
+        })
+        .map(Value::from)
+        .unwrap_or(Value::Null);
       json!({
         "hits": {
           "total": { "value": total, "relation": "eq" },
-          "max_score": Value::Null,
+          "max_score": max_score,
           "hits": translated_hits,
         }
       })

--- a/searchlite-adapter-elastic/src/translate/sort.rs
+++ b/searchlite-adapter-elastic/src/translate/sort.rs
@@ -62,7 +62,16 @@ fn translate_sort_entry(entry: &Value) -> Result<Value, Unsupported> {
               "not implemented",
             ));
           }
-          // `missing` accepted but ignored (SearchLite default behavior applies).
+          if opts.contains_key("missing") {
+            // ES `missing` controls where docs without the sort field land
+            // (`_first` / `_last` / a literal value). SearchLite has no
+            // equivalent knob — silently accepting would diverge from ES
+            // ordering with no signal. Reject loudly.
+            return Err(Unsupported::with_detail(
+              "sort.missing",
+              "not implemented; SearchLite has no equivalent missing-value placement directive",
+            ));
+          }
           Ok(json!({ "field": field, "order": order }))
         }
         _ => Err(Unsupported::with_detail(

--- a/searchlite-adapter-elastic/src/translate/sort.rs
+++ b/searchlite-adapter-elastic/src/translate/sort.rs
@@ -1,0 +1,89 @@
+use serde_json::{json, Value};
+
+use super::unsupported::Unsupported;
+
+/// Translate the ES `sort` field into SearchLite's `[{field, order}]` shape.
+///
+/// Accepted forms:
+/// - `"field"` → `[{field, order: "asc"}]`
+/// - `["field", {field2: "desc"}]`
+/// - `[{field: {order: "desc", missing: "_last"}}]`
+/// - `"_score"` translates verbatim
+pub fn translate_sort(es_sort: &Value) -> Result<Vec<Value>, Unsupported> {
+  let entries = match es_sort {
+    Value::String(_) | Value::Object(_) => vec![es_sort.clone()],
+    Value::Array(items) => items.clone(),
+    _ => {
+      return Err(Unsupported::with_detail(
+        "sort",
+        "expected string, object, or array of either",
+      ));
+    }
+  };
+
+  let mut translated = Vec::with_capacity(entries.len());
+  for entry in entries {
+    translated.push(translate_sort_entry(&entry)?);
+  }
+  Ok(translated)
+}
+
+fn translate_sort_entry(entry: &Value) -> Result<Value, Unsupported> {
+  match entry {
+    Value::String(field) => Ok(json!({ "field": field, "order": "asc" })),
+    Value::Object(map) => {
+      if map.len() != 1 {
+        return Err(Unsupported::with_detail(
+          "sort",
+          "sort object must contain exactly one field",
+        ));
+      }
+      let (field, spec) = map.iter().next().unwrap();
+      match spec {
+        Value::String(order) => Ok(json!({ "field": field, "order": normalize_order(order)? })),
+        Value::Object(opts) => {
+          let order = opts
+            .get("order")
+            .and_then(Value::as_str)
+            .map(normalize_order)
+            .transpose()?
+            .unwrap_or_else(|| "asc".to_string());
+
+          if opts.contains_key("mode") {
+            return Err(Unsupported::with_detail("sort.mode", "not implemented"));
+          }
+          if opts.contains_key("nested") || opts.contains_key("nested_path") {
+            return Err(Unsupported::with_detail("sort.nested", "not implemented"));
+          }
+          if opts.contains_key("unmapped_type") {
+            return Err(Unsupported::with_detail(
+              "sort.unmapped_type",
+              "not implemented",
+            ));
+          }
+          // `missing` accepted but ignored (SearchLite default behavior applies).
+          Ok(json!({ "field": field, "order": order }))
+        }
+        _ => Err(Unsupported::with_detail(
+          "sort",
+          "sort spec must be a string or object",
+        )),
+      }
+    }
+    _ => Err(Unsupported::with_detail(
+      "sort",
+      "sort entry must be a string or object",
+    )),
+  }
+}
+
+fn normalize_order(order: &str) -> Result<String, Unsupported> {
+  match order.to_ascii_lowercase().as_str() {
+    "asc" => Ok("asc".to_string()),
+    "desc" => Ok("desc".to_string()),
+    other => Err(Unsupported::with_detail(
+      "sort.order",
+      format!("unknown order `{other}`, expected `asc` or `desc`"),
+    )),
+  }
+}

--- a/searchlite-adapter-elastic/src/translate/sort.rs
+++ b/searchlite-adapter-elastic/src/translate/sort.rs
@@ -5,7 +5,8 @@ use super::unsupported::Unsupported;
 /// Translate the ES `sort` field into SearchLite's `[{field, order}]` shape.
 ///
 /// Accepted forms:
-/// - `"field"` → `[{field, order: "asc"}]`
+/// - `"field"` → `[{field, order: "asc"}]` (but `_score` defaults to `desc`,
+///   matching Elasticsearch — score-sorting is normally relevance-descending)
 /// - `["field", {field2: "desc"}]`
 /// - `[{field: {order: "desc", missing: "_last"}}]`
 /// - `"_score"` translates verbatim
@@ -30,7 +31,7 @@ pub fn translate_sort(es_sort: &Value) -> Result<Vec<Value>, Unsupported> {
 
 fn translate_sort_entry(entry: &Value) -> Result<Value, Unsupported> {
   match entry {
-    Value::String(field) => Ok(json!({ "field": field, "order": "asc" })),
+    Value::String(field) => Ok(json!({ "field": field, "order": default_order(field) })),
     Value::Object(map) => {
       if map.len() != 1 {
         return Err(Unsupported::with_detail(
@@ -47,7 +48,7 @@ fn translate_sort_entry(entry: &Value) -> Result<Value, Unsupported> {
             .and_then(Value::as_str)
             .map(normalize_order)
             .transpose()?
-            .unwrap_or_else(|| "asc".to_string());
+            .unwrap_or_else(|| default_order(field).to_string());
 
           if opts.contains_key("mode") {
             return Err(Unsupported::with_detail("sort.mode", "not implemented"));
@@ -74,6 +75,17 @@ fn translate_sort_entry(entry: &Value) -> Result<Value, Unsupported> {
       "sort",
       "sort entry must be a string or object",
     )),
+  }
+}
+
+/// Elasticsearch defaults `_score` sorting to `desc` (relevance high → low) and
+/// other fields to `asc`. Mirror that so `sort: "_score"` and `sort: {"_score": {}}`
+/// behave like ES.
+fn default_order(field: &str) -> &'static str {
+  if field == "_score" {
+    "desc"
+  } else {
+    "asc"
   }
 }
 

--- a/searchlite-adapter-elastic/src/translate/unsupported.rs
+++ b/searchlite-adapter-elastic/src/translate/unsupported.rs
@@ -1,0 +1,43 @@
+use thiserror::Error;
+
+use crate::error::ESError;
+
+#[derive(Debug, Clone, Error)]
+#[error("elasticsearch feature `{feature}` is not supported by searchlite adapter: {detail}")]
+pub struct Unsupported {
+  pub feature: String,
+  pub detail: String,
+}
+
+impl Unsupported {
+  pub fn feature(feature: impl Into<String>) -> Self {
+    Self {
+      feature: feature.into(),
+      detail: String::new(),
+    }
+  }
+
+  pub fn with_detail(feature: impl Into<String>, detail: impl Into<String>) -> Self {
+    Self {
+      feature: feature.into(),
+      detail: detail.into(),
+    }
+  }
+}
+
+impl From<Unsupported> for ESError {
+  fn from(value: Unsupported) -> ESError {
+    let reason = if value.detail.is_empty() {
+      format!(
+        "feature `{}` not supported by searchlite adapter",
+        value.feature
+      )
+    } else {
+      format!(
+        "feature `{}` not supported by searchlite adapter: {}",
+        value.feature, value.detail
+      )
+    };
+    ESError::bad_request("x_content_parse_exception", reason)
+  }
+}

--- a/searchlite-adapter-elastic/tests/translate_aggregation.rs
+++ b/searchlite-adapter-elastic/tests/translate_aggregation.rs
@@ -91,3 +91,218 @@ fn cardinality_translates() {
   assert_eq!(translated.get("type").unwrap(), &json!("cardinality"));
   assert_eq!(translated.get("field").unwrap(), &json!("user_id"));
 }
+
+#[test]
+fn top_hits_translates_with_size_from_sort() {
+  let es = aggs(json!({
+    "hits": {
+      "top_hits": {
+        "size": 5,
+        "from": 1,
+        "sort": [{ "price": "desc" }]
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("hits").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("top_hits"));
+  assert_eq!(translated.get("size").unwrap(), &json!(5));
+  assert_eq!(translated.get("from").unwrap(), &json!(1));
+  let sort = translated.get("sort").unwrap().as_array().unwrap();
+  assert_eq!(sort.len(), 1);
+  assert_eq!(sort[0].get("field").unwrap(), &json!("price"));
+  assert_eq!(sort[0].get("order").unwrap(), &json!("desc"));
+}
+
+#[test]
+fn top_hits_uses_default_size_when_omitted() {
+  let es = aggs(json!({ "hits": { "top_hits": {} } }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("hits").unwrap();
+  assert_eq!(translated.get("size").unwrap(), &json!(3));
+  assert_eq!(translated.get("from").unwrap(), &json!(0));
+}
+
+#[test]
+fn composite_agg_translates_terms_source() {
+  let es = aggs(json!({
+    "by_cat_then_brand": {
+      "composite": {
+        "size": 100,
+        "sources": [
+          { "cat": { "terms": { "field": "category" } } }
+        ]
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("by_cat_then_brand").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("composite"));
+  assert_eq!(translated.get("size").unwrap(), &json!(100));
+  let sources = translated.get("sources").unwrap().as_array().unwrap();
+  assert_eq!(sources.len(), 1);
+  assert_eq!(sources[0].get("type").unwrap(), &json!("terms"));
+  assert_eq!(sources[0].get("name").unwrap(), &json!("cat"));
+  assert_eq!(sources[0].get("field").unwrap(), &json!("category"));
+}
+
+#[test]
+fn composite_agg_with_histogram_source_carries_interval() {
+  let es = aggs(json!({
+    "by_price_bucket": {
+      "composite": {
+        "size": 50,
+        "sources": [
+          { "p": { "histogram": { "field": "price", "interval": 10.0 } } }
+        ]
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let sources = sl
+    .get("by_price_bucket")
+    .unwrap()
+    .get("sources")
+    .unwrap()
+    .as_array()
+    .unwrap();
+  assert_eq!(sources[0].get("type").unwrap(), &json!("histogram"));
+  assert_eq!(sources[0].get("interval").unwrap(), &json!(10.0));
+}
+
+#[test]
+fn composite_agg_propagates_after_key() {
+  let es = aggs(json!({
+    "page2": {
+      "composite": {
+        "size": 10,
+        "after": { "cat": "books" },
+        "sources": [
+          { "cat": { "terms": { "field": "category" } } }
+        ]
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  assert_eq!(
+    sl.get("page2").unwrap().get("after").unwrap(),
+    &json!({ "cat": "books" })
+  );
+}
+
+#[test]
+fn pipeline_agg_avg_bucket_carries_buckets_path() {
+  let es = aggs(json!({
+    "avg_per_day": {
+      "avg_bucket": { "buckets_path": "by_day>price.avg" }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("avg_per_day").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("avg_bucket"));
+  assert_eq!(
+    translated.get("buckets_path").unwrap(),
+    &json!("by_day>price.avg")
+  );
+}
+
+#[test]
+fn pipeline_agg_sum_bucket_translates() {
+  let es = aggs(json!({
+    "sum_per_day": {
+      "sum_bucket": { "buckets_path": "by_day>price.sum" }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  assert_eq!(
+    sl.get("sum_per_day").unwrap().get("type").unwrap(),
+    &json!("sum_bucket")
+  );
+}
+
+#[test]
+fn pipeline_agg_derivative_translates() {
+  let es = aggs(json!({
+    "deriv": { "derivative": { "buckets_path": "by_day>doc_count" } }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  assert_eq!(
+    sl.get("deriv").unwrap().get("type").unwrap(),
+    &json!("derivative")
+  );
+  assert_eq!(
+    sl.get("deriv").unwrap().get("buckets_path").unwrap(),
+    &json!("by_day>doc_count")
+  );
+}
+
+#[test]
+fn pipeline_agg_moving_avg_carries_window_and_predict() {
+  let es = aggs(json!({
+    "smoothed": {
+      "moving_avg": {
+        "buckets_path": "by_day>doc_count",
+        "window": 5,
+        "model": "simple",
+        "predict": 2
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("smoothed").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("moving_avg"));
+  assert_eq!(translated.get("window").unwrap(), &json!(5));
+  assert_eq!(translated.get("model").unwrap(), &json!("simple"));
+  assert_eq!(translated.get("predict").unwrap(), &json!(2));
+}
+
+#[test]
+fn pipeline_agg_bucket_script_passes_through_paths_and_script() {
+  let es = aggs(json!({
+    "ratio": {
+      "bucket_script": {
+        "buckets_path": { "a": "x>v", "b": "y>v" },
+        "script": "params.a / params.b"
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("ratio").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("bucket_script"));
+  assert_eq!(
+    translated.get("buckets_path").unwrap(),
+    &json!({ "a": "x>v", "b": "y>v" })
+  );
+  assert_eq!(
+    translated.get("script").unwrap(),
+    &json!("params.a / params.b")
+  );
+}
+
+#[test]
+fn bucket_sort_pipeline_agg_carries_from_size_and_sort() {
+  let es = aggs(json!({
+    "sorted": {
+      "bucket_sort": {
+        "from": 0,
+        "size": 5,
+        "sort": [{ "doc_count": "desc" }]
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("sorted").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("bucket_sort"));
+  assert_eq!(translated.get("from").unwrap(), &json!(0));
+  assert_eq!(translated.get("size").unwrap(), &json!(5));
+  let sort = translated.get("sort").unwrap().as_array().unwrap();
+  assert_eq!(sort[0].get("field").unwrap(), &json!("doc_count"));
+  assert_eq!(sort[0].get("order").unwrap(), &json!("desc"));
+}
+
+#[test]
+fn unsupported_avg_bucket_missing_buckets_path_rejected() {
+  let es = aggs(json!({ "x": { "avg_bucket": {} } }));
+  let err = translate_aggs(&es).unwrap_err();
+  assert!(err.feature.contains("avg_bucket"), "got {err:?}");
+}

--- a/searchlite-adapter-elastic/tests/translate_aggregation.rs
+++ b/searchlite-adapter-elastic/tests/translate_aggregation.rs
@@ -1,0 +1,93 @@
+use searchlite_adapter_elastic::translate::translate_aggs;
+use serde_json::{json, Map};
+
+fn aggs(body: serde_json::Value) -> Map<String, serde_json::Value> {
+  body.as_object().unwrap().clone()
+}
+
+#[test]
+fn terms_agg_round_trips_field_and_size() {
+  let es = aggs(json!({
+    "by_category": { "terms": { "field": "category", "size": 5 } }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  assert_eq!(
+    sl.get("by_category").unwrap(),
+    &json!({ "type": "terms", "field": "category", "size": 5 })
+  );
+}
+
+#[test]
+fn date_histogram_translates_calendar_interval() {
+  let es = aggs(json!({
+    "by_day": { "date_histogram": { "field": "ts", "calendar_interval": "day" } }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("by_day").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("date_histogram"));
+  assert_eq!(translated.get("field").unwrap(), &json!("ts"));
+  assert_eq!(translated.get("calendar_interval").unwrap(), &json!("day"));
+}
+
+#[test]
+fn range_agg_carries_keyed_default_false() {
+  let es = aggs(json!({
+    "by_price": {
+      "range": {
+        "field": "price",
+        "ranges": [{"to": 10}, {"from": 10, "to": 100}, {"from": 100}]
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("by_price").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("range"));
+  assert_eq!(translated.get("keyed").unwrap(), &json!(false));
+  let ranges = translated.get("ranges").unwrap().as_array().unwrap();
+  assert_eq!(ranges.len(), 3);
+}
+
+#[test]
+fn stats_metric_agg() {
+  let es = aggs(json!({ "p": { "stats": { "field": "price" } } }));
+  let sl = translate_aggs(&es).unwrap();
+  assert_eq!(
+    sl.get("p").unwrap(),
+    &json!({ "type": "stats", "field": "price", "missing": null })
+  );
+}
+
+#[test]
+fn nested_sub_aggs_recurse() {
+  let es = aggs(json!({
+    "by_category": {
+      "terms": { "field": "category" },
+      "aggs": {
+        "avg_price": { "stats": { "field": "price" } }
+      }
+    }
+  }));
+  let sl = translate_aggs(&es).unwrap();
+  let outer = sl.get("by_category").unwrap();
+  let inner = outer.get("aggs").unwrap();
+  assert_eq!(
+    inner.get("avg_price").unwrap(),
+    &json!({ "type": "stats", "field": "price", "missing": null })
+  );
+}
+
+#[test]
+fn unsupported_avg_returns_helpful_error() {
+  let es = aggs(json!({ "avg_price": { "avg": { "field": "price" } } }));
+  let err = translate_aggs(&es).unwrap_err();
+  assert!(err.detail.contains("stats"), "got {err:?}");
+}
+
+#[test]
+fn cardinality_translates() {
+  let es = aggs(json!({ "uniq": { "cardinality": { "field": "user_id" } } }));
+  let sl = translate_aggs(&es).unwrap();
+  let translated = sl.get("uniq").unwrap();
+  assert_eq!(translated.get("type").unwrap(), &json!("cardinality"));
+  assert_eq!(translated.get("field").unwrap(), &json!("user_id"));
+}

--- a/searchlite-adapter-elastic/tests/translate_highlight.rs
+++ b/searchlite-adapter-elastic/tests/translate_highlight.rs
@@ -1,0 +1,107 @@
+use searchlite_adapter_elastic::translate::translate_highlight;
+use serde_json::json;
+
+#[test]
+fn basic_per_field_highlight() {
+  let es = json!({
+    "fields": {
+      "title": {}
+    }
+  });
+  let sl = translate_highlight(&es).unwrap();
+  let title = sl
+    .pointer("/fields/title")
+    .expect("title field")
+    .as_object()
+    .unwrap();
+  // No global tags, no per-field options → empty per-field config.
+  assert!(
+    title.is_empty() || (!title.contains_key("pre_tag") && !title.contains_key("post_tag")),
+    "got {title:?}"
+  );
+}
+
+#[test]
+fn global_pre_post_tags_apply_to_all_fields() {
+  let es = json!({
+    "pre_tags": ["<em>"],
+    "post_tags": ["</em>"],
+    "fields": {
+      "title": {},
+      "description": {}
+    }
+  });
+  let sl = translate_highlight(&es).unwrap();
+  for field in ["title", "description"] {
+    let pre = sl.pointer(&format!("/fields/{field}/pre_tag")).unwrap();
+    let post = sl.pointer(&format!("/fields/{field}/post_tag")).unwrap();
+    assert_eq!(pre, &json!("<em>"));
+    assert_eq!(post, &json!("</em>"));
+  }
+}
+
+#[test]
+fn picks_first_tag_when_array_supplied() {
+  // ES allows arrays; SearchLite uses singular pre_tag/post_tag — first wins.
+  let es = json!({
+    "pre_tags": ["<a>", "<b>", "<c>"],
+    "post_tags": ["</a>", "</b>"],
+    "fields": { "title": {} }
+  });
+  let sl = translate_highlight(&es).unwrap();
+  assert_eq!(sl.pointer("/fields/title/pre_tag").unwrap(), &json!("<a>"));
+  assert_eq!(
+    sl.pointer("/fields/title/post_tag").unwrap(),
+    &json!("</a>")
+  );
+}
+
+#[test]
+fn per_field_tags_override_global() {
+  let es = json!({
+    "pre_tags": ["<em>"],
+    "post_tags": ["</em>"],
+    "fields": {
+      "title": { "pre_tags": ["<b>"], "post_tags": ["</b>"] },
+      "description": {}
+    }
+  });
+  let sl = translate_highlight(&es).unwrap();
+  assert_eq!(sl.pointer("/fields/title/pre_tag").unwrap(), &json!("<b>"));
+  assert_eq!(
+    sl.pointer("/fields/description/pre_tag").unwrap(),
+    &json!("<em>")
+  );
+}
+
+#[test]
+fn fragment_size_and_number_of_fragments_propagate() {
+  let es = json!({
+    "fields": {
+      "title": { "fragment_size": 200, "number_of_fragments": 3 }
+    }
+  });
+  let sl = translate_highlight(&es).unwrap();
+  assert_eq!(
+    sl.pointer("/fields/title/fragment_size").unwrap(),
+    &json!(200)
+  );
+  assert_eq!(
+    sl.pointer("/fields/title/number_of_fragments").unwrap(),
+    &json!(3)
+  );
+}
+
+#[test]
+fn missing_fields_object_rejected() {
+  let es = json!({ "pre_tags": ["<em>"] });
+  let err = translate_highlight(&es).unwrap_err();
+  assert!(err.feature.starts_with("highlight"), "got {err:?}");
+}
+
+#[test]
+fn non_object_input_rejected() {
+  let es = json!("not an object");
+  let err = translate_highlight(&es).unwrap_err();
+  assert_eq!(err.feature, "highlight");
+}

--- a/searchlite-adapter-elastic/tests/translate_mapping.rs
+++ b/searchlite-adapter-elastic/tests/translate_mapping.rs
@@ -114,6 +114,12 @@ fn nested_array_translates_to_es_nested_with_properties() {
     .unwrap();
   assert_eq!(comments.get("type").unwrap(), &json!("nested"));
   let inner = comments.get("properties").unwrap();
-  assert_eq!(inner.get("author").unwrap().get("type").unwrap(), &json!("keyword"));
-  assert_eq!(inner.get("votes").unwrap().get("type").unwrap(), &json!("long"));
+  assert_eq!(
+    inner.get("author").unwrap().get("type").unwrap(),
+    &json!("keyword")
+  );
+  assert_eq!(
+    inner.get("votes").unwrap().get("type").unwrap(),
+    &json!("long")
+  );
 }

--- a/searchlite-adapter-elastic/tests/translate_mapping.rs
+++ b/searchlite-adapter-elastic/tests/translate_mapping.rs
@@ -1,0 +1,119 @@
+use searchlite_adapter_elastic::translate::schema_to_es;
+use serde_json::json;
+
+#[test]
+fn text_field_maps_to_es_text_with_analyzer() {
+  let schema = json!({
+    "type": "object",
+    "properties": {
+      "title": {
+        "type": "string",
+        "searchlite:analyzer": "english",
+      }
+    }
+  });
+  let es = schema_to_es("books", &schema).unwrap();
+  let mapping = es.get("books").unwrap().get("mappings").unwrap();
+  let title = mapping.get("properties").unwrap().get("title").unwrap();
+  assert_eq!(title.get("type").unwrap(), &json!("text"));
+  assert_eq!(title.get("analyzer").unwrap(), &json!("english"));
+}
+
+#[test]
+fn keyword_field_maps_to_es_keyword() {
+  let schema = json!({
+    "type": "object",
+    "properties": {
+      "tag": {
+        "type": "string",
+        "searchlite:kind": "keyword",
+      }
+    }
+  });
+  let es = schema_to_es("idx", &schema).unwrap();
+  let tag = es
+    .get("idx")
+    .unwrap()
+    .get("mappings")
+    .unwrap()
+    .get("properties")
+    .unwrap()
+    .get("tag")
+    .unwrap();
+  assert_eq!(tag.get("type").unwrap(), &json!("keyword"));
+}
+
+#[test]
+fn integer_maps_to_long() {
+  let schema = json!({
+    "type": "object",
+    "properties": {
+      "count": { "type": "integer" }
+    }
+  });
+  let es = schema_to_es("idx", &schema).unwrap();
+  let count = es
+    .get("idx")
+    .unwrap()
+    .get("mappings")
+    .unwrap()
+    .get("properties")
+    .unwrap()
+    .get("count")
+    .unwrap();
+  assert_eq!(count.get("type").unwrap(), &json!("long"));
+}
+
+#[test]
+fn number_maps_to_double() {
+  let schema = json!({
+    "type": "object",
+    "properties": {
+      "price": { "type": "number" }
+    }
+  });
+  let es = schema_to_es("idx", &schema).unwrap();
+  let price = es
+    .get("idx")
+    .unwrap()
+    .get("mappings")
+    .unwrap()
+    .get("properties")
+    .unwrap()
+    .get("price")
+    .unwrap();
+  assert_eq!(price.get("type").unwrap(), &json!("double"));
+}
+
+#[test]
+fn nested_array_translates_to_es_nested_with_properties() {
+  let schema = json!({
+    "type": "object",
+    "properties": {
+      "comments": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "author": { "type": "string", "searchlite:kind": "keyword" },
+            "votes": { "type": "integer" }
+          }
+        }
+      }
+    }
+  });
+  let es = schema_to_es("idx", &schema).unwrap();
+  let comments = es
+    .get("idx")
+    .unwrap()
+    .get("mappings")
+    .unwrap()
+    .get("properties")
+    .unwrap()
+    .get("comments")
+    .unwrap();
+  assert_eq!(comments.get("type").unwrap(), &json!("nested"));
+  let inner = comments.get("properties").unwrap();
+  assert_eq!(inner.get("author").unwrap().get("type").unwrap(), &json!("keyword"));
+  assert_eq!(inner.get("votes").unwrap().get("type").unwrap(), &json!("long"));
+}

--- a/searchlite-adapter-elastic/tests/translate_pagination.rs
+++ b/searchlite-adapter-elastic/tests/translate_pagination.rs
@@ -50,6 +50,25 @@ fn track_total_hits_invalid_type_rejected() {
 }
 
 #[test]
+fn track_total_hits_negative_int_rejected() {
+  let mut out = Map::new();
+  let body = json!({ "track_total_hits": -1 });
+  let map = body.as_object().unwrap().clone();
+  let err = apply_pagination(&map, &mut out).unwrap_err();
+  assert_eq!(err.feature, "track_total_hits");
+  assert!(err.detail.contains("non-negative"), "got {err:?}");
+}
+
+#[test]
+fn track_total_hits_float_rejected() {
+  let mut out = Map::new();
+  let body = json!({ "track_total_hits": 1.5 });
+  let map = body.as_object().unwrap().clone();
+  let err = apply_pagination(&map, &mut out).unwrap_err();
+  assert_eq!(err.feature, "track_total_hits");
+}
+
+#[test]
 fn scroll_is_rejected() {
   let mut out = Map::new();
   let body = json!({ "scroll": "1m" });

--- a/searchlite-adapter-elastic/tests/translate_pagination.rs
+++ b/searchlite-adapter-elastic/tests/translate_pagination.rs
@@ -1,0 +1,59 @@
+use searchlite_adapter_elastic::translate::apply_pagination;
+use serde_json::{json, Map, Value};
+
+fn run(es_body: Value) -> Map<String, Value> {
+  let mut out = Map::new();
+  let map = es_body.as_object().unwrap().clone();
+  apply_pagination(&map, &mut out).unwrap();
+  out
+}
+
+#[test]
+fn from_size_search_after_pass_through() {
+  let out = run(json!({ "from": 5, "size": 20, "search_after": ["sort-key"] }));
+  assert_eq!(out.get("from").unwrap(), &json!(5));
+  assert_eq!(out.get("limit").unwrap(), &json!(20));
+  assert_eq!(out.get("search_after").unwrap(), &json!(["sort-key"]));
+}
+
+#[test]
+fn track_total_hits_true_is_forwarded() {
+  let out = run(json!({ "track_total_hits": true }));
+  assert_eq!(out.get("track_total_hits").unwrap(), &json!(true));
+}
+
+#[test]
+fn track_total_hits_false_is_forwarded() {
+  let out = run(json!({ "track_total_hits": false }));
+  assert_eq!(out.get("track_total_hits").unwrap(), &json!(false));
+}
+
+#[test]
+fn track_total_hits_positive_int_maps_to_true() {
+  let out = run(json!({ "track_total_hits": 10000 }));
+  assert_eq!(out.get("track_total_hits").unwrap(), &json!(true));
+}
+
+#[test]
+fn track_total_hits_zero_int_maps_to_false() {
+  let out = run(json!({ "track_total_hits": 0 }));
+  assert_eq!(out.get("track_total_hits").unwrap(), &json!(false));
+}
+
+#[test]
+fn track_total_hits_invalid_type_rejected() {
+  let mut out = Map::new();
+  let body = json!({ "track_total_hits": "true" });
+  let map = body.as_object().unwrap().clone();
+  let err = apply_pagination(&map, &mut out).unwrap_err();
+  assert_eq!(err.feature, "track_total_hits");
+}
+
+#[test]
+fn scroll_is_rejected() {
+  let mut out = Map::new();
+  let body = json!({ "scroll": "1m" });
+  let map = body.as_object().unwrap().clone();
+  let err = apply_pagination(&map, &mut out).unwrap_err();
+  assert_eq!(err.feature, "scroll");
+}

--- a/searchlite-adapter-elastic/tests/translate_query.rs
+++ b/searchlite-adapter-elastic/tests/translate_query.rs
@@ -108,21 +108,49 @@ fn regexp_translates_to_regex() {
 }
 
 #[test]
-fn match_phrase_string_form() {
+fn match_phrase_string_form_uses_query_string_for_analyzer_aware_tokenization() {
+  // Slop=0 (default) is delegated to `query_string` with a quoted phrase so
+  // SearchLite's per-field analyzer drives tokenization. Previously we split
+  // on whitespace and emitted a `phrase` query — that diverged from ES on
+  // any input with punctuation, contractions, or non-ASCII text.
   let es = json!({"match_phrase": {"title": "to be or not to be"}});
   let sl = translate_query(&es).unwrap();
   assert_eq!(
     sl,
     json!({
-      "type": "phrase",
-      "field": "title",
-      "terms": ["to", "be", "or", "not", "to", "be"],
+      "type": "query_string",
+      "query": "\"to be or not to be\"",
+      "fields": ["title"],
     })
   );
 }
 
 #[test]
-fn match_phrase_object_form_with_slop() {
+fn match_phrase_with_punctuation_is_quoted_intact_for_analyzer() {
+  let es = json!({"match_phrase": {"title": "U.S.A. today"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "query_string",
+      "query": "\"U.S.A. today\"",
+      "fields": ["title"],
+    })
+  );
+}
+
+#[test]
+fn match_phrase_escapes_quote_and_backslash() {
+  let es = json!({"match_phrase": {"title": "say \"hi\" \\here"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("query").unwrap(), &json!(r#""say \"hi\" \\here""#));
+}
+
+#[test]
+fn match_phrase_with_slop_keeps_phrase_form_for_token_proximity() {
+  // Slop > 0 controls token proximity, which `query_string` quoted phrases
+  // don't model. Fall back to the literal-token `phrase` translation; the
+  // tokenization-divergence limitation is documented for this path.
   let es = json!({"match_phrase": {"title": {"query": "rust safety", "slop": 2}}});
   let sl = translate_query(&es).unwrap();
   assert_eq!(
@@ -252,6 +280,30 @@ fn unsupported_clause_returns_error() {
   let es = json!({"geo_distance": {"point": {"lat": 0.0, "lon": 0.0}}});
   let err = translate_query(&es).unwrap_err();
   assert!(err.feature.contains("geo_distance"), "got {err:?}");
+}
+
+#[test]
+fn multi_match_phrase_type_rejection_does_not_recommend_a_substitute_with_different_semantics() {
+  // Regression: previously the error said "use best_fields/most_fields/cross_fields",
+  // but those are bag-of-words match modes — copying the suggestion would silently
+  // change phrase semantics and return wrong results without warning.
+  let es = json!({
+    "multi_match": {
+      "query": "exact phrase",
+      "fields": ["title", "description"],
+      "type": "phrase"
+    }
+  });
+  let err = translate_query(&es).unwrap_err();
+  let detail = err.detail.to_lowercase();
+  assert!(
+    !detail.contains("best_fields"),
+    "rejection should not suggest a substitute that changes match semantics: {err:?}"
+  );
+  assert!(
+    !detail.contains("most_fields") && !detail.contains("cross_fields"),
+    "rejection should not suggest a substitute that changes match semantics: {err:?}"
+  );
 }
 
 #[test]
@@ -446,4 +498,115 @@ fn terms_filter_single_integer_emits_bare_filter() {
     sl,
     json!({ "I64Range": { "field": "price", "min": 42, "max": 42 } })
   );
+}
+
+#[test]
+fn terms_with_field_literally_named_boost_is_queryable() {
+  // Regression for review: `terms` translation filtered out any key named
+  // `boost` so a schema field literally named `boost` was unqueryable. The
+  // filter should only treat `boost` as the meta-key when its value is a
+  // numeric boost — when it's an array it's a field selector.
+  let es = json!({"terms": {"boost": ["a", "b"]}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "bool",
+      "should": [
+        {"type": "term", "field": "boost", "value": "a"},
+        {"type": "term", "field": "boost", "value": "b"},
+      ],
+      "minimum_should_match": 1,
+    })
+  );
+}
+
+#[test]
+fn terms_filter_with_field_literally_named_boost_is_queryable() {
+  let es = json!({"terms": {"boost": ["a"]}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "KeywordIn": { "field": "boost", "values": ["a"] } })
+  );
+}
+
+#[test]
+fn bool_minimum_should_match_percentage_resolves_to_floor() {
+  // Regression: previously ANY non-integer minimum_should_match was rejected,
+  // including ES's common `"75%"` form. Now we resolve it adapter-side
+  // (count should clauses, floor multiply) since core's Bool variant only
+  // accepts a usize.
+  let es = json!({
+    "bool": {
+      "should": [
+        {"term": {"a": "1"}},
+        {"term": {"b": "2"}},
+        {"term": {"c": "3"}},
+        {"term": {"d": "4"}},
+      ],
+      "minimum_should_match": "75%"
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  // 4 should-clauses * 0.75 = 3.0 → floor = 3
+  assert_eq!(sl.get("minimum_should_match").unwrap(), &json!(3));
+}
+
+#[test]
+fn bool_minimum_should_match_percentage_floors_fractional() {
+  // 3 clauses * 75% = 2.25 → floor = 2
+  let es = json!({
+    "bool": {
+      "should": [
+        {"term": {"a": "1"}},
+        {"term": {"b": "2"}},
+        {"term": {"c": "3"}},
+      ],
+      "minimum_should_match": "75%"
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("minimum_should_match").unwrap(), &json!(2));
+}
+
+#[test]
+fn bool_minimum_should_match_integer_string_accepted() {
+  let es = json!({
+    "bool": {
+      "should": [{"term": {"a": "1"}}, {"term": {"b": "2"}}],
+      "minimum_should_match": "1"
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("minimum_should_match").unwrap(), &json!(1));
+}
+
+#[test]
+fn bool_minimum_should_match_complex_syntax_rejected() {
+  // ES supports "3<90%" combinator syntax. We don't (yet) — reject loudly
+  // with a descriptive error rather than silently mis-translating.
+  let es = json!({
+    "bool": {
+      "should": [{"term": {"a": "1"}}],
+      "minimum_should_match": "3<90%"
+    }
+  });
+  let err = translate_query(&es).unwrap_err();
+  assert!(
+    err.feature.starts_with("bool.minimum_should_match"),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn terms_with_real_boost_meta_key_still_works() {
+  // Sanity check that the boost-as-meta-key path still works when boost is
+  // a number alongside a real field array.
+  let es = json!({"terms": {"category": ["books"], "boost": 2.0}});
+  let sl = translate_query(&es).unwrap();
+  // Bool.should should target `category`, not `boost`.
+  let shoulds = sl.get("should").unwrap().as_array().unwrap();
+  assert_eq!(shoulds.len(), 1);
+  assert_eq!(shoulds[0].get("field").unwrap(), &json!("category"));
 }

--- a/searchlite-adapter-elastic/tests/translate_query.rs
+++ b/searchlite-adapter-elastic/tests/translate_query.rs
@@ -293,3 +293,75 @@ fn bool_filter_context_with_must_not_emits_not() {
     })
   );
 }
+
+// ── Numeric `term` handling ─────────────────────────────────────────────
+
+#[test]
+fn term_with_integer_emits_constant_score_with_i64range() {
+  let es = json!({"term": {"price": 25}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "constant_score",
+      "filter": { "I64Range": { "field": "price", "min": 25, "max": 25 } }
+    })
+  );
+}
+
+#[test]
+fn term_with_float_emits_constant_score_with_f64range() {
+  let es = json!({"term": {"rating": 4.5}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "constant_score",
+      "filter": { "F64Range": { "field": "rating", "min": 4.5, "max": 4.5 } }
+    })
+  );
+}
+
+#[test]
+fn term_with_integer_in_filter_context_emits_i64range() {
+  let es = json!({"term": {"price": 25}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "I64Range": { "field": "price", "min": 25, "max": 25 } })
+  );
+}
+
+#[test]
+fn term_with_float_in_filter_context_emits_f64range() {
+  let es = json!({"term": {"rating": 4.5}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "F64Range": { "field": "rating", "min": 4.5, "max": 4.5 } })
+  );
+}
+
+#[test]
+fn term_with_object_integer_value_carries_boost() {
+  let es = json!({"term": {"price": {"value": 25, "boost": 2.0}}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "constant_score",
+      "filter": { "I64Range": { "field": "price", "min": 25, "max": 25 } },
+      "boost": 2.0
+    })
+  );
+}
+
+// ── Validation: terms filter rejects multi-field input ─────────────────
+
+#[test]
+fn terms_in_filter_context_rejects_multiple_field_entries() {
+  let es = json!({"terms": {"a": ["x"], "b": ["y"]}});
+  let err = translate_to_filter(&es).unwrap_err();
+  assert!(err.feature == "terms", "got {err:?}");
+  assert!(err.detail.contains("exactly one"), "got {err:?}");
+}

--- a/searchlite-adapter-elastic/tests/translate_query.rs
+++ b/searchlite-adapter-elastic/tests/translate_query.rs
@@ -254,6 +254,67 @@ fn bool_translates_recursively() {
 }
 
 #[test]
+fn multi_match_translates_tie_breaker_verbatim() {
+  let es = json!({
+    "multi_match": { "query": "x", "fields": ["a"], "tie_breaker": 0.3 }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("tie_breaker").unwrap(), &json!(0.3));
+}
+
+#[test]
+fn multi_match_translates_operator_lowercased() {
+  let es = json!({
+    "multi_match": { "query": "x", "fields": ["a"], "operator": "AND" }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("operator").unwrap(), &json!("and"));
+}
+
+#[test]
+fn multi_match_translates_fuzziness_auto_to_max_edits_2() {
+  let es = json!({
+    "multi_match": { "query": "x", "fields": ["a"], "fuzziness": "AUTO" }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("fuzziness").unwrap(), &json!({ "max_edits": 2 }));
+}
+
+#[test]
+fn multi_match_translates_fuzziness_numeric_string() {
+  let es = json!({
+    "multi_match": { "query": "x", "fields": ["a"], "fuzziness": "1" }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("fuzziness").unwrap(), &json!({ "max_edits": 1 }));
+}
+
+#[test]
+fn multi_match_forwards_minimum_should_match_verbatim_for_percentage_form() {
+  // Unlike `bool.minimum_should_match` (resolved adapter-side because
+  // SearchLite's Bool variant only accepts a usize), `multi_match` keeps
+  // the percentage form on the wire — core's MultiMatch field accepts
+  // both shapes via an untagged enum.
+  let es = json!({
+    "multi_match": {
+      "query": "x", "fields": ["a"],
+      "minimum_should_match": "75%"
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("minimum_should_match").unwrap(), &json!("75%"));
+}
+
+#[test]
+fn multi_match_translates_boost() {
+  let es = json!({
+    "multi_match": { "query": "x", "fields": ["a"], "boost": 2.5 }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl.get("boost").unwrap(), &json!(2.5));
+}
+
+#[test]
 fn multi_match_translates_with_field_boost_parsing() {
   let es = json!({
     "multi_match": {
@@ -313,6 +374,94 @@ fn dis_max_translates() {
       "tie_breaker": 0.3,
     })
   );
+}
+
+// --- match / multi_match: well-known options with semantic implications ----
+//
+// These options change matching semantics in ways SearchLite has no
+// equivalent for. Silent drops would let a request succeed but diverge from
+// ES intent without any signal — match the project pattern of rejecting
+// loudly (per `bool.minimum_should_match` combinator handling).
+
+#[test]
+fn match_with_zero_terms_query_is_rejected() {
+  let es = json!({ "match": { "title": { "query": "the", "zero_terms_query": "all" } } });
+  let err = translate_query(&es).unwrap_err();
+  assert!(
+    err.feature.starts_with("match.zero_terms_query"),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn match_with_lenient_is_rejected() {
+  let es = json!({ "match": { "title": { "query": "x", "lenient": true } } });
+  let err = translate_query(&es).unwrap_err();
+  assert!(err.feature.starts_with("match.lenient"), "got {err:?}");
+}
+
+#[test]
+fn match_with_analyzer_override_is_rejected() {
+  let es = json!({ "match": { "title": { "query": "x", "analyzer": "english" } } });
+  let err = translate_query(&es).unwrap_err();
+  assert!(err.feature.starts_with("match.analyzer"), "got {err:?}");
+}
+
+#[test]
+fn multi_match_with_zero_terms_query_is_rejected() {
+  let es = json!({
+    "multi_match": { "query": "the", "fields": ["a"], "zero_terms_query": "all" }
+  });
+  let err = translate_query(&es).unwrap_err();
+  assert!(
+    err.feature.starts_with("multi_match.zero_terms_query"),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn multi_match_with_analyzer_override_is_rejected() {
+  let es = json!({
+    "multi_match": { "query": "x", "fields": ["a"], "analyzer": "english" }
+  });
+  let err = translate_query(&es).unwrap_err();
+  assert!(
+    err.feature.starts_with("multi_match.analyzer"),
+    "got {err:?}"
+  );
+}
+
+#[test]
+fn multi_match_with_slop_prefix_length_max_expansions_is_rejected() {
+  for opt in ["slop", "prefix_length", "max_expansions", "lenient"] {
+    let es = json!({
+      "multi_match": { "query": "x", "fields": ["a"], opt: 2 }
+    });
+    let err = translate_query(&es).unwrap_err();
+    assert!(
+      err.feature.starts_with(&format!("multi_match.{opt}")),
+      "option `{opt}` should be rejected; got {err:?}"
+    );
+  }
+}
+
+#[test]
+fn function_score_clause_is_rejected_with_clear_error() {
+  // Docs<>code contract: the compatibility matrix used to claim
+  // function_score was "partial / Limited to SearchLite's whitelist", but
+  // the dispatcher had no arm for it and silently fell through to a
+  // generic Unsupported error. Now docs say "rejected" — pin the rejection
+  // here so future support is added deliberately.
+  let es = json!({"function_score": {"query": {"match_all": {}}, "functions": []}});
+  let err = translate_query(&es).unwrap_err();
+  assert!(err.feature.contains("function_score"), "got {err:?}");
+}
+
+#[test]
+fn script_score_clause_is_rejected_with_clear_error() {
+  let es = json!({"script_score": {"query": {"match_all": {}}, "script": "_score * 2"}});
+  let err = translate_query(&es).unwrap_err();
+  assert!(err.feature.contains("script_score"), "got {err:?}");
 }
 
 #[test]

--- a/searchlite-adapter-elastic/tests/translate_query.rs
+++ b/searchlite-adapter-elastic/tests/translate_query.rs
@@ -1,0 +1,295 @@
+use searchlite_adapter_elastic::translate::query::{translate_query, translate_to_filter};
+use serde_json::json;
+
+#[test]
+fn match_all_translates_to_match_all() {
+  let es = json!({"match_all": {}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl, json!({"type": "match_all"}));
+}
+
+#[test]
+fn match_all_carries_boost() {
+  let es = json!({"match_all": {"boost": 2.5}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(sl, json!({"type": "match_all", "boost": 2.5}));
+}
+
+#[test]
+fn match_with_string_value_uses_query_string() {
+  let es = json!({"match": {"title": "rust"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({"type": "query_string", "query": "rust", "fields": ["title"]})
+  );
+}
+
+#[test]
+fn match_with_object_value_picks_query_field() {
+  let es = json!({"match": {"title": {"query": "rust", "boost": 1.5}}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "query_string",
+      "query": "rust",
+      "fields": ["title"],
+      "boost": 1.5,
+    })
+  );
+}
+
+#[test]
+fn term_with_string_value() {
+  let es = json!({"term": {"status": "active"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({"type": "term", "field": "status", "value": "active"})
+  );
+}
+
+#[test]
+fn term_with_object_value_and_boost() {
+  let es = json!({"term": {"status": {"value": "active", "boost": 2.0}}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({"type": "term", "field": "status", "value": "active", "boost": 2.0})
+  );
+}
+
+#[test]
+fn terms_translates_to_should_bool() {
+  let es = json!({"terms": {"tag": ["rust", "search"]}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "bool",
+      "should": [
+        {"type": "term", "field": "tag", "value": "rust"},
+        {"type": "term", "field": "tag", "value": "search"},
+      ],
+      "minimum_should_match": 1,
+    })
+  );
+}
+
+#[test]
+fn prefix_translates_directly() {
+  let es = json!({"prefix": {"name": "ja"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({"type": "prefix", "field": "name", "value": "ja"})
+  );
+}
+
+#[test]
+fn wildcard_translates_directly() {
+  let es = json!({"wildcard": {"name": "j*n"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({"type": "wildcard", "field": "name", "value": "j*n"})
+  );
+}
+
+#[test]
+fn regexp_translates_to_regex() {
+  let es = json!({"regexp": {"name": "j.*n"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({"type": "regex", "field": "name", "value": "j.*n"})
+  );
+}
+
+#[test]
+fn match_phrase_string_form() {
+  let es = json!({"match_phrase": {"title": "to be or not to be"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "phrase",
+      "field": "title",
+      "terms": ["to", "be", "or", "not", "to", "be"],
+    })
+  );
+}
+
+#[test]
+fn match_phrase_object_form_with_slop() {
+  let es = json!({"match_phrase": {"title": {"query": "rust safety", "slop": 2}}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "phrase",
+      "field": "title",
+      "terms": ["rust", "safety"],
+      "slop": 2,
+    })
+  );
+}
+
+#[test]
+fn range_wraps_in_constant_score() {
+  let es = json!({"range": {"price": {"gte": 10, "lt": 100}}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "constant_score",
+      "filter": { "I64Range": { "field": "price", "min": 10, "max": 99 } },
+    })
+  );
+}
+
+#[test]
+fn range_picks_f64_when_floats() {
+  let es = json!({"range": {"score": {"gte": 0.5, "lte": 0.9}}});
+  let sl = translate_query(&es).unwrap();
+  let inner = sl.get("filter").unwrap();
+  assert_eq!(
+    inner,
+    &json!({ "F64Range": { "field": "score", "min": 0.5, "max": 0.9 } })
+  );
+}
+
+#[test]
+fn bool_translates_recursively() {
+  let es = json!({
+    "bool": {
+      "must": [{"term": {"a": "1"}}],
+      "should": [{"term": {"b": "2"}}],
+      "must_not": [{"term": {"c": "3"}}],
+      "filter": [{"term": {"d": "4"}}],
+      "minimum_should_match": 1,
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "bool",
+      "must": [{"type": "term", "field": "a", "value": "1"}],
+      "should": [{"type": "term", "field": "b", "value": "2"}],
+      "must_not": [{"type": "term", "field": "c", "value": "3"}],
+      "filter": [{ "KeywordEq": { "field": "d", "value": "4" } }],
+      "minimum_should_match": 1,
+    })
+  );
+}
+
+#[test]
+fn multi_match_translates_with_field_boost_parsing() {
+  let es = json!({
+    "multi_match": {
+      "query": "rust",
+      "fields": ["title^2", "body"],
+      "type": "best_fields",
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "multi_match",
+      "query": "rust",
+      "fields": [
+        {"field": "title", "boost": 2.0},
+        {"field": "body"},
+      ],
+      "match_type": "best_fields",
+    })
+  );
+}
+
+#[test]
+fn query_string_passes_through() {
+  let es = json!({"query_string": {"query": "title:rust OR body:safety"}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "query_string",
+      "query": "title:rust OR body:safety",
+    })
+  );
+}
+
+#[test]
+fn dis_max_translates() {
+  let es = json!({
+    "dis_max": {
+      "queries": [
+        {"term": {"a": "x"}},
+        {"term": {"b": "y"}},
+      ],
+      "tie_breaker": 0.3,
+    }
+  });
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "dis_max",
+      "queries": [
+        {"type": "term", "field": "a", "value": "x"},
+        {"type": "term", "field": "b", "value": "y"},
+      ],
+      "tie_breaker": 0.3,
+    })
+  );
+}
+
+#[test]
+fn unsupported_clause_returns_error() {
+  let es = json!({"geo_distance": {"point": {"lat": 0.0, "lon": 0.0}}});
+  let err = translate_query(&es).unwrap_err();
+  assert!(err.feature.contains("geo_distance"), "got {err:?}");
+}
+
+#[test]
+fn term_in_filter_context_emits_keyword_eq() {
+  let es = json!({"term": {"status": "active"}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "KeywordEq": { "field": "status", "value": "active" } })
+  );
+}
+
+#[test]
+fn terms_in_filter_context_emits_keyword_in() {
+  let es = json!({"terms": {"tag": ["a", "b"]}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "KeywordIn": { "field": "tag", "values": ["a", "b"] } })
+  );
+}
+
+#[test]
+fn bool_filter_context_with_must_not_emits_not() {
+  let es = json!({
+    "bool": {
+      "must": [{"term": {"a": "1"}}],
+      "must_not": [{"term": {"b": "2"}}],
+    }
+  });
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "And": [
+        { "KeywordEq": { "field": "a", "value": "1" } },
+        { "Not": { "KeywordEq": { "field": "b", "value": "2" } } },
+      ]
+    })
+  );
+}

--- a/searchlite-adapter-elastic/tests/translate_query.rs
+++ b/searchlite-adapter-elastic/tests/translate_query.rs
@@ -178,6 +178,46 @@ fn range_wraps_in_constant_score() {
 }
 
 #[test]
+fn range_gt_at_i64_max_emits_impossible_range() {
+  // Regression: previously `gt: i64::MAX` saturated to i64::MAX and the
+  // resulting range matched documents at i64::MAX, even though the ES
+  // predicate should match nothing. Verify the translated range is empty.
+  let es = json!({"range": {"f": {"gt": i64::MAX}}});
+  let sl = translate_query(&es).unwrap();
+  let i64_filter = sl
+    .pointer("/filter/I64Range")
+    .expect("expected I64Range filter");
+  let min = i64_filter.get("min").unwrap().as_i64().unwrap();
+  let max = i64_filter.get("max").unwrap().as_i64().unwrap();
+  assert!(
+    min > max,
+    "gt: i64::MAX should produce an empty range (min > max); got min={min} max={max}"
+  );
+}
+
+#[test]
+fn range_lt_at_i64_min_emits_impossible_range() {
+  let es = json!({"range": {"f": {"lt": i64::MIN}}});
+  let sl = translate_query(&es).unwrap();
+  let i64_filter = sl.pointer("/filter/I64Range").unwrap();
+  let min = i64_filter.get("min").unwrap().as_i64().unwrap();
+  let max = i64_filter.get("max").unwrap().as_i64().unwrap();
+  assert!(
+    min > max,
+    "lt: i64::MIN should produce an empty range (min > max); got min={min} max={max}"
+  );
+}
+
+#[test]
+fn range_gt_at_normal_value_still_works() {
+  let es = json!({"range": {"f": {"gt": 10}}});
+  let sl = translate_query(&es).unwrap();
+  let i64_filter = sl.pointer("/filter/I64Range").unwrap();
+  assert_eq!(i64_filter.get("min").unwrap(), &json!(11));
+  assert_eq!(i64_filter.get("max").unwrap(), &json!(i64::MAX));
+}
+
+#[test]
 fn range_picks_f64_when_floats() {
   let es = json!({"range": {"score": {"gte": 0.5, "lte": 0.9}}});
   let sl = translate_query(&es).unwrap();

--- a/searchlite-adapter-elastic/tests/translate_query.rs
+++ b/searchlite-adapter-elastic/tests/translate_query.rs
@@ -365,3 +365,85 @@ fn terms_in_filter_context_rejects_multiple_field_entries() {
   assert!(err.feature == "terms", "got {err:?}");
   assert!(err.detail.contains("exactly one"), "got {err:?}");
 }
+
+// ── Numeric `terms` handling (mainline + filter) ───────────────────────
+
+#[test]
+fn terms_with_integer_values_emits_constant_score_should_clauses() {
+  let es = json!({"terms": {"price": [10, 20]}});
+  let sl = translate_query(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "type": "bool",
+      "should": [
+        { "type": "constant_score", "filter": { "I64Range": { "field": "price", "min": 10, "max": 10 } } },
+        { "type": "constant_score", "filter": { "I64Range": { "field": "price", "min": 20, "max": 20 } } },
+      ],
+      "minimum_should_match": 1,
+    })
+  );
+}
+
+#[test]
+fn terms_with_float_values_emits_f64range_should_clauses() {
+  let es = json!({"terms": {"rating": [4.5, 4.8]}});
+  let sl = translate_query(&es).unwrap();
+  let shoulds = sl.get("should").unwrap().as_array().unwrap();
+  assert_eq!(shoulds.len(), 2);
+  assert_eq!(
+    shoulds[0],
+    json!({"type": "constant_score", "filter": {"F64Range": {"field": "rating", "min": 4.5, "max": 4.5}}})
+  );
+}
+
+#[test]
+fn terms_with_mixed_string_and_number_dispatches_per_value() {
+  let es = json!({"terms": {"f": ["a", 1]}});
+  let sl = translate_query(&es).unwrap();
+  let shoulds = sl.get("should").unwrap().as_array().unwrap();
+  assert_eq!(shoulds.len(), 2);
+  assert_eq!(
+    shoulds[0],
+    json!({"type": "term", "field": "f", "value": "a"})
+  );
+  assert_eq!(
+    shoulds[1],
+    json!({"type": "constant_score", "filter": {"I64Range": {"field": "f", "min": 1, "max": 1}}})
+  );
+}
+
+#[test]
+fn terms_filter_all_strings_uses_keyword_in() {
+  let es = json!({"terms": {"category": ["books", "music"]}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "KeywordIn": { "field": "category", "values": ["books", "music"] } })
+  );
+}
+
+#[test]
+fn terms_filter_all_integers_uses_or_of_i64ranges() {
+  let es = json!({"terms": {"price": [10, 20]}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({
+      "Or": [
+        { "I64Range": { "field": "price", "min": 10, "max": 10 } },
+        { "I64Range": { "field": "price", "min": 20, "max": 20 } },
+      ]
+    })
+  );
+}
+
+#[test]
+fn terms_filter_single_integer_emits_bare_filter() {
+  let es = json!({"terms": {"price": [42]}});
+  let sl = translate_to_filter(&es).unwrap();
+  assert_eq!(
+    sl,
+    json!({ "I64Range": { "field": "price", "min": 42, "max": 42 } })
+  );
+}

--- a/searchlite-adapter-elastic/tests/translate_request.rs
+++ b/searchlite-adapter-elastic/tests/translate_request.rs
@@ -1,0 +1,44 @@
+use searchlite_adapter_elastic::translate::translate_search_body;
+use serde_json::{json, Value};
+
+#[test]
+fn empty_object_body_translates_to_match_all() {
+  let sl = translate_search_body(&json!({})).unwrap();
+  assert_eq!(sl.get("query").unwrap(), &json!({ "type": "match_all" }));
+}
+
+#[test]
+fn null_body_translates_to_match_all() {
+  // Some ES clients send a literal `null` body when no search criteria are
+  // supplied. ES treats that the same as an empty body / match-all, and so
+  // do we.
+  let sl = translate_search_body(&Value::Null).unwrap();
+  assert_eq!(sl.get("query").unwrap(), &json!({ "type": "match_all" }));
+}
+
+#[test]
+fn array_body_is_rejected() {
+  // Regression: previously a non-object body was silently coerced into an
+  // empty map and run as match_all. For `_msearch` that meant a malformed
+  // body line silently scanned the whole index.
+  let err = translate_search_body(&json!([])).unwrap_err();
+  assert!(err.feature.contains("body"), "got {err:?}");
+}
+
+#[test]
+fn string_body_is_rejected() {
+  let err = translate_search_body(&json!("not a body")).unwrap_err();
+  assert!(err.feature.contains("body"), "got {err:?}");
+}
+
+#[test]
+fn number_body_is_rejected() {
+  let err = translate_search_body(&json!(42)).unwrap_err();
+  assert!(err.feature.contains("body"), "got {err:?}");
+}
+
+#[test]
+fn boolean_body_is_rejected() {
+  let err = translate_search_body(&json!(true)).unwrap_err();
+  assert!(err.feature.contains("body"), "got {err:?}");
+}

--- a/searchlite-adapter-elastic/tests/translate_request.rs
+++ b/searchlite-adapter-elastic/tests/translate_request.rs
@@ -42,3 +42,46 @@ fn boolean_body_is_rejected() {
   let err = translate_search_body(&json!(true)).unwrap_err();
   assert!(err.feature.contains("body"), "got {err:?}");
 }
+
+// --- _source.includes shape handling ---------------------------------------
+
+#[test]
+fn source_includes_string_form_is_accepted() {
+  // Regression: previously only the array form was handled, so the
+  // single-string shape silently widened the response (no field restriction
+  // applied) instead of returning just `["title"]`.
+  let sl = translate_search_body(&json!({
+    "_source": { "includes": "title" }
+  }))
+  .unwrap();
+  assert_eq!(sl.get("fields").unwrap(), &json!(["title"]));
+}
+
+#[test]
+fn source_includes_array_with_non_string_is_rejected() {
+  // Silently dropping the non-string element (as filter_map did) widens the
+  // payload with whatever fields the dropped entry would have restricted.
+  let err = translate_search_body(&json!({
+    "_source": { "includes": ["title", 42] }
+  }))
+  .unwrap_err();
+  assert_eq!(err.feature, "_source.includes");
+}
+
+#[test]
+fn source_includes_non_string_non_array_value_rejected() {
+  let err = translate_search_body(&json!({
+    "_source": { "includes": 42 }
+  }))
+  .unwrap_err();
+  assert_eq!(err.feature, "_source.includes");
+}
+
+#[test]
+fn source_includes_array_of_strings_still_works() {
+  let sl = translate_search_body(&json!({
+    "_source": { "includes": ["title", "category"] }
+  }))
+  .unwrap();
+  assert_eq!(sl.get("fields").unwrap(), &json!(["title", "category"]));
+}

--- a/searchlite-adapter-elastic/tests/translate_response.rs
+++ b/searchlite-adapter-elastic/tests/translate_response.rs
@@ -53,6 +53,87 @@ fn hits_have_index_id_score_source_fields() {
 }
 
 #[test]
+fn keyed_range_aggregation_emits_object_buckets() {
+  // Regression: ES returns range/date_range buckets as an object map keyed
+  // by each bucket's `key` when `keyed: true` is requested. Previously the
+  // adapter always emitted an array, breaking clients that destructure the
+  // keyed shape.
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "by_price": {
+        "type": "range",
+        "keyed": true,
+        "buckets": [
+          {"key": "cheap", "doc_count": 5},
+          {"key": "premium", "doc_count": 3},
+        ]
+      }
+    }
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let buckets = es.pointer("/aggregations/by_price/buckets").unwrap();
+  assert!(
+    buckets.is_object(),
+    "keyed range should emit object buckets, got: {buckets}"
+  );
+  assert_eq!(
+    buckets.pointer("/cheap/doc_count").unwrap(),
+    &json!(5),
+    "got: {buckets}"
+  );
+  assert_eq!(buckets.pointer("/premium/doc_count").unwrap(), &json!(3));
+  // The key should NOT appear inside the value (it's the outer map key).
+  assert!(
+    buckets.pointer("/cheap/key").is_none(),
+    "key should not be duplicated inside the keyed bucket value"
+  );
+}
+
+#[test]
+fn unkeyed_range_aggregation_emits_array_buckets() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "by_price": {
+        "type": "range",
+        "keyed": false,
+        "buckets": [{"key": "cheap", "doc_count": 5}]
+      }
+    }
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let buckets = es.pointer("/aggregations/by_price/buckets").unwrap();
+  assert!(
+    buckets.is_array(),
+    "non-keyed range should emit array buckets"
+  );
+}
+
+#[test]
+fn keyed_date_range_aggregation_emits_object_buckets() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "by_month": {
+        "type": "date_range",
+        "keyed": true,
+        "buckets": [
+          {"key": "2024-Q1", "doc_count": 100},
+        ]
+      }
+    }
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let buckets = es.pointer("/aggregations/by_month/buckets").unwrap();
+  assert!(buckets.is_object(), "got: {buckets}");
+  assert_eq!(buckets.pointer("/2024-Q1/doc_count").unwrap(), &json!(100));
+}
+
+#[test]
 fn aggregations_terms_buckets_translated() {
   let sl = json!({
     "total_hits_estimate": 10,

--- a/searchlite-adapter-elastic/tests/translate_response.rs
+++ b/searchlite-adapter-elastic/tests/translate_response.rs
@@ -1,6 +1,12 @@
 use searchlite_adapter_elastic::translate::translate_search_response;
 use serde_json::json;
 
+fn translate(sl: &serde_json::Value) -> serde_json::Value {
+  // Default-tracking helper for legacy tests that don't care about
+  // track_total_hits semantics (treated as unset).
+  translate_search_response("idx", sl, 0, None)
+}
+
 #[test]
 fn empty_result_has_zero_hits_and_shards_envelope() {
   let sl = json!({
@@ -8,7 +14,7 @@ fn empty_result_has_zero_hits_and_shards_envelope() {
     "hits": [],
     "aggregations": {},
   });
-  let es = translate_search_response("books", &sl, 12);
+  let es = translate_search_response("books", &sl, 12, None);
   assert_eq!(es.get("took").unwrap(), &json!(12));
   assert_eq!(es.get("timed_out").unwrap(), &json!(false));
   assert_eq!(
@@ -23,6 +29,58 @@ fn empty_result_has_zero_hits_and_shards_envelope() {
   assert_eq!(hits.get("hits").unwrap(), &json!([]));
 }
 
+// --- track_total_hits semantics ---------------------------------------------
+
+#[test]
+fn track_total_hits_true_emits_relation_eq() {
+  // Regression: response always emitted relation:"gte" regardless of the
+  // request's track_total_hits. When the caller asked for exact totals,
+  // ES emits relation:"eq".
+  let sl = json!({
+    "total_hits_estimate": 42,
+    "hits": [],
+  });
+  let es = translate_search_response("idx", &sl, 0, Some(true));
+  assert_eq!(
+    es.pointer("/hits/total").unwrap(),
+    &json!({"value": 42, "relation": "eq"})
+  );
+}
+
+#[test]
+fn track_total_hits_false_omits_total() {
+  // ES omits hits.total entirely when track_total_hits=false, signaling
+  // that totals were not computed. Clients that rely on the presence of
+  // `total` to distinguish exact-vs-approximate must not see a fabricated
+  // value here.
+  let sl = json!({
+    "total_hits_estimate": 17,
+    "hits": [],
+  });
+  let es = translate_search_response("idx", &sl, 0, Some(false));
+  assert!(
+    es.pointer("/hits/total").is_none(),
+    "hits.total should be omitted when track_total_hits=false; got: {es}"
+  );
+  // The hits array should still be present.
+  assert!(es.pointer("/hits/hits").is_some());
+}
+
+#[test]
+fn track_total_hits_unset_keeps_relation_gte() {
+  // No explicit signal from the caller → preserve historical default
+  // (lower-bound semantics).
+  let sl = json!({
+    "total_hits_estimate": 9,
+    "hits": [],
+  });
+  let es = translate_search_response("idx", &sl, 0, None);
+  assert_eq!(
+    es.pointer("/hits/total").unwrap(),
+    &json!({"value": 9, "relation": "gte"})
+  );
+}
+
 #[test]
 fn hits_have_index_id_score_source_fields() {
   let sl = json!({
@@ -32,7 +90,7 @@ fn hits_have_index_id_score_source_fields() {
       { "doc_id": "b", "score": 0.9, "fields": {"title": "search"} },
     ],
   });
-  let es = translate_search_response("books", &sl, 0);
+  let es = translate_search_response("books", &sl, 0, None);
   let hits_arr = es
     .get("hits")
     .unwrap()
@@ -72,7 +130,7 @@ fn keyed_range_aggregation_emits_object_buckets() {
       }
     }
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let buckets = es.pointer("/aggregations/by_price/buckets").unwrap();
   assert!(
     buckets.is_object(),
@@ -104,7 +162,7 @@ fn unkeyed_range_aggregation_emits_array_buckets() {
       }
     }
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let buckets = es.pointer("/aggregations/by_price/buckets").unwrap();
   assert!(
     buckets.is_array(),
@@ -127,7 +185,7 @@ fn keyed_date_range_aggregation_emits_object_buckets() {
       }
     }
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let buckets = es.pointer("/aggregations/by_month/buckets").unwrap();
   assert!(buckets.is_object(), "got: {buckets}");
   assert_eq!(buckets.pointer("/2024-Q1/doc_count").unwrap(), &json!(100));
@@ -148,7 +206,7 @@ fn aggregations_terms_buckets_translated() {
       }
     }
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let aggs = es.get("aggregations").unwrap();
   let by_cat = aggs.get("by_cat").unwrap();
   let buckets = by_cat.get("buckets").unwrap().as_array().unwrap();
@@ -164,7 +222,7 @@ fn hit_with_only_snippet_emits_snippet_under_sentinel_key() {
     "total_hits_estimate": 1,
     "hits": [{ "doc_id": "a", "score": 1.0, "snippet": "rust …safety" }],
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let hits = es.pointer("/hits/hits").unwrap().as_array().unwrap();
   assert_eq!(
     hits[0].get("highlight").unwrap(),
@@ -182,7 +240,7 @@ fn hit_with_only_highlights_emits_highlights_verbatim() {
       "highlights": { "title": ["<em>rust</em> safety"] }
     }],
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let hits = es.pointer("/hits/hits").unwrap().as_array().unwrap();
   assert_eq!(
     hits[0].get("highlight").unwrap(),
@@ -206,7 +264,7 @@ fn hit_with_both_snippet_and_highlights_prefers_highlights_without_dropping_snip
       "highlights": { "title": ["<em>rust</em> safety"] }
     }],
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let highlight = es.pointer("/hits/hits").unwrap().as_array().unwrap()[0]
     .get("highlight")
     .unwrap();
@@ -228,7 +286,7 @@ fn hit_without_highlight_omits_highlight_field() {
     "total_hits_estimate": 1,
     "hits": [{ "doc_id": "a", "score": 1.0 }],
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let hit = &es.pointer("/hits/hits").unwrap().as_array().unwrap()[0];
   assert!(hit.get("highlight").is_none());
 }
@@ -249,7 +307,7 @@ fn stats_aggregation_translates_to_es_envelope() {
       }
     }
   });
-  let es = translate_search_response("idx", &sl, 0);
+  let es = translate(&sl);
   let aggs = es.get("aggregations").unwrap();
   assert_eq!(
     aggs.get("p").unwrap(),

--- a/searchlite-adapter-elastic/tests/translate_response.rs
+++ b/searchlite-adapter-elastic/tests/translate_response.rs
@@ -291,6 +291,110 @@ fn hit_without_highlight_omits_highlight_field() {
   assert!(hit.get("highlight").is_none());
 }
 
+// --- pipeline-aggregation response translation -----------------------------
+//
+// These pin the field-copying behavior in translate_aggregation's pipeline
+// branch so a refactor that drops `value`/`predictions`/`from`/`size`
+// silently doesn't ship.
+
+#[test]
+fn avg_bucket_response_carries_value_field() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "avg_per_day": { "type": "avg_bucket", "value": 12.5 }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/avg_per_day/value").unwrap(),
+    &json!(12.5)
+  );
+}
+
+#[test]
+fn sum_bucket_response_carries_value_field() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "sum_per_day": { "type": "sum_bucket", "value": 100.0 }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/sum_per_day/value").unwrap(),
+    &json!(100.0)
+  );
+}
+
+#[test]
+fn derivative_response_carries_value_field() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "deriv": { "type": "derivative", "value": 5.0 }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/deriv/value").unwrap(),
+    &json!(5.0)
+  );
+}
+
+#[test]
+fn moving_avg_response_carries_value_and_predictions() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "smoothed": {
+        "type": "moving_avg",
+        "value": 7.5,
+        "predictions": [8.0, 8.5, 9.0]
+      }
+    }
+  });
+  let es = translate(&sl);
+  let agg = es.pointer("/aggregations/smoothed").unwrap();
+  assert_eq!(agg.get("value").unwrap(), &json!(7.5));
+  assert_eq!(agg.get("predictions").unwrap(), &json!([8.0, 8.5, 9.0]));
+}
+
+#[test]
+fn bucket_script_response_carries_value_field() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "ratio": { "type": "bucket_script", "value": 0.42 }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/ratio/value").unwrap(),
+    &json!(0.42)
+  );
+}
+
+#[test]
+fn bucket_sort_response_carries_from_size_when_present() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "sorted": { "type": "bucket_sort", "from": 10, "size": 5 }
+    }
+  });
+  let es = translate(&sl);
+  let agg = es.pointer("/aggregations/sorted").unwrap();
+  assert_eq!(agg.get("from").unwrap(), &json!(10));
+  assert_eq!(agg.get("size").unwrap(), &json!(5));
+}
+
 #[test]
 fn stats_aggregation_translates_to_es_envelope() {
   let sl = json!({

--- a/searchlite-adapter-elastic/tests/translate_response.rs
+++ b/searchlite-adapter-elastic/tests/translate_response.rs
@@ -78,6 +78,81 @@ fn aggregations_terms_buckets_translated() {
 }
 
 #[test]
+fn hit_with_only_snippet_emits_snippet_under_sentinel_key() {
+  let sl = json!({
+    "total_hits_estimate": 1,
+    "hits": [{ "doc_id": "a", "score": 1.0, "snippet": "rust …safety" }],
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let hits = es.pointer("/hits/hits").unwrap().as_array().unwrap();
+  assert_eq!(
+    hits[0].get("highlight").unwrap(),
+    &json!({ "_snippet": ["rust …safety"] })
+  );
+}
+
+#[test]
+fn hit_with_only_highlights_emits_highlights_verbatim() {
+  let sl = json!({
+    "total_hits_estimate": 1,
+    "hits": [{
+      "doc_id": "a",
+      "score": 1.0,
+      "highlights": { "title": ["<em>rust</em> safety"] }
+    }],
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let hits = es.pointer("/hits/hits").unwrap().as_array().unwrap();
+  assert_eq!(
+    hits[0].get("highlight").unwrap(),
+    &json!({ "title": ["<em>rust</em> safety"] })
+  );
+}
+
+#[test]
+fn hit_with_both_snippet_and_highlights_prefers_highlights_without_dropping_snippet() {
+  // Regression for review feedback: previously the second `out.insert("highlight", …)`
+  // silently overwrote the snippet entry. Either the structured `highlights` or the
+  // legacy `snippet` is informative on its own; if both are present we keep the
+  // structured one (richer) and surface the snippet alongside it under `_snippet`
+  // so neither field is silently lost.
+  let sl = json!({
+    "total_hits_estimate": 1,
+    "hits": [{
+      "doc_id": "a",
+      "score": 1.0,
+      "snippet": "rust …safety",
+      "highlights": { "title": ["<em>rust</em> safety"] }
+    }],
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let highlight = es.pointer("/hits/hits").unwrap().as_array().unwrap()[0]
+    .get("highlight")
+    .unwrap();
+  assert_eq!(
+    highlight.get("title").unwrap(),
+    &json!(["<em>rust</em> safety"]),
+    "structured highlights should be preserved"
+  );
+  assert_eq!(
+    highlight.get("_snippet").unwrap(),
+    &json!(["rust …safety"]),
+    "legacy snippet should also be preserved alongside structured highlights"
+  );
+}
+
+#[test]
+fn hit_without_highlight_omits_highlight_field() {
+  let sl = json!({
+    "total_hits_estimate": 1,
+    "hits": [{ "doc_id": "a", "score": 1.0 }],
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let hit = &es.pointer("/hits/hits").unwrap().as_array().unwrap()[0];
+  assert!(hit.get("highlight").is_none());
+}
+
+#[test]
 fn stats_aggregation_translates_to_es_envelope() {
   let sl = json!({
     "total_hits_estimate": 5,

--- a/searchlite-adapter-elastic/tests/translate_response.rs
+++ b/searchlite-adapter-elastic/tests/translate_response.rs
@@ -1,0 +1,102 @@
+use searchlite_adapter_elastic::translate::translate_search_response;
+use serde_json::json;
+
+#[test]
+fn empty_result_has_zero_hits_and_shards_envelope() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {},
+  });
+  let es = translate_search_response("books", &sl, 12);
+  assert_eq!(es.get("took").unwrap(), &json!(12));
+  assert_eq!(es.get("timed_out").unwrap(), &json!(false));
+  assert_eq!(
+    es.get("_shards").unwrap(),
+    &json!({"total": 1, "successful": 1, "skipped": 0, "failed": 0})
+  );
+  let hits = es.get("hits").unwrap();
+  assert_eq!(
+    hits.get("total").unwrap(),
+    &json!({"value": 0, "relation": "gte"})
+  );
+  assert_eq!(hits.get("hits").unwrap(), &json!([]));
+}
+
+#[test]
+fn hits_have_index_id_score_source_fields() {
+  let sl = json!({
+    "total_hits_estimate": 2,
+    "hits": [
+      { "doc_id": "a", "score": 1.5, "fields": {"title": "rust"} },
+      { "doc_id": "b", "score": 0.9, "fields": {"title": "search"} },
+    ],
+  });
+  let es = translate_search_response("books", &sl, 0);
+  let hits_arr = es
+    .get("hits")
+    .unwrap()
+    .get("hits")
+    .unwrap()
+    .as_array()
+    .unwrap();
+  assert_eq!(hits_arr.len(), 2);
+  let first = &hits_arr[0];
+  assert_eq!(first.get("_index").unwrap(), &json!("books"));
+  assert_eq!(first.get("_id").unwrap(), &json!("a"));
+  assert_eq!(first.get("_score").unwrap(), &json!(1.5));
+  assert_eq!(first.get("_source").unwrap(), &json!({"title": "rust"}));
+  assert_eq!(
+    es.get("hits").unwrap().get("max_score").unwrap(),
+    &json!(1.5)
+  );
+}
+
+#[test]
+fn aggregations_terms_buckets_translated() {
+  let sl = json!({
+    "total_hits_estimate": 10,
+    "hits": [],
+    "aggregations": {
+      "by_cat": {
+        "type": "terms",
+        "buckets": [
+          {"key": "books", "doc_count": 7},
+          {"key": "music", "doc_count": 3},
+        ]
+      }
+    }
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let aggs = es.get("aggregations").unwrap();
+  let by_cat = aggs.get("by_cat").unwrap();
+  let buckets = by_cat.get("buckets").unwrap().as_array().unwrap();
+  assert_eq!(buckets.len(), 2);
+  assert_eq!(buckets[0].get("key").unwrap(), &json!("books"));
+  assert_eq!(buckets[0].get("doc_count").unwrap(), &json!(7));
+  assert_eq!(buckets[0].get("key_as_string").unwrap(), &json!("books"));
+}
+
+#[test]
+fn stats_aggregation_translates_to_es_envelope() {
+  let sl = json!({
+    "total_hits_estimate": 5,
+    "hits": [],
+    "aggregations": {
+      "p": {
+        "type": "stats",
+        "count": 5,
+        "min": 1.0,
+        "max": 10.0,
+        "sum": 25.0,
+        "avg": 5.0
+      }
+    }
+  });
+  let es = translate_search_response("idx", &sl, 0);
+  let aggs = es.get("aggregations").unwrap();
+  assert_eq!(
+    aggs.get("p").unwrap(),
+    &json!({"count": 5, "min": 1.0, "max": 10.0, "sum": 25.0, "avg": 5.0})
+  );
+}

--- a/searchlite-adapter-elastic/tests/translate_response.rs
+++ b/searchlite-adapter-elastic/tests/translate_response.rs
@@ -1,5 +1,5 @@
 use searchlite_adapter_elastic::translate::translate_search_response;
-use serde_json::json;
+use serde_json::{json, Value};
 
 fn translate(sl: &serde_json::Value) -> serde_json::Value {
   // Default-tracking helper for legacy tests that don't care about
@@ -416,5 +416,78 @@ fn stats_aggregation_translates_to_es_envelope() {
   assert_eq!(
     aggs.get("p").unwrap(),
     &json!({"count": 5, "min": 1.0, "max": 10.0, "sum": 25.0, "avg": 5.0})
+  );
+}
+
+// --- top_hits aggregation --------------------------------------------------
+//
+// Regression: previously hard-coded `max_score: null` regardless of inner hit
+// scores. ES populates this with the maximum `_score` across the inner hits
+// (or null when there are none / none are scored) — so SDKs that branch on
+// `aggregations.<name>.hits.max_score` to short-circuit empty buckets were
+// reading a stale signal.
+
+#[test]
+fn top_hits_aggregation_max_score_is_max_of_inner_hit_scores() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "best": {
+        "type": "top_hits",
+        "total": 2,
+        "hits": [
+          { "doc_id": "b", "score": 1.5 },
+          { "doc_id": "a", "score": 0.5 }
+        ]
+      }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/best/hits/max_score").unwrap(),
+    &json!(1.5)
+  );
+}
+
+#[test]
+fn top_hits_aggregation_max_score_null_when_no_inner_hits() {
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "best": {
+        "type": "top_hits",
+        "total": 0,
+        "hits": []
+      }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/best/hits/max_score").unwrap(),
+    &Value::Null
+  );
+}
+
+#[test]
+fn top_hits_aggregation_max_score_null_when_hits_lack_scores() {
+  // Sort-only inner queries don't carry a `score` field per hit; ES emits
+  // null in that case rather than fabricating a value.
+  let sl = json!({
+    "total_hits_estimate": 0,
+    "hits": [],
+    "aggregations": {
+      "best": {
+        "type": "top_hits",
+        "total": 1,
+        "hits": [{ "doc_id": "a" }]
+      }
+    }
+  });
+  let es = translate(&sl);
+  assert_eq!(
+    es.pointer("/aggregations/best/hits/max_score").unwrap(),
+    &Value::Null
   );
 }

--- a/searchlite-adapter-elastic/tests/translate_sort.rs
+++ b/searchlite-adapter-elastic/tests/translate_sort.rs
@@ -1,0 +1,56 @@
+use searchlite_adapter_elastic::translate::translate_sort;
+use serde_json::json;
+
+#[test]
+fn bare_field_string_defaults_to_asc() {
+  let es = json!("price");
+  let sl = translate_sort(&es).unwrap();
+  assert_eq!(sl, vec![json!({"field": "price", "order": "asc"})]);
+}
+
+#[test]
+fn bare_score_string_defaults_to_desc() {
+  let es = json!("_score");
+  let sl = translate_sort(&es).unwrap();
+  assert_eq!(sl, vec![json!({"field": "_score", "order": "desc"})]);
+}
+
+#[test]
+fn score_object_without_explicit_order_defaults_to_desc() {
+  let es = json!([{"_score": {}}]);
+  let sl = translate_sort(&es).unwrap();
+  assert_eq!(sl, vec![json!({"field": "_score", "order": "desc"})]);
+}
+
+#[test]
+fn field_object_without_explicit_order_defaults_to_asc() {
+  let es = json!([{"price": {}}]);
+  let sl = translate_sort(&es).unwrap();
+  assert_eq!(sl, vec![json!({"field": "price", "order": "asc"})]);
+}
+
+#[test]
+fn explicit_order_overrides_field_default() {
+  let es = json!([{"_score": {"order": "asc"}}, {"price": "desc"}]);
+  let sl = translate_sort(&es).unwrap();
+  assert_eq!(
+    sl,
+    vec![
+      json!({"field": "_score", "order": "asc"}),
+      json!({"field": "price", "order": "desc"}),
+    ]
+  );
+}
+
+#[test]
+fn array_form_with_mixed_entries() {
+  let es = json!(["price", "_score"]);
+  let sl = translate_sort(&es).unwrap();
+  assert_eq!(
+    sl,
+    vec![
+      json!({"field": "price", "order": "asc"}),
+      json!({"field": "_score", "order": "desc"}),
+    ]
+  );
+}

--- a/searchlite-adapter-elastic/tests/translate_sort.rs
+++ b/searchlite-adapter-elastic/tests/translate_sort.rs
@@ -43,6 +43,17 @@ fn explicit_order_overrides_field_default() {
 }
 
 #[test]
+fn sort_with_missing_directive_is_explicitly_rejected() {
+  // Regression: `sort: { field: { missing: "_first" } }` used to be silently
+  // accepted-and-ignored, leading to ranking divergence from ES with no
+  // signal. Reject loudly per the project pattern of "silent drops are
+  // worse than loud rejections."
+  let es = json!([{ "price": { "missing": "_first" } }]);
+  let err = translate_sort(&es).unwrap_err();
+  assert!(err.feature.starts_with("sort.missing"), "got {err:?}");
+}
+
+#[test]
 fn array_form_with_mixed_entries() {
   let es = json!(["price", "_score"]);
   let sl = translate_sort(&es).unwrap();


### PR DESCRIPTION
## Summary

- Adds `searchlite-adapter-elastic`, a standalone HTTP service that proxies Elasticsearch-shaped requests to a `searchlite-http` upstream — JSON-to-JSON translation via `serde_json::Value`, no dependency on `searchlite-core` or `searchlite-http` types.
- v1 is read-only: `_search`, `_count`, `_mget`, `_msearch`, `_mapping`, `HEAD /{index}`, cluster stubs (`/`, `_cluster/health`, `_nodes`). Writes and DDL return `400 not_supported_in_v1`.
- Designed so future adapters (`searchlite-adapter-solr`, `searchlite-adapter-meili`) can follow the same shape, and so the entire crate can be removed cleanly if dropped.

The adapter binary is `searchlite-elastic`. It listens on `127.0.0.1:9200` by default and forwards to `--upstream-url http://127.0.0.1:8080`. Configuration mirrors `searchlite-http` style (clap + `SEARCHLITE_ELASTIC_*` env vars).

## Test coverage

Three layers, each catching a different class of regression:

1. **38 translation unit tests** in `searchlite-adapter-elastic/tests/translate_*.rs` — pure JSON-in / JSON-out for query DSL, aggregations, sort, highlight, pagination, mapping, and the response envelope.
2. **13 functional integration tests** in `integration/tests/elastic_compat.rs` — spawns both the upstream and the adapter on `portpicker`-allocated ports, exercises every MVP route via `reqwest`, asserts shapes and rejection behaviour.
3. **30 parity tests** in `integration/tests/elastic_parity.rs` — loads identical 10-document corpora into a Docker-launched Elasticsearch 9 container and the adapter, then runs the same queries against both and asserts equivalence under several rules:
   - filter/sort/aggregation set or order parity
   - top-K relevance bounds (every top-K hit must be in a known-relevant allowlist on **both** sides — catches spurious matches on either engine)
   - top-K cross-engine overlap (catches engines disagreeing on which docs match)
   - top-1 sanity (for queries with an obvious best answer)

The parity test self-skips when Docker isn't running so local dev without Docker isn't blocked. CI on `ubuntu-latest` has Docker available out of the box.

## Findings from real-ES parity

SearchLite + adapter agree with real Elasticsearch 9.0.0 across:

- Filter queries (`term`, `terms`, `range`, `bool.filter`)
- Sort (asc and desc)
- Aggregations (`terms`, `stats`, `_count`)
- Single-token full-text `match` (and identical relevance ordering of returned docs, e.g. `match: advanced` ranks the shorter doc higher on both engines via BM25 length normalization)
- Multi-token `match`, including top-1 sanity (`match: \"rust safety\"` returns the only doc with both terms)
- Case insensitivity (`match: RUST` finds rust docs on both)
- `match_phrase` (only true phrase matches returned)
- Multi-field `multi_match` over title+description with field boost (`title^3`)
- Stemming behaviour — neither engine stems by default; `match: pattern` returns nothing on both even though doc 2 has \"patterns\"
- Stopword behaviour — neither engine strips stopwords; `match: \"of the music\"` returns the same doc set on both
- Long-text BM25 — `match: kitchen` against the description field ranks `[6, 5]` on both (doc 6 has \"kitchen\" twice in a shorter description)

## Bug found and fixed during parity testing

The adapter was emitting `{\"name\": \"title\"}` for `multi_match` field specs, but SearchLite's `FieldSpec` deserializes from `{\"field\": \"title\"}`. The original 13 functional tests didn't exercise `multi_match`, so this only surfaced when a real ES query exercised it. Fixed in `translate/query.rs` and the matching unit test before merge.

## Files

- New crate at `searchlite-adapter-elastic/` (lib + binary `searchlite-elastic`)
- Workspace registration in `Cargo.toml`
- `integration/Cargo.toml` gains `searchlite-adapter-elastic` as a path dep so the test harness can locate the binary
- `integration/tests/elastic_compat.rs`, `integration/tests/elastic_parity.rs`

No changes to `searchlite-http` or `searchlite-core`.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` clean
- [x] `cargo test -p searchlite-adapter-elastic` — 38/38 pass
- [x] `cargo test -p integration --test elastic_compat -- --test-threads=2` — 13/13 pass
- [x] `cargo test -p integration --test elastic_parity` — 30/30 pass against real ES 9.0.0 in Docker (~10s warm, ~70s cold pull)
- [x] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)