### PR TITLE
chore: gitignore napi-generated searchlite-node/index.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ searchlite-node/node_modules/
 searchlite-node/dist/
 searchlite-node/*.node
 searchlite-node/index.d.ts
+searchlite-node/index.js


### PR DESCRIPTION
## Summary
`napi build` (invoked via `npm run build:native`) auto-generates both `searchlite-node/index.d.ts` *and* `searchlite-node/index.js`. The `.d.ts` was already gitignored but the `.js` was missed, leaving it as an untracked file in `git status` for any contributor who runs the documented build commands. Add the missing entry alongside the existing one.

## Test plan
- [x] `cd searchlite-node && npm run build:debug` — both `index.js` and `index.d.ts` are generated as before
- [x] `git status` afterwards shows only the `.gitignore` change in this PR (no untracked `searchlite-node/index.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)