### PR TITLE
fix(pagination): reject and suppress cursor/search_after with rescore over score sort (BUG-411)

### DIFF
--- a/docs/queries.md
+++ b/docs/queries.md
@@ -353,6 +353,18 @@ re-ranks them with phrase proximity. This gives you phrase-quality results at BM
 }
 ```
 
+Rescore reorders the top window by combining the rescore score with the
+base score. When the request sorts by `_score`, the resulting order
+cannot be resumed with `cursor` or `search_after`: those tokens are keyed
+on the score component, and the next page would compare them against the
+*pre-rescore* score stream. To make this unambiguous, Searchlite does
+**not** emit `next_cursor` / `next_search_after` for a request that
+combines `rescore` with a score-bearing sort, and rejects a request that
+supplies either token with the same combination. Sort plans that don't
+include `_score` (e.g. sort by a numeric field) are unaffected — rescore
+changes the displayed score without touching the sort key, so the cursor
+remains stable and pagination is fully supported.
+
 ---
 
 ## Request-level tuning knobs

--- a/searchlite-core/CHANGELOG.md
+++ b/searchlite-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- *(pagination)* reject cursor/search_after pagination when rescore is combined with a score-bearing sort, and suppress `next_cursor`/`next_search_after` emission for the same combination — the cursor would otherwise carry the rescored score and never match the base-score keys on page 2, producing `"stale or invalid cursor for this result set"` (BUG-411).
+
 ## [0.9.1](https://github.com/davidkelley/searchlite/compare/searchlite-core-v0.9.0...searchlite-core-v0.9.1) - 2026-05-07
 
 ### Other

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1183,25 +1183,6 @@ impl IndexReader {
       ensure_keyword_fast(&self.manifest.schema, &collapse.field, "collapse", None)?;
     }
     let sort_plan = SortPlan::from_request(&self.manifest.schema, &req.sort)?;
-    // BUG-411: a rescore stage rewrites `hit.score` and, for score-bearing sort
-    // plans, the score-keyed `hit.key` too. The cursor / search_after token
-    // emitted for a paginated rescore would therefore carry the *rescored*
-    // score, which page 2 cannot match against the base-score keys built
-    // during segment search — `saw_cursor` would never fire and the request
-    // would bail with `"stale or invalid cursor for this result set"`. Sort
-    // plans that don't use `_score` are unaffected because `build_key`
-    // ignores the score for non-score sort fields. Reject the inbound side
-    // here so a hand-crafted cursor can't reach the cursor-key comparison;
-    // the outbound side suppresses tokens at emission time to ensure callers
-    // are never handed one they can't use.
-    if req.rescore.is_some() && sort_plan.uses_score() {
-      if req.cursor.is_some() {
-        bail!("cursor pagination is not supported when rescore is combined with a sort that uses _score");
-      }
-      if req.search_after.is_some() {
-        bail!("search_after pagination is not supported when rescore is combined with a sort that uses _score");
-      }
-    }
     let track_total_hits = req.track_total_hits.unwrap_or(false);
     let score_fast_path = !track_total_hits
       && sort_plan.is_score_only()
@@ -1292,6 +1273,28 @@ impl IndexReader {
     if let Some(plan) = vector_plan.as_ref() {
       if plan.vector_only {
         return self.search_vector_only(req, sort_plan, manifest_generation, cursor_state, plan);
+      }
+    }
+    // BUG-411: a rescore stage rewrites `hit.score` and, for score-bearing sort
+    // plans, the score-keyed `hit.key` too. The cursor / search_after token
+    // emitted for a paginated rescore would therefore carry the *rescored*
+    // score, which page 2 cannot match against the base-score keys built
+    // during segment search — `saw_cursor` would never fire and the request
+    // would bail with `"stale or invalid cursor for this result set"`. Sort
+    // plans that don't use `_score` are unaffected because `build_key`
+    // ignores the score for non-score sort fields. The check (and the
+    // outbound `suppress_pagination_tokens` flag further down) runs *after*
+    // the vector-only early return on purpose: `search_vector_only` never
+    // calls `rescore_hits`, so its cursor is built from the base vector
+    // score and is not corrupted by rescore. Applying this guard there
+    // too would reject vector-only requests whose tokens are still valid,
+    // breaking what was previously a working flow.
+    if req.rescore.is_some() && sort_plan.uses_score() {
+      if req.cursor.is_some() {
+        bail!("cursor pagination is not supported when rescore is combined with a sort that uses _score");
+      }
+      if req.search_after.is_some() {
+        bail!("search_after pagination is not supported when rescore is combined with a sort that uses _score");
       }
     }
     let query_plan = build_query_plan(&req.query, &default_fields)?;
@@ -3971,43 +3974,55 @@ mod tests {
   // tokens so the failure mode is unreachable. The sister assertion below
   // guards the non-score sort plan, where rescore does not corrupt the
   // key and pagination must still work.
-  fn make_rescore_index(dir: &tempfile::TempDir) -> Index {
+  const RESCORE_CORPUS: &[(&str, &str)] = &[
+    ("doc-1", "rust rust search engine"),
+    ("doc-2", "rust query optimizer"),
+    ("doc-3", "rust safe parallel rust"),
+    ("doc-4", "rust borrow checker"),
+    ("doc-5", "rust traits and generics"),
+  ];
+
+  fn rescore_index_options(path: &std::path::Path) -> IndexOptions {
+    IndexOptions {
+      path: path.to_path_buf(),
+      create_if_missing: true,
+      enable_positions: true,
+      bm25_k1: 0.9,
+      bm25_b: 0.4,
+      storage: StorageType::Filesystem,
+      checksum_policy: Default::default(),
+      checksum_audit_failure_hook: None,
+      read_only: false,
+      #[cfg(feature = "vectors")]
+      vector_defaults: None,
+    }
+  }
+
+  /// Build an index from a custom `schema` and a closure that maps each
+  /// `(id, text, index)` tuple from `RESCORE_CORPUS` to a full `Document`.
+  /// Tests with extra fields (e.g. a numeric `rank` for sort-stability
+  /// checks) pass a closure that augments the base `_id` + `body`
+  /// fields; tests that only need the base schema pass the
+  /// `default_text_body` schema and the identity-style closure.
+  fn make_rescore_index_with(
+    dir: &tempfile::TempDir,
+    schema: Schema,
+    mut build_doc: impl FnMut(usize, &str, &str) -> Document,
+  ) -> Index {
     let path = dir.path().join("idx");
-    let schema = Schema::default_text_body();
-    let idx = Index::create(
-      &path,
-      schema,
-      IndexOptions {
-        path: path.clone(),
-        create_if_missing: true,
-        enable_positions: true,
-        bm25_k1: 0.9,
-        bm25_b: 0.4,
-        storage: StorageType::Filesystem,
-        checksum_policy: Default::default(),
-        checksum_audit_failure_hook: None,
-        read_only: false,
-        #[cfg(feature = "vectors")]
-        vector_defaults: None,
-      },
-    )
-    .unwrap();
+    let idx = Index::create(&path, schema, rescore_index_options(&path)).unwrap();
     let mut writer = idx.writer().unwrap();
-    for (id, text) in [
-      ("doc-1", "rust rust search engine"),
-      ("doc-2", "rust query optimizer"),
-      ("doc-3", "rust safe parallel rust"),
-      ("doc-4", "rust borrow checker"),
-      ("doc-5", "rust traits and generics"),
-    ] {
-      writer
-        .add_document(&Document {
-          fields: BTreeMap::from([("_id".into(), json!(id)), ("body".into(), json!(text))]),
-        })
-        .unwrap();
+    for (i, (id, text)) in RESCORE_CORPUS.iter().enumerate() {
+      writer.add_document(&build_doc(i, id, text)).unwrap();
     }
     writer.commit().unwrap();
     idx
+  }
+
+  fn make_rescore_index(dir: &tempfile::TempDir) -> Index {
+    make_rescore_index_with(dir, Schema::default_text_body(), |_, id, text| Document {
+      fields: BTreeMap::from([("_id".into(), json!(id)), ("body".into(), json!(text))]),
+    })
   }
 
   fn rescore_search_request(
@@ -4132,7 +4147,6 @@ mod tests {
   #[test]
   fn rescore_with_numeric_sort_still_paginates() {
     let dir = tempfile::tempdir().unwrap();
-    let path = dir.path().join("idx");
     let mut schema = Schema::default_text_body();
     schema.numeric_fields.push(NumericField {
       name: "rank".into(),
@@ -4141,46 +4155,13 @@ mod tests {
       stored: false,
       nullable: false,
     });
-    let idx = Index::create(
-      &path,
-      schema,
-      IndexOptions {
-        path: path.clone(),
-        create_if_missing: true,
-        enable_positions: true,
-        bm25_k1: 0.9,
-        bm25_b: 0.4,
-        storage: StorageType::Filesystem,
-        checksum_policy: Default::default(),
-        checksum_audit_failure_hook: None,
-        read_only: false,
-        #[cfg(feature = "vectors")]
-        vector_defaults: None,
-      },
-    )
-    .unwrap();
-    let mut writer = idx.writer().unwrap();
-    for (idx_n, (id, text)) in [
-      ("doc-1", "rust rust search engine"),
-      ("doc-2", "rust query optimizer"),
-      ("doc-3", "rust safe parallel rust"),
-      ("doc-4", "rust borrow checker"),
-      ("doc-5", "rust traits and generics"),
-    ]
-    .iter()
-    .enumerate()
-    {
-      writer
-        .add_document(&Document {
-          fields: BTreeMap::from([
-            ("_id".into(), json!(id)),
-            ("body".into(), json!(text)),
-            ("rank".into(), json!(idx_n as i64)),
-          ]),
-        })
-        .unwrap();
-    }
-    writer.commit().unwrap();
+    let idx = make_rescore_index_with(&dir, schema, |i, id, text| Document {
+      fields: BTreeMap::from([
+        ("_id".into(), json!(id)),
+        ("body".into(), json!(text)),
+        ("rank".into(), json!(i as i64)),
+      ]),
+    });
     let reader = idx.reader().unwrap();
     let mut req = rescore_search_request(None, None, true);
     req.sort = vec![SortSpec {

--- a/searchlite-core/src/api/reader.rs
+++ b/searchlite-core/src/api/reader.rs
@@ -1183,6 +1183,25 @@ impl IndexReader {
       ensure_keyword_fast(&self.manifest.schema, &collapse.field, "collapse", None)?;
     }
     let sort_plan = SortPlan::from_request(&self.manifest.schema, &req.sort)?;
+    // BUG-411: a rescore stage rewrites `hit.score` and, for score-bearing sort
+    // plans, the score-keyed `hit.key` too. The cursor / search_after token
+    // emitted for a paginated rescore would therefore carry the *rescored*
+    // score, which page 2 cannot match against the base-score keys built
+    // during segment search — `saw_cursor` would never fire and the request
+    // would bail with `"stale or invalid cursor for this result set"`. Sort
+    // plans that don't use `_score` are unaffected because `build_key`
+    // ignores the score for non-score sort fields. Reject the inbound side
+    // here so a hand-crafted cursor can't reach the cursor-key comparison;
+    // the outbound side suppresses tokens at emission time to ensure callers
+    // are never handed one they can't use.
+    if req.rescore.is_some() && sort_plan.uses_score() {
+      if req.cursor.is_some() {
+        bail!("cursor pagination is not supported when rescore is combined with a sort that uses _score");
+      }
+      if req.search_after.is_some() {
+        bail!("search_after pagination is not supported when rescore is combined with a sort that uses _score");
+      }
+    }
     let track_total_hits = req.track_total_hits.unwrap_or(false);
     let score_fast_path = !track_total_hits
       && sort_plan.is_score_only()
@@ -1539,10 +1558,15 @@ impl IndexReader {
     }
     let mut next_cursor = None;
     let mut next_search_after = None;
+    // BUG-411: never hand out pagination tokens we can't honor on the next
+    // page. When rescore is paired with a score-bearing sort plan the
+    // emitted key would carry the rescored score, which cannot match the
+    // base-score keys produced during segment search.
+    let suppress_pagination_tokens = req.rescore.is_some() && sort_plan.uses_score();
     let hits: Vec<Hit> = if req.return_hits {
       let total_needed = from.saturating_add(req.limit);
       let has_more = total_needed > 0 && hits.len() > total_needed;
-      if has_more {
+      if has_more && !suppress_pagination_tokens {
         let last = &hits[total_needed - 1];
         if !search_after_mode {
           let returned = cursor_returned
@@ -1632,7 +1656,7 @@ impl IndexReader {
           Some(hit)
         })
         .collect();
-      if has_more {
+      if has_more && !suppress_pagination_tokens {
         if let Some(key) = last_returned_key.as_ref() {
           next_search_after = encode_search_after_token(&sort_plan, key, &self.segments).ok();
         }
@@ -3937,6 +3961,254 @@ mod tests {
     assert!(err
       .to_string()
       .contains("cursor cannot be combined with search_after"));
+  }
+
+  // BUG-411: a rescore stage rewrites the score-bearing component of the
+  // sort key, so a cursor / search_after token emitted alongside rescore
+  // would carry the rescored score and never match the base-score keys
+  // built during segment search on the next page (the engine bailed with
+  // "stale or invalid cursor"). Suppress emission and reject inbound
+  // tokens so the failure mode is unreachable. The sister assertion below
+  // guards the non-score sort plan, where rescore does not corrupt the
+  // key and pagination must still work.
+  fn make_rescore_index(dir: &tempfile::TempDir) -> Index {
+    let path = dir.path().join("idx");
+    let schema = Schema::default_text_body();
+    let idx = Index::create(
+      &path,
+      schema,
+      IndexOptions {
+        path: path.clone(),
+        create_if_missing: true,
+        enable_positions: true,
+        bm25_k1: 0.9,
+        bm25_b: 0.4,
+        storage: StorageType::Filesystem,
+        checksum_policy: Default::default(),
+        checksum_audit_failure_hook: None,
+        read_only: false,
+        #[cfg(feature = "vectors")]
+        vector_defaults: None,
+      },
+    )
+    .unwrap();
+    let mut writer = idx.writer().unwrap();
+    for (id, text) in [
+      ("doc-1", "rust rust search engine"),
+      ("doc-2", "rust query optimizer"),
+      ("doc-3", "rust safe parallel rust"),
+      ("doc-4", "rust borrow checker"),
+      ("doc-5", "rust traits and generics"),
+    ] {
+      writer
+        .add_document(&Document {
+          fields: BTreeMap::from([("_id".into(), json!(id)), ("body".into(), json!(text))]),
+        })
+        .unwrap();
+    }
+    writer.commit().unwrap();
+    idx
+  }
+
+  fn rescore_search_request(
+    cursor: Option<String>,
+    search_after: Option<Vec<serde_json::Value>>,
+    rescore: bool,
+  ) -> SearchRequest {
+    SearchRequest {
+      query: Query::String("rust".into()),
+      fields: None,
+      filter: None,
+      limit: 2,
+      from: 0,
+      return_hits: true,
+      candidate_size: None,
+      #[cfg(feature = "vectors")]
+      max_global_vector_candidates: None,
+      sort: Vec::new(),
+      cursor,
+      search_after,
+      execution: ExecutionStrategy::Bm25,
+      bmw_block_size: None,
+      fuzzy: None,
+      track_total_hits: None,
+      #[cfg(feature = "vectors")]
+      vector_query: None,
+      #[cfg(feature = "vectors")]
+      vector_filter: None,
+      return_stored: false,
+      highlight_field: None,
+      highlight: None,
+      collapse: None,
+      aggs: BTreeMap::new(),
+      suggest: BTreeMap::new(),
+      rescore: rescore.then(|| RescoreRequest {
+        window_size: 5,
+        query: QueryNode::Phrase {
+          field: Some("body".into()),
+          terms: vec!["rust".into(), "search".into()],
+          slop: Some(2),
+          boost: None,
+        },
+        score_mode: RescoreMode::Total,
+      }),
+      explain: false,
+      profile: false,
+    }
+  }
+
+  #[test]
+  fn rescore_with_score_sort_suppresses_pagination_tokens() {
+    let dir = tempfile::tempdir().unwrap();
+    let idx = make_rescore_index(&dir);
+    let reader = idx.reader().unwrap();
+    let result = reader
+      .search(&rescore_search_request(None, None, true))
+      .unwrap();
+    assert!(
+      result.hits.len() >= 2,
+      "expected at least 2 hits, got {}",
+      result.hits.len()
+    );
+    assert!(
+      result.next_cursor.is_none(),
+      "rescore + score-sort must not emit next_cursor; got {:?}",
+      result.next_cursor
+    );
+    assert!(
+      result.next_search_after.is_none(),
+      "rescore + score-sort must not emit next_search_after; got {:?}",
+      result.next_search_after
+    );
+  }
+
+  #[test]
+  fn rescore_with_score_sort_rejects_cursor_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let idx = make_rescore_index(&dir);
+    let reader = idx.reader().unwrap();
+    // Forge a syntactically valid cursor by running a non-rescore query
+    // first, then replay it together with rescore — the engine must
+    // reject the combination rather than silently mis-paginate.
+    let first = reader
+      .search(&rescore_search_request(None, None, false))
+      .unwrap();
+    let cursor = first
+      .next_cursor
+      .clone()
+      .expect("next_cursor from base query");
+    let err = reader
+      .search(&rescore_search_request(Some(cursor), None, true))
+      .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+      msg.contains("cursor pagination is not supported when rescore"),
+      "unexpected error: {msg}"
+    );
+  }
+
+  #[test]
+  fn rescore_with_score_sort_rejects_search_after_token() {
+    let dir = tempfile::tempdir().unwrap();
+    let idx = make_rescore_index(&dir);
+    let reader = idx.reader().unwrap();
+    let first = reader
+      .search(&rescore_search_request(None, None, false))
+      .unwrap();
+    let token = first
+      .next_search_after
+      .clone()
+      .expect("next_search_after from base query");
+    let err = reader
+      .search(&rescore_search_request(None, Some(token), true))
+      .unwrap_err();
+    let msg = err.to_string();
+    assert!(
+      msg.contains("search_after pagination is not supported when rescore"),
+      "unexpected error: {msg}"
+    );
+  }
+
+  #[test]
+  fn rescore_with_numeric_sort_still_paginates() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("idx");
+    let mut schema = Schema::default_text_body();
+    schema.numeric_fields.push(NumericField {
+      name: "rank".into(),
+      i64: true,
+      fast: true,
+      stored: false,
+      nullable: false,
+    });
+    let idx = Index::create(
+      &path,
+      schema,
+      IndexOptions {
+        path: path.clone(),
+        create_if_missing: true,
+        enable_positions: true,
+        bm25_k1: 0.9,
+        bm25_b: 0.4,
+        storage: StorageType::Filesystem,
+        checksum_policy: Default::default(),
+        checksum_audit_failure_hook: None,
+        read_only: false,
+        #[cfg(feature = "vectors")]
+        vector_defaults: None,
+      },
+    )
+    .unwrap();
+    let mut writer = idx.writer().unwrap();
+    for (idx_n, (id, text)) in [
+      ("doc-1", "rust rust search engine"),
+      ("doc-2", "rust query optimizer"),
+      ("doc-3", "rust safe parallel rust"),
+      ("doc-4", "rust borrow checker"),
+      ("doc-5", "rust traits and generics"),
+    ]
+    .iter()
+    .enumerate()
+    {
+      writer
+        .add_document(&Document {
+          fields: BTreeMap::from([
+            ("_id".into(), json!(id)),
+            ("body".into(), json!(text)),
+            ("rank".into(), json!(idx_n as i64)),
+          ]),
+        })
+        .unwrap();
+    }
+    writer.commit().unwrap();
+    let reader = idx.reader().unwrap();
+    let mut req = rescore_search_request(None, None, true);
+    req.sort = vec![SortSpec {
+      field: "rank".into(),
+      order: Some(SortOrder::Asc),
+    }];
+    let first = reader.search(&req).unwrap();
+    // Numeric-only sort key is unchanged by rescore (build_key ignores
+    // score for non-score sort fields), so the engine must still emit
+    // pagination tokens here.
+    let cursor = first
+      .next_cursor
+      .clone()
+      .expect("rescore + numeric sort must still emit next_cursor");
+    let mut next = rescore_search_request(None, None, true);
+    next.sort = req.sort.clone();
+    next.cursor = Some(cursor);
+    let second = reader.search(&next).expect("paginated page 2 succeeds");
+    assert!(!second.hits.is_empty(), "page 2 must return hits");
+    let first_ids: std::collections::HashSet<&str> =
+      first.hits.iter().map(|h| h.doc_id.as_str()).collect();
+    for hit in &second.hits {
+      assert!(
+        !first_ids.contains(hit.doc_id.as_str()),
+        "page 1 and page 2 must be disjoint; {} appeared in both",
+        hit.doc_id
+      );
+    }
   }
 
   #[test]

--- a/searchlite-core/tests/vector_search.rs
+++ b/searchlite-core/tests/vector_search.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 use searchlite_core::api::builder::IndexBuilder;
 use searchlite_core::api::types::{
   Aggregation, Document, ExecutionStrategy, Filter, IndexOptions, LegacyVectorQuery, Query,
-  QueryNode, SearchRequest, SortSpec, StorageType, VectorQuery, VectorQuerySpec,
+  QueryNode, RescoreMode, RescoreRequest, SearchRequest, SortSpec, StorageType, VectorQuery,
+  VectorQuerySpec,
 };
 use searchlite_core::{Index, Schema};
 use serde_json::json;
@@ -194,6 +195,111 @@ fn vector_query_with_limit_zero_succeeds_without_hits() {
   assert!(res.hits.is_empty());
   assert_eq!(res.next_cursor, None);
   assert!(res.total_hits_estimate > 0);
+}
+
+// BUG-411 follow-up (Codex P1 / Copilot review on #501): the text/hybrid
+// rescore + score-sort cursor guard must not regress vector-only queries.
+// `search_vector_only` never calls `rescore_hits`, so its cursor is built
+// from the base vector score and is not corrupted by rescore even when a
+// caller provides a (silently-ignored) `rescore` block. The inbound
+// validation and outbound suppression in `IndexReader::search` therefore
+// run *after* the vector-only early return; this test pins that scoping
+// in place so page 2 of a vector-only paginated request still succeeds.
+#[test]
+fn vector_only_paginated_cursor_works_when_request_carries_rescore() {
+  let dir = tempdir().unwrap();
+  let schema = schema();
+  IndexBuilder::create(dir.path(), schema.clone(), opts(dir.path())).unwrap();
+  let idx = Index::open(opts(dir.path())).unwrap();
+  add_docs(
+    &idx,
+    &[
+      Document {
+        fields: [
+          ("_id".into(), json!("vec-1")),
+          ("body".into(), json!("rust search engine")),
+          ("embedding".into(), json!([1.0, 0.0])),
+        ]
+        .into_iter()
+        .collect(),
+      },
+      Document {
+        fields: [
+          ("_id".into(), json!("vec-2")),
+          ("body".into(), json!("rust traits")),
+          ("embedding".into(), json!([0.95, 0.05])),
+        ]
+        .into_iter()
+        .collect(),
+      },
+      Document {
+        fields: [
+          ("_id".into(), json!("vec-3")),
+          ("body".into(), json!("rust query")),
+          ("embedding".into(), json!([0.9, 0.1])),
+        ]
+        .into_iter()
+        .collect(),
+      },
+      Document {
+        fields: [
+          ("_id".into(), json!("vec-4")),
+          ("body".into(), json!("rust borrow checker")),
+          ("embedding".into(), json!([0.8, 0.2])),
+        ]
+        .into_iter()
+        .collect(),
+      },
+    ],
+  );
+  let reader = idx.reader().unwrap();
+  // Vector-only request: alpha=0.0 means pure vector ranking, no text
+  // contribution. The included `rescore` block would matter for a
+  // text/hybrid search, but `search_vector_only` silently ignores it —
+  // we still expect a working cursor.
+  let mut req = SearchRequest {
+    query: Query::Node(QueryNode::Vector(VectorQuery {
+      field: "embedding".into(),
+      vector: vec![1.0, 0.0],
+      k: Some(4),
+      alpha: Some(0.0),
+      ef_search: None,
+      candidate_size: Some(4),
+      boost: None,
+    })),
+    vector_query: None,
+    vector_filter: None,
+    rescore: Some(RescoreRequest {
+      window_size: 2,
+      query: QueryNode::Phrase {
+        field: Some("body".into()),
+        terms: vec!["rust".into(), "search".into()],
+        slop: Some(2),
+        boost: None,
+      },
+      score_mode: RescoreMode::Total,
+    }),
+    ..base_request(Query::String("".into()), 2)
+  };
+  let first = reader.search(&req).expect("page 1 must succeed");
+  assert_eq!(first.hits.len(), 2, "expected limit=2 hits on page 1");
+  let cursor = first
+    .next_cursor
+    .clone()
+    .expect("vector-only + rescore must still emit next_cursor");
+
+  req.cursor = Some(cursor);
+  let second = reader.search(&req).expect("page 2 must succeed");
+  assert!(!second.hits.is_empty(), "page 2 must return hits");
+  let first_ids: std::collections::HashSet<&str> =
+    first.hits.iter().map(|h| h.doc_id.as_str()).collect();
+  for hit in &second.hits {
+    assert!(
+      !first_ids.contains(hit.doc_id.as_str()),
+      "page 1 and page 2 must be disjoint; {} appeared in both",
+      hit.doc_id
+    );
+  }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes the 41 `feature_matrix_execution` cases that failed in the nightly `INTEGRATION_MODE=full` run with `"stale or invalid cursor for this result set"`, all on the `speedrun-rescore-bmw` query that combines a phrase rescore with score-only sort and cursor/search_after pagination ([failing run](https://github.com/davidkelley/searchlite/actions/runs/25777998501)).
- Rejects inbound `cursor` / `search_after` and suppresses outbound `next_cursor` / `next_search_after` whenever `rescore` is combined with a sort plan that uses `_score` — the only condition under which the cursor would carry a rescored score that page 2 cannot match against base-score keys.
- Sort plans that don't use `_score` (e.g. `instant-pot-chili-rescore`, which sorts by `total_time_minutes`) are unaffected because `SortPlan::build_key` discards the score arg for non-score sort fields.

## Root cause

`rescore_hits` rewrites `hit.score` and, for score-bearing sort plans, the score component of `hit.key`. The token emitted at the end of page 1 therefore carries the *rescored* score. On page 2, `search_segment` builds candidate keys from the *base* score — the score parts differ for the same doc, the equality check at `key.cmp(cur).is_eq()` never fires, `saw_cursor` stays false, and `IndexReader::search` bails. Non-score sort plans don't surface the bug because `build_key` ignores the score component for them.

## Changes

| File | What |
|---|---|
| [searchlite-core/src/api/reader.rs](searchlite-core/src/api/reader.rs) | Reject inbound tokens, suppress outbound tokens, 4 new unit tests |
| [searchlite-core/CHANGELOG.md](searchlite-core/CHANGELOG.md) | `Unreleased` entry referencing BUG-411 |
| [docs/queries.md](docs/queries.md) | Document the constraint under the Rescoring section |

## Test plan

- [x] `cargo test -p searchlite-core --all-features` — 680+ tests pass, including 4 new tests covering the suppression, both rejection paths, and the positive case for numeric-sort + rescore.
- [x] `cargo test -p integration --all-features` (quick mode) — 65 tests pass.
- [x] `INTEGRATION_MODE=full cargo test -p integration --all-features --test feature_matrix_execution` — **18142 passed, 2 failed** (down from 41 in the failing nightly). Both remaining failures are unrelated 10s HTTP-client timeouts in `Recipes::Http::*::Cursor::PostCompact` for `mediterranean-romaine-salad` and `pescatarian-shrimp-curry`; neither query uses rescore.
- [x] `cargo clippy --all --all-features --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)