### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,7 +2002,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-adapter-elastic"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "napi",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-s3"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Searchlite Authors"]
 license = "MIT"
 

--- a/searchlite-adapter-elastic/CHANGELOG.md
+++ b/searchlite-adapter-elastic/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.6...searchlite-adapter-elastic-v0.3.0) - 2026-05-06
+
+### Added
+
+- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))
+
+### Other
+
+- release v0.2.6 ([#479](https://github.com/davidkelley/searchlite/pull/479))
+- *(deps)* bump the rust-minor-patch group across 1 directory with 4 updates ([#481](https://github.com/davidkelley/searchlite/pull/481))
+- *(deps)* bump tower-http from 0.5.2 to 0.6.8 ([#474](https://github.com/davidkelley/searchlite/pull/474))
+- *(deps)* bump tower from 0.4.13 to 0.5.2 ([#477](https://github.com/davidkelley/searchlite/pull/477))
+
 ## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.5...searchlite-adapter-elastic-v0.2.6) - 2026-04-29
 
 ### Added

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.6...searchlite-http-v0.3.0) - 2026-05-06
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.4...searchlite-http-v0.2.5) - 2026-04-27
 
 ### Other

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.6",
+	"version": "0.3.0",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {

--- a/searchlite-s3/CHANGELOG.md
+++ b/searchlite-s3/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-s3-v0.2.6...searchlite-s3-v0.3.0) - 2026-05-06
+
+### Added
+
+- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))
+
+### Other
+
+- release ([#485](https://github.com/davidkelley/searchlite/pull/485))
+
 ## [0.2.6](https://github.com/davidkelley/searchlite/releases/tag/searchlite-s3-v0.2.6) - 2026-05-06
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `searchlite-adapter-elastic`: 0.2.6 -> 0.3.0
* `searchlite-s3`: 0.2.6 -> 0.3.0
* `searchlite-http`: 0.2.6 -> 0.3.0 (⚠ API breaking changes)
* `integration`: 0.2.6 -> 0.3.0
* `searchlite-node`: 0.2.6 -> 0.3.0

### ⚠ `searchlite-http` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field IndexSpec.s3 in /tmp/.tmpyHylgm/searchlite/searchlite-http/src/lib.rs:62
  field ServeArgs.checksum_policy in /tmp/.tmpyHylgm/searchlite/searchlite-http/src/lib.rs:290
  field ServeArgs.s3_endpoint in /tmp/.tmpyHylgm/searchlite/searchlite-http/src/lib.rs:302
  field ServeArgs.s3_region in /tmp/.tmpyHylgm/searchlite/searchlite-http/src/lib.rs:309
  field ServeArgs.s3_force_path_style in /tmp/.tmpyHylgm/searchlite/searchlite-http/src/lib.rs:316
  field ServeArgs.s3_conditional_put in /tmp/.tmpyHylgm/searchlite/searchlite-http/src/lib.rs:325
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-adapter-elastic`

<blockquote>

## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.6...searchlite-adapter-elastic-v0.3.0) - 2026-05-06

### Added

- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))

### Other

- release v0.2.6 ([#479](https://github.com/davidkelley/searchlite/pull/479))
- *(deps)* bump the rust-minor-patch group across 1 directory with 4 updates ([#481](https://github.com/davidkelley/searchlite/pull/481))
- *(deps)* bump tower-http from 0.5.2 to 0.6.8 ([#474](https://github.com/davidkelley/searchlite/pull/474))
- *(deps)* bump tower from 0.4.13 to 0.5.2 ([#477](https://github.com/davidkelley/searchlite/pull/477))
</blockquote>

## `searchlite-s3`

<blockquote>

## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-s3-v0.2.6...searchlite-s3-v0.3.0) - 2026-05-06

### Added

- BlobStore trait + searchlite-s3 backend (S3/R2/MinIO) ([#482](https://github.com/davidkelley/searchlite/pull/482))

### Other

- release ([#485](https://github.com/davidkelley/searchlite/pull/485))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.3.0](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.6...searchlite-http-v0.3.0) - 2026-05-06

### Other

- update Cargo.toml dependencies
</blockquote>

## `integration`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/compare/integration-v0.2.5...integration-v0.2.6) - 2026-04-29

### Added

- add Elasticsearch HTTP-API compatibility adapter ([#465](https://github.com/davidkelley/searchlite/pull/465))
</blockquote>

## `searchlite-node`

<blockquote>

## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-node-v0.2.5...searchlite-node-v0.2.6) - 2026-04-29

### Other

- *(deps-dev)* bump @swc/core from 1.15.30 to 1.15.32 in /searchlite-node in the npm-minor-patch group ([#466](https://github.com/davidkelley/searchlite/pull/466))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).