### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3202,7 +3202,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3248,7 +3248,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-ffi"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "searchlite-core",
@@ -3316,7 +3316,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-wasm"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "futures",

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.13](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.12...searchlite-cli-v0.1.13) - 2026-05-06
+
+### Added
+
+- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
+
 ## [0.1.12](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.11...searchlite-cli-v0.1.12) - 2026-04-27
 
 ### Other

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.2...searchlite-core-v0.9.0) - 2026-05-06
+
+### Added
+
+- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
+
 ## [0.8.2](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.1...searchlite-core-v0.8.2) - 2026-04-27
 
 ### Other

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.8.2"
+version = "0.9.0"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-ffi/CHANGELOG.md
+++ b/searchlite-ffi/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.8...searchlite-ffi-v0.1.9) - 2026-05-06
+
+### Added
+
+- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
+
 ## [0.1.8](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.7...searchlite-ffi-v0.1.8) - 2026-04-27
 
 ### Other

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-ffi"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-s3/CHANGELOG.md
+++ b/searchlite-s3/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.6](https://github.com/davidkelley/searchlite/releases/tag/searchlite-s3-v0.2.6) - 2026-05-06
+
+### Added
+
+- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))

--- a/searchlite-wasm/CHANGELOG.md
+++ b/searchlite-wasm/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.10](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.9...searchlite-wasm-v0.1.10) - 2026-05-06
+
+### Added
+
+- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
+
 ## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.8...searchlite-wasm-v0.1.9) - 2026-04-27
 
 ### Other

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-wasm"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `searchlite-adapter-elastic`: 0.2.6
* `searchlite-core`: 0.8.2 -> 0.9.0 (⚠ API breaking changes)
* `searchlite-s3`: 0.2.6
* `searchlite-cli`: 0.1.12 -> 0.1.13
* `searchlite-ffi`: 0.1.8 -> 0.1.9
* `searchlite-wasm`: 0.1.9 -> 0.1.10

### ⚠ `searchlite-core` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type IndexOptions is no longer UnwindSafe, in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:93
  type IndexOptions is no longer RefUnwindSafe, in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:93
  type IndexOptions is no longer UnwindSafe, in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:93
  type IndexOptions is no longer RefUnwindSafe, in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:93

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IndexOptions.checksum_policy in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:105
  field IndexOptions.checksum_audit_failure_hook in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:110
  field IndexOptions.read_only in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:128
  field IndexOptions.checksum_policy in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:105
  field IndexOptions.checksum_audit_failure_hook in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:110
  field IndexOptions.read_only in /tmp/.tmp4XFNHK/searchlite/searchlite-core/src/api/types.rs:128
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-adapter-elastic`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.5...searchlite-adapter-elastic-v0.2.6) - 2026-04-29

### Added

- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))
</blockquote>

## `searchlite-core`

<blockquote>

## [0.9.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.2...searchlite-core-v0.9.0) - 2026-05-06

### Added

- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
</blockquote>

## `searchlite-s3`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/releases/tag/searchlite-s3-v0.2.6) - 2026-05-06

### Added

- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.13](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.12...searchlite-cli-v0.1.13) - 2026-05-06

### Added

- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
</blockquote>

## `searchlite-ffi`

<blockquote>

## [0.1.9](https://github.com/davidkelley/searchlite/compare/searchlite-ffi-v0.1.8...searchlite-ffi-v0.1.9) - 2026-05-06

### Added

- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
</blockquote>

## `searchlite-wasm`

<blockquote>

## [0.1.10](https://github.com/davidkelley/searchlite/compare/searchlite-wasm-v0.1.9...searchlite-wasm-v0.1.10) - 2026-05-06

### Added

- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).