### PR TITLE
chore: release v0.2.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -2275,7 +2275,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "searchlite-adapter-elastic"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -2363,7 +2363,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "axum",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "anyhow",
  "napi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/integration/CHANGELOG.md
+++ b/integration/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/davidkelley/searchlite/compare/integration-v0.2.5...integration-v0.2.6) - 2026-04-29
+
+### Added
+
+- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))
+
 ## [0.2.5](https://github.com/davidkelley/searchlite/compare/integration-v0.2.4...integration-v0.2.5) - 2026-04-27
 
 ### Other

--- a/searchlite-adapter-elastic/CHANGELOG.md
+++ b/searchlite-adapter-elastic/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.5...searchlite-adapter-elastic-v0.2.6) - 2026-04-29
+
+### Added
+
+- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))

--- a/searchlite-node/CHANGELOG.md
+++ b/searchlite-node/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.5...searchlite-node-v0.2.6) - 2026-04-29
+
+### Other
+
+- *(deps-dev)* bump @swc/core from 1.15.30 to 1.15.32 in /searchlite-node in the npm-minor-patch group ([#466](https://github.com/davidkelley/searchlite/pull/466))
+
 ## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.4...searchlite-node-v0.2.5) - 2026-04-27
 
 ### Fixed

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.5",
+	"version": "0.2.6",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {


### PR DESCRIPTION



## 🤖 New release

* `searchlite-adapter-elastic`: 0.2.5 -> 0.2.6
* `searchlite-http`: 0.2.5 -> 0.2.6
* `integration`: 0.2.5 -> 0.2.6 (✓ API compatible changes)
* `searchlite-node`: 0.2.5 -> 0.2.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-adapter-elastic`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.5...searchlite-adapter-elastic-v0.2.6) - 2026-04-29

### Added

- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.4...searchlite-http-v0.2.5) - 2026-04-27

### Other

- *(deps)* bump axum from 0.7.9 to 0.8.9 ([#432](https://github.com/davidkelley/searchlite/pull/432))
- *(deps)* bump the rust-minor-patch group across 1 directory with 16 updates ([#448](https://github.com/davidkelley/searchlite/pull/448))
</blockquote>

## `integration`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/compare/integration-v0.2.5...integration-v0.2.6) - 2026-04-29

### Added

- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.5...searchlite-node-v0.2.6) - 2026-04-29

### Other

- *(deps-dev)* bump @swc/core from 1.15.30 to 1.15.32 in /searchlite-node in the npm-minor-patch group ([#466](https://github.com/davidkelley/searchlite/pull/466))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).