### PR TITLE
ci: pin searchlite-wasm to nightly-2026-05-05

### DIFF
--- a/searchlite-wasm/rust-toolchain.toml
+++ b/searchlite-wasm/rust-toolchain.toml
@@ -1,4 +1,9 @@
 [toolchain]
-channel = "nightly"
+# Pinned to last known-good nightly. The 2026-05-06 nightly broke
+# wasm-bindgen's threading init with `failed to find __heap_base for
+# injecting thread id`. Bump this date once wasm-bindgen ships a fix,
+# or once a newer nightly is confirmed compatible with our threading
+# rustflags in .cargo/config.toml.
+channel = "nightly-2026-05-05"
 components = ["rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## Summary
The 2026-05-06 Rust nightly broke wasm-bindgen's threading init step on the searchlite-wasm crate:

```
error: failed to prepare module for threading
Caused by: failed to find `__heap_base` for injecting thread id
```

This is a known wasm-bindgen failure mode when rustc nightly changes how it lays out wasm symbols. Pinning [searchlite-wasm/rust-toolchain.toml](searchlite-wasm/rust-toolchain.toml) to the last green nightly (`nightly-2026-05-05`) restores CI.

Unrelated to the publishing PR ([#491](https://github.com/davidkelley/searchlite/pull/491)) that just merged — same wasm code, same wasm-bindgen 0.2.118, the only variable that changed was the rustc nightly:
- 2026-05-06 main run (#485): `1.97.0-nightly (e95e73209 2026-05-05)` → green
- 2026-05-07 main run (#491): `1.97.0-nightly (365c0e1d7 2026-05-06)` → red

## Why pin instead of upgrade wasm-bindgen
Smaller blast radius; bumping wasm-bindgen could cascade. Pinning is a one-line change that's easy to revert when the nightly is confirmed working again (or wasm-bindgen ships a fix).

## Once merged
Unblocks the open release-plz PR ([#492](https://github.com/davidkelley/searchlite/pull/492)) — CI on the release branch will pick up this pin once release-plz regenerates the PR on the next push to main.

## Test plan
- [ ] CI passes on this PR (specifically `WASM Browser` and `WASM Browser (Firefox)`).
- [ ] After merge: release-plz PR #492 picks up the fix and goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)