### PR TITLE
ci: publish 5 searchlite crates to crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Run release-plz
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
           set -euo pipefail
           # release-plz detects the previous published version from git tags; the registry manifest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ edition = "2021"
 version = "0.2.6"
 authors = ["Searchlite Authors"]
 license = "MIT"
+repository = "https://github.com/davidkelley/searchlite"
+homepage = "https://github.com/davidkelley/searchlite"
 
 [workspace.dependencies]
 anyhow = "1.0.102"

--- a/integration/Cargo.toml
+++ b/integration/Cargo.toml
@@ -4,6 +4,7 @@ edition.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true
+publish = false
 
 [features]
 default = []

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,8 +1,24 @@
 [workspace]
-publish = false
+publish = true
 git_release_enable = true
 git_tag_enable = true
 release_always = true
+
+# Internal-only crates: not published to crates.io.
+
+[[package]]
+name = "searchlite-ffi"
+publish = false
+release = true
+git_release_enable = true
+git_tag_enable = true
+
+[[package]]
+name = "searchlite-wasm"
+publish = false
+release = true
+git_release_enable = true
+git_tag_enable = true
 
 # Node.js addon — published to npm, not crates.io
 [[package]]
@@ -11,3 +27,10 @@ publish = false
 release = true
 git_release_enable = true
 git_tag_enable = true
+
+[[package]]
+name = "integration"
+publish = false
+release = false
+git_release_enable = false
+git_tag_enable = false

--- a/searchlite-adapter-elastic/Cargo.toml
+++ b/searchlite-adapter-elastic/Cargo.toml
@@ -4,6 +4,12 @@ edition.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Elasticsearch-compatible HTTP adapter for searchlite (translates ES query DSL to native API)"
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["search", "elasticsearch", "adapter", "proxy", "compatibility"]
+categories = ["web-programming::http-server", "database"]
 
 [[bin]]
 name = "searchlite-elastic"

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -4,7 +4,12 @@ version = "0.1.13"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"
-description = "CLI for searchlite"
+description = "Command-line interface for searchlite: build, query, sync, and serve full-text indexes"
+repository.workspace = true
+homepage.workspace = true
+readme = "../README.md"
+keywords = ["search", "cli", "index", "bm25", "fulltext"]
+categories = ["command-line-utilities", "database"]
 
 [features]
 default = ["s3"]
@@ -29,9 +34,9 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-searchlite-core = { path = "../searchlite-core", package = "searchlite-core", features = ["write-key"] }
-searchlite-http = { path = "../searchlite-http", package = "searchlite-http" }
-searchlite-s3 = { path = "../searchlite-s3", package = "searchlite-s3", optional = true }
+searchlite-core = { path = "../searchlite-core", version = "0.9.0", package = "searchlite-core", features = ["write-key"] }
+searchlite-http = { path = "../searchlite-http", version = "0.2.6", package = "searchlite-http" }
+searchlite-s3 = { path = "../searchlite-s3", version = "0.2.6", package = "searchlite-s3", optional = true }
 tokio = { version = "1.52.2", features = ["rt-multi-thread"] }
 chrono = { workspace = true }
 env_logger = { workspace = true }

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -4,7 +4,12 @@ version = "0.9.0"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"
-description = "Embedded search engine core for searchlite"
+description = "Embedded full-text search engine: BM25, inverted index, WAL durability, aggregations"
+repository.workspace = true
+homepage.workspace = true
+readme = "../README.md"
+keywords = ["search", "index", "bm25", "embedded", "fulltext"]
+categories = ["database-implementations", "text-processing"]
 
 [features]
 default = []

--- a/searchlite-ffi/Cargo.toml
+++ b/searchlite-ffi/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"
 description = "C FFI for searchlite"
+publish = false
 
 [features]
 default = []

--- a/searchlite-http/Cargo.toml
+++ b/searchlite-http/Cargo.toml
@@ -4,6 +4,12 @@ edition.workspace = true
 version.workspace = true
 authors.workspace = true
 license.workspace = true
+description = "Axum-based HTTP server exposing searchlite indexes (search, mget, msearch, write)"
+repository.workspace = true
+homepage.workspace = true
+readme = "../README.md"
+keywords = ["search", "http", "server", "index", "bm25"]
+categories = ["web-programming::http-server", "database"]
 
 [features]
 default = []
