### PR TITLE
docs: remove "SQLite of search" positioning references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <p align="center">
   <h1 align="center">searchlite</h1>
   <p align="center">
-    <strong>The SQLite of search.</strong>
-    <br />
     An embedded full-text search engine for Rust. No JVM, no cluster, no external
     process &mdash; just add a crate and search. WAL-backed durability, BM25
     relevance with WAND/BMW pruning, aggregations, filters, highlights, and

--- a/docs.jsonl
+++ b/docs.jsonl
@@ -1,3 +1,0 @@
-{"_id":"doc-1","body":"Rust is a systems programming language","lang":"en","year":2023}
-{"_id":"doc-2","body":"SQLite is a small database engine","lang":"en","year":2020}
-{"_id":"doc-3","body":"Searchlite keeps a SQLite vibe for search","lang":"en","year":2024}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,7 +87,7 @@ searchlite init "$INDEX" schema.json
 # 2. Add documents (NDJSON: one JSON object per line)
 cat > /tmp/docs.jsonl <<'EOF'
 {"_id":"1","body":"Rust is a systems programming language","lang":"en","year":2024}
-{"_id":"2","body":"SQLite is an embedded database","lang":"en","year":2023}
+{"_id":"2","body":"Tantivy is a Rust search library","lang":"en","year":2023}
 {"_id":"3","body":"Full-text search with BM25 scoring","lang":"en","year":2024}
 EOF
 searchlite add "$INDEX" /tmp/docs.jsonl
@@ -344,7 +344,7 @@ searchlite init "$INDEX" /tmp/schema.json
 cat > /tmp/posts.jsonl <<'EOF'
 {"_id":"p1","title":"Why Rust is winning",       "body":"Safe systems programming",       "tag":"rust",   "year":2024}
 {"_id":"p2","title":"Intro to BM25",             "body":"How search engines rank results", "tag":"search", "year":2023}
-{"_id":"p3","title":"SQLite for embedded data",  "body":"A single-file database",          "tag":"data",   "year":2022}
+{"_id":"p3","title":"Embedded data stores",     "body":"On-disk indexes",                 "tag":"data",   "year":2022}
 EOF
 searchlite add    "$INDEX" /tmp/posts.jsonl
 searchlite commit "$INDEX"

