### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "integration"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3165,7 +3165,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-adapter-elastic"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3186,7 +3186,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-cli"
-version = "0.1.13"
+version = "0.1.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3204,7 +3204,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-core"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-http"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3283,7 +3283,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-node"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "napi",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "searchlite-s3"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["Searchlite Authors"]
 license = "MIT"
 repository = "https://github.com/davidkelley/searchlite"

--- a/searchlite-adapter-elastic/CHANGELOG.md
+++ b/searchlite-adapter-elastic/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.6...searchlite-adapter-elastic-v0.2.7) - 2026-05-07
+
+### Other
+
+- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
+- *(deps)* bump the rust-minor-patch group across 1 directory with 6 updates ([#487](https://github.com/davidkelley/searchlite/pull/487))
+
 ## [0.2.6](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.5...searchlite-adapter-elastic-v0.2.6) - 2026-04-29
 
 ### Added

--- a/searchlite-cli/CHANGELOG.md
+++ b/searchlite-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.14](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.13...searchlite-cli-v0.1.14) - 2026-05-07
+
+### Other
+
+- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
+- *(deps)* bump the rust-minor-patch group across 1 directory with 6 updates ([#487](https://github.com/davidkelley/searchlite/pull/487))
+
 ## [0.1.13](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.12...searchlite-cli-v0.1.13) - 2026-05-06
 
 ### Added

--- a/searchlite-cli/Cargo.toml
+++ b/searchlite-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-cli"
-version = "0.1.13"
+version = "0.1.14"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"
@@ -34,9 +34,9 @@ anyhow = { workspace = true }
 clap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-searchlite-core = { path = "../searchlite-core", version = "0.9.0", package = "searchlite-core", features = ["write-key"] }
-searchlite-http = { path = "../searchlite-http", version = "0.2.6", package = "searchlite-http" }
-searchlite-s3 = { path = "../searchlite-s3", version = "0.2.6", package = "searchlite-s3", optional = true }
+searchlite-core = { path = "../searchlite-core", version = "0.9.1", package = "searchlite-core", features = ["write-key"] }
+searchlite-http = { path = "../searchlite-http", version = "0.2.7", package = "searchlite-http" }
+searchlite-s3 = { path = "../searchlite-s3", version = "0.2.7", package = "searchlite-s3", optional = true }
 tokio = { version = "1.52.2", features = ["rt-multi-thread"] }
 chrono = { workspace = true }
 env_logger = { workspace = true }

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.9.0...searchlite-core-v0.9.1) - 2026-05-07
+
+### Other
+
+- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
+
 ## [0.9.0](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.8.2...searchlite-core-v0.9.0) - 2026-05-06
 
 ### Added

--- a/searchlite-core/Cargo.toml
+++ b/searchlite-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "searchlite-core"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 authors = ["Searchlite Authors"]
 license = "MIT"

--- a/searchlite-http/CHANGELOG.md
+++ b/searchlite-http/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.6...searchlite-http-v0.2.7) - 2026-05-07
+
+### Other
+
+- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
+- *(deps)* bump the rust-minor-patch group across 1 directory with 6 updates ([#487](https://github.com/davidkelley/searchlite/pull/487))
+
 ## [0.2.5](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.4...searchlite-http-v0.2.5) - 2026-04-27
 
 ### Other

--- a/searchlite-http/Cargo.toml
+++ b/searchlite-http/Cargo.toml
@@ -27,8 +27,8 @@ anyhow = { workspace = true }
 axum = "0.8.9"
 clap = { workspace = true, features = ["derive", "env"] }
 futures-util = "0.3.32"
-searchlite-core = { path = "../searchlite-core", version = "0.9.0", package = "searchlite-core", features = ["write-key"] }
-searchlite-s3 = { path = "../searchlite-s3", version = "0.2.6", package = "searchlite-s3", optional = true }
+searchlite-core = { path = "../searchlite-core", version = "0.9.1", package = "searchlite-core", features = ["write-key"] }
+searchlite-s3 = { path = "../searchlite-s3", version = "0.2.7", package = "searchlite-s3", optional = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/searchlite-node/package.json
+++ b/searchlite-node/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "searchlite-js",
-	"version": "0.2.6",
+	"version": "0.2.7",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"napi": {

--- a/searchlite-s3/CHANGELOG.md
+++ b/searchlite-s3/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.7](https://github.com/davidkelley/searchlite/compare/searchlite-s3-v0.2.6...searchlite-s3-v0.2.7) - 2026-05-07
+
+### Other
+
+- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
+- release ([#485](https://github.com/davidkelley/searchlite/pull/485))
+
 ## [0.2.6](https://github.com/davidkelley/searchlite/releases/tag/searchlite-s3-v0.2.6) - 2026-05-06
 
 ### Added

--- a/searchlite-s3/Cargo.toml
+++ b/searchlite-s3/Cargo.toml
@@ -26,7 +26,7 @@ vectors = ["searchlite-core/vectors"]
 # TLS). Wasm consumers continue on the StorageAsBlobStore path inside
 # searchlite-core; this crate is non-wasm-only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-searchlite-core = { path = "../searchlite-core", version = "0.9.0", features = ["tokio-runtime"] }
+searchlite-core = { path = "../searchlite-core", version = "0.9.1", features = ["tokio-runtime"] }
 anyhow = { workspace = true }
 async-trait = "0.1"
 base64 = { workspace = true }
@@ -47,4 +47,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "test-util"] }
 tempfile = { workspace = true }
 crc32fast = { workspace = true }
-searchlite-core = { path = "../searchlite-core", version = "0.9.0", features = ["tokio-runtime"] }
+searchlite-core = { path = "../searchlite-core", version = "0.9.1", features = ["tokio-runtime"] }


### PR DESCRIPTION



## 🤖 New release

* `searchlite-adapter-elastic`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `searchlite-core`: 0.9.0 -> 0.9.1 (✓ API compatible changes)
* `searchlite-s3`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `searchlite-http`: 0.2.6 -> 0.2.7 (✓ API compatible changes)
* `searchlite-cli`: 0.1.13 -> 0.1.14

<details><summary><i><b>Changelog</b></i></summary><p>

## `searchlite-adapter-elastic`

<blockquote>

## [0.2.7](https://github.com/davidkelley/searchlite/compare/searchlite-adapter-elastic-v0.2.6...searchlite-adapter-elastic-v0.2.7) - 2026-05-07

### Other

- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
- *(deps)* bump the rust-minor-patch group across 1 directory with 6 updates ([#487](https://github.com/davidkelley/searchlite/pull/487))
</blockquote>

## `searchlite-core`

<blockquote>

## [0.9.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.9.0...searchlite-core-v0.9.1) - 2026-05-07

### Other

- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
</blockquote>

## `searchlite-s3`

<blockquote>

## [0.2.7](https://github.com/davidkelley/searchlite/compare/searchlite-s3-v0.2.6...searchlite-s3-v0.2.7) - 2026-05-07

### Other

- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
- release ([#485](https://github.com/davidkelley/searchlite/pull/485))
</blockquote>

## `searchlite-http`

<blockquote>

## [0.2.7](https://github.com/davidkelley/searchlite/compare/searchlite-http-v0.2.6...searchlite-http-v0.2.7) - 2026-05-07

### Other

- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
- *(deps)* bump the rust-minor-patch group across 1 directory with 6 updates ([#487](https://github.com/davidkelley/searchlite/pull/487))
</blockquote>

## `searchlite-cli`

<blockquote>

## [0.1.14](https://github.com/davidkelley/searchlite/compare/searchlite-cli-v0.1.13...searchlite-cli-v0.1.14) - 2026-05-07

### Other

- publish 5 searchlite crates to crates.io ([#491](https://github.com/davidkelley/searchlite/pull/491))
- *(deps)* bump the rust-minor-patch group across 1 directory with 6 updates ([#487](https://github.com/davidkelley/searchlite/pull/487))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).