@@ -21,8 +27,8 @@ anyhow = { workspace = true }
 axum = "0.8.9"
 clap = { workspace = true, features = ["derive", "env"] }
 futures-util = "0.3.32"
-searchlite-core = { path = "../searchlite-core", package = "searchlite-core", features = ["write-key"] }
-searchlite-s3 = { path = "../searchlite-s3", package = "searchlite-s3", optional = true }
+searchlite-core = { path = "../searchlite-core", version = "0.9.0", package = "searchlite-core", features = ["write-key"] }
+searchlite-s3 = { path = "../searchlite-s3", version = "0.2.6", package = "searchlite-s3", optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/searchlite-node/Cargo.toml
+++ b/searchlite-node/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "Node.js native addon for searchlite"
+publish = false
 
 [features]
 default = []

--- a/searchlite-s3/Cargo.toml
+++ b/searchlite-s3/Cargo.toml
@@ -5,6 +5,11 @@ version.workspace = true
 authors.workspace = true
 license.workspace = true
 description = "S3-compatible BlobStore implementation for searchlite (AWS S3, R2, MinIO)"
+repository.workspace = true
+homepage.workspace = true
+readme = "README.md"
+keywords = ["search", "s3", "r2", "minio", "blobstore"]
+categories = ["database", "web-programming"]
 
 [lib]
 path = "src/lib.rs"
@@ -21,7 +26,7 @@ vectors = ["searchlite-core/vectors"]
 # TLS). Wasm consumers continue on the StorageAsBlobStore path inside
 # searchlite-core; this crate is non-wasm-only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-searchlite-core = { path = "../searchlite-core", features = ["tokio-runtime"] }
+searchlite-core = { path = "../searchlite-core", version = "0.9.0", features = ["tokio-runtime"] }
 anyhow = { workspace = true }
 async-trait = "0.1"
 base64 = { workspace = true }
@@ -42,4 +47,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 tempfile = { workspace = true }
 crc32fast = { workspace = true }
-searchlite-core = { path = "../searchlite-core", features = ["tokio-runtime"] }
+searchlite-core = { path = "../searchlite-core", version = "0.9.0", features = ["tokio-runtime"] }

--- a/searchlite-wasm/Cargo.toml
+++ b/searchlite-wasm/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"
 description = "WASM bindings for searchlite with IndexedDB-backed storage"
+publish = false
 
 [features]
 default = []


### PR DESCRIPTION
## Summary
- Flips workspace `publish = false` → `true` and marks the 4 internal/non-Rust-channel crates (`searchlite-ffi`, `searchlite-wasm`, `searchlite-node`, `integration`) as `publish = false` explicitly.
- Adds the manifest metadata crates.io expects — `description`, `repository`, `homepage`, `readme`, `keywords`, `categories` — on the 5 publishable crates: `searchlite-core`, `searchlite-cli`, `searchlite-http`, `searchlite-s3`, `searchlite-adapter-elastic`.
- Pins path-dep versions on inter-crate dependencies so release-plz can publish in topological order: `core` → `s3` → `http` → `cli` (and `adapter-elastic` independently).
- Wires `CARGO_REGISTRY_TOKEN` into the release-plz step in `.github/workflows/release.yml`.

## What happens after merge
On the next push to `main`, the existing release-plz workflow will run and (because none of the crate names exist on crates.io yet) will publish all 5 at their current local versions, claiming the names. Subsequent releases keep using the same workflow with no further setup.

The other crates retain their existing distribution channels:
- `searchlite-ffi` → cdylib + C header via release-artifacts
- `searchlite-wasm` → wasm-pack output (consumed by `searchlite-node`'s npm package)
- `searchlite-node` → npm
- `integration` → internal test crate

## Test plan
- [x] `cargo package --workspace --exclude integration --exclude searchlite-ffi --exclude searchlite-wasm --exclude searchlite-node` packages and full-verifies all 5 crates with zero warnings.
- [ ] After merge: confirm release-plz workflow run on `main` publishes all 5 crates and that they appear at https://crates.io/crates/searchlite-core etc.
- [ ] After publish: confirm the crates.io badge in the README resolves to the published version.

## Prerequisites (already done)
- [x] `CARGO_REGISTRY_TOKEN` added as a repo Actions secret with `publish-new` + `publish-update` scopes, scoped to `searchlite-*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)