--- a/docs/ffi.md
+++ b/docs/ffi.md
@@ -90,7 +90,7 @@ int main(void) {
 
   // 2. Queue two documents. The bodies are JSON objects keyed by field names.
   const char* doc1 = "{\"_id\":\"1\",\"body\":\"Rust is fast\"}";
-  const char* doc2 = "{\"_id\":\"2\",\"body\":\"SQLite is embedded\"}";
+  const char* doc2 = "{\"_id\":\"2\",\"body\":\"Embedded indexing in C\"}";
   if (searchlite_add_json(idx, doc1, strlen(doc1)) < 0 ||
       searchlite_add_json(idx, doc2, strlen(doc2)) < 0) {
     fprintf(stderr, "add failed\n");

--- a/docs/http.md
+++ b/docs/http.md
@@ -391,7 +391,7 @@ curl -s -XPOST "$BASE/init" -H 'Content-Type: application/json' --data-binary @/
 # 2. Ingest via NDJSON
 cat > /tmp/docs.ndjson <<'EOF'
 {"_id":"a","body":"Rust search","tag":"rust","year":2024}
-{"_id":"b","body":"SQLite internals","tag":"data","year":2023}
+{"_id":"b","body":"WAL durability","tag":"data","year":2023}
 {"_id":"c","body":"BM25 explained","tag":"search","year":2024}
 EOF
 curl -s -XPOST "$BASE/add" -H 'Content-Type: application/x-ndjson' --data-binary @/tmp/docs.ndjson

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,13 +1,13 @@
 # Searchlite in a Nutshell
 
-Searchlite is a lightweight, SQLite-flavored search engine: a single on-disk index with WAL durability, BM25 relevance, and modern search features, all in a lean Rust binary (no JVM, no cluster to manage).
+Searchlite is a lightweight embedded search engine: a single on-disk index with WAL durability, BM25 relevance, and modern search features, all in a lean Rust binary (no JVM, no cluster to manage).
 
 ## Why Searchlite?
 
 - **Minimal ops**: open an index path and go — no Zookeeper, no cluster sizing, and simple backups/compaction.
 - **Predictable costs**: runs well on one NVMe-backed box; scale up before you have to scale out.
 - **Developer friendly**: clear Rust API, CLI, optional C FFI and wasm; JSON-based requests mirror how you think about queries and filters.
-- **SQLite mindset**: single-writer/multi-reader with WAL-style commits and atomic manifests; readers stay online during writes.
+- **WAL-backed commits**: single-writer/multi-reader design with atomic manifests; readers stay online during writes.
 - **Performance without bloat**: BM25 with WAND/BMW pruning, fast fields, and optional vectors—all without a heavyweight runtime.
 
 ## Try It Fast
@@ -45,7 +45,7 @@ Walk through ingesting a small JSONL file and running your first search in minut
 
 ## Limits and Expectations
 
-- Single-node scope: no built-in sharding/replication; think “SQLite for search.”
+- Single-node scope: no built-in sharding/replication; designed to run on one box, not a cluster.
 - Concurrency model: single writer, many readers; readers stay live across commits.
 - HA story: primary + standby via snapshots/backups rather than cluster replication.
 - Workload fit: low-latency top-k queries with filters/aggregations; not a distributed analytics engine.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -56,7 +56,7 @@ Create a small JSONL file (`/tmp/docs.jsonl`) with your documents. Each line is 
 ```bash
 cat > /tmp/docs.jsonl <<'EOF'
 {"_id":"doc-1","title":"Rust search engine","body":"Searchlite is a lightweight search engine written in Rust.","lang":"en","year":2024}
-{"_id":"doc-2","title":"SQLite vibes","body":"Single-node search with a WAL and atomic manifests.","lang":"en","year":2023}
+{"_id":"doc-2","title":"Atomic manifests","body":"Single-node search with a WAL and atomic manifests.","lang":"en","year":2023}
 {"_id":"doc-3","title":"Edge ready","body":"Run full-text search at the edge or in appliances.","lang":"en","year":2022}
 EOF
 ```
@@ -190,7 +190,7 @@ const index = new EmbeddedIndex("./my-index", {
 // 2. Add documents and commit
 await index.addMany([
   { _id: "1", title: "Rust Search Engine", body: "Searchlite is a fast embedded search engine.", lang: "en", year: 2024 },
-  { _id: "2", title: "SQLite Vibes", body: "Single-node search with WAL durability.", lang: "en", year: 2023 },
+  { _id: "2", title: "Atomic Manifests", body: "Single-node search with WAL durability.", lang: "en", year: 2023 },
   { _id: "3", title: "Edge Ready", body: "Run full-text search at the edge.", lang: "en", year: 2022 },
 ]);
 await index.commit();

--- a/searchlite-core/examples/pruning.rs
+++ b/searchlite-core/examples/pruning.rs
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
   let query_count = 200usize;
   let k = 10usize;
   let vocab = [
-    "rust", "search", "engine", "tiny", "sqlite", "wand", "bmw", "fast", "index",
+    "rust", "search", "engine", "tiny", "score", "wand", "bmw", "fast", "index",
   ];
   let dir = tempfile::tempdir()?;
   let path = dir.path().join("pruning_bench");


### PR DESCRIPTION
## Summary
- Drops the "The SQLite of search" tagline from `README.md` (the existing description already covers it) and rewrites the SQLite-flavored positioning in `docs/intro.md` ("SQLite-flavored" → "embedded", "SQLite mindset" → "WAL-backed commits", `think "SQLite for search."` → "designed to run on one box, not a cluster").
- Replaces SQLite-themed example documents in `docs/{cli,ffi,http,quickstart}.md` with neutral, search-relevant content so the docs don't reinforce the analogy.
- Swaps `"sqlite"` for `"score"` in the pruning benchmark vocab (`searchlite-core/examples/pruning.rs`) — internal example only.
- Deletes the orphaned `docs.jsonl` at repo root (not referenced from any guide).

Motivation: the "SQLite of search" framing can invoke the wrong assumptions about what searchlite does (key/value or relational semantics), where searchlite is in fact an embedded full-text search engine.

Pure docs + one example-vocab string; no library or API changes.

## Test plan
- [ ] CI green
- [ ] Skim `README.md` and `docs/intro.md` for readability after the tagline/positioning removal
- [ ] Confirm `grep -ni sqlite` across the repo returns no positioning references (only any incidental matches that may remain in vendored or generated content